### PR TITLE
Adiciona adapter e modo para inicializar a conexão com o MongoDB

### DIFF
--- a/documentstore_migracao/__init__.py
+++ b/documentstore_migracao/__init__.py
@@ -4,6 +4,8 @@ import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from documentstore_migracao.utils import logger, files
+from documentstore_migracao import config
+from documentstore import adapters
 
 
 # SET LOGGER
@@ -11,3 +13,11 @@ logger.configure_logger()
 
 # SET FOLDER PROCESSOR
 files.setup_processing_folder()
+
+# SET DATABASE CONNECTION
+mongo = adapters.MongoDB(
+    uri=config.get("DATABASE_URI"), dbname=config.get("DATABASE_NAME")
+)
+
+Session = adapters.Session.partial(mongo)
+session = Session()

--- a/documentstore_migracao/config.py
+++ b/documentstore_migracao/config.py
@@ -33,6 +33,8 @@ _default = dict(
     LOGGER_PATH=os.path.join(BASE_PATH, ""),
     ISIS_BASE_PATH=os.environ.get("ISIS_BASE_PATH"),
     SPS_PKG_PATH=os.environ.get("SPS_PKG_PATH"),
+    DATABASE_URI=os.environ.get("DATABASE_URI", "localhost:27017"),
+    DATABASE_NAME=os.environ.get("DATABASE_NAME", "document-store"),
 )
 
 

--- a/documentstore_migracao/exceptions.py
+++ b/documentstore_migracao/exceptions.py
@@ -2,6 +2,7 @@ class ExtractError(Exception):
     """Erro do qual não pode ser recuperado durante uma extração
     de informações de uma base de dados"""
 
+
 class FetchEnvVariableError(Exception):
     """Erro do qual não pode ser recuperado durante a aquisição
     de informações do ambiente de execução. Informações as quais

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,4 @@ WebTest==2.0.33
 xylose==1.35.1
 zope.deprecation==4.4.0
 zope.interface==4.6.0
+-e git://github.com/scieloorg/document-store.git@9422e6c8b8c25d5980c0c441b77293a42aaf77ec#egg=documentstore


### PR DESCRIPTION
### O que sse PR faz?

Adiciona o `documentstore` como dependência, utiliza do seu MongoDB adapter para estabelecer a camada de conexão com o banco de dados.

### Onde a revisão poderia começar?
- `documentstore_migracao/__init__.py` linha `18`
- `documentstore_migracao/config.py` linha `15`

### Como este poderia ser testado manualmente?
Deve-se:
- Executar o interpretador python;
- Importar a session `from documentstore_migracao import session`
- Realizar alguma busca e.g `session.journals.fetch("1806-907X")`

### Algum cenário de contexto que queira dar?
N/A

### Quais são tickets relevantes?
N/A

### Referências
N/A