### PR TITLE
Reorganiza os arquivos XML em pastas correspondentes a sua situação nas etapas de migração

### DIFF
--- a/documentstore_migracao/config.py
+++ b/documentstore_migracao/config.py
@@ -3,15 +3,36 @@ from packtools.catalogs import XML_CATALOG
 
 BASE_PATH = os.path.dirname(os.path.dirname(__file__))
 
+"""
+SOURCE_PATH:
+    arquivos XML baixados do AM (body HTML)
+PROCESSED_SOURCE_PATH:
+    arquivos XML baixados do AM, mas que após convertidos para SPS e
+    validados sem erro, são movidos de SOURCE_PATH para PROCESSED_SOURCE_PATH
+CONVERSION_PATH:
+    arquivos XML resultantes da conversão de
+    "XML do AM" (SOURCE_PATH) para "XML SPS" (CONVERSION_PATH)
+VALID_XML_PATH:
+    arquivos "XML SPS" sem erros
+XML_ERRORS_PATH:
+    arquivos .err cujo conteúdo é XML + mensagens de erro
+SPS_PKG_PATH:
+    pacotes de XML validados e nomeados de acordo com SPS
+"""
+
 _default = dict(
     SCIELO_COLLECTION="spa",
     AM_URL_API="http://articlemeta.scielo.org/api/v1",
     SOURCE_PATH=os.path.join(BASE_PATH, "xml/source"),
     CONVERSION_PATH=os.path.join(BASE_PATH, "xml/conversion"),
     SUCCESS_PROCESSING_PATH=os.path.join(BASE_PATH, "xml/success"),
+    VALID_XML_PATH=os.path.join(BASE_PATH, "xml/xml_valid"),
+    XML_ERRORS_PATH=os.path.join(BASE_PATH, "xml/xml_errors"),
+    PROCESSED_SOURCE_PATH=os.path.join(BASE_PATH, "xml/source_processed"),
     GENERATOR_PATH=os.path.join(BASE_PATH, "xml/html"),
     LOGGER_PATH=os.path.join(BASE_PATH, ""),
     ISIS_BASE_PATH=os.environ.get("ISIS_BASE_PATH"),
+    SPS_PKG_PATH=os.environ.get("SPS_PKG_PATH"),
 )
 
 
@@ -24,12 +45,10 @@ def get(config: str):
 
 
 INITIAL_PATH = [
-    get("LOGGER_PATH"),
-    get("SOURCE_PATH"),
-    get("SUCCESS_PROCESSING_PATH"),
-    get("CONVERSION_PATH"),
-    get("GENERATOR_PATH"),
+    get(k) for k, v in _default.items() if k.endswith('_PATH')
 ]
+INITIAL_PATH = [item for item in INITIAL_PATH if item is not None]
+
 
 DOC_TYPE_XML = """<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">"""
 

--- a/documentstore_migracao/main.py
+++ b/documentstore_migracao/main.py
@@ -39,13 +39,25 @@ def process(args):
         "--conversionFiles",
         "-c",
         action="store_true",
-        help="Converte todos os arquivos XML baixados",
+        help="Converte todos os arquivos XML de 'source'",
     )
     parser.add_argument(
         "--validationFiles",
         "-V",
         action="store_true",
-        help="Converte todos os arquivos XML baixados",
+        help="Valida todos os arquivos XML de 'source'",
+    )
+    parser.add_argument(
+        "--move_to_processed_source",
+        "-MS",
+        action="store_true",
+        help="Move os arquivos válidos de 'source' para 'processed_source'",
+    )
+    parser.add_argument(
+        "--move_to_valid_xml",
+        "-MC",
+        action="store_true",
+        help="Move os arquivos válidos de 'conversion' para 'valid_xml'",
     )
     parser.add_argument(
         "--generationFiles",
@@ -84,7 +96,8 @@ def process(args):
         extrated.extrated_all_data()
 
     elif args.validationFiles:
-        validation.validator_article_ALLxml()
+        validation.validator_article_ALLxml(
+            args.move_to_processed_source, args.move_to_valid_xml)
 
     elif args.generationFiles:
         generation.article_ALL_html_generator()

--- a/documentstore_migracao/processing/conversion.py
+++ b/documentstore_migracao/processing/conversion.py
@@ -54,7 +54,7 @@ def conversion_article_xml(file_xml_path):
 def conversion_article_ALLxml():
 
     logger.info("Iniciando Conversão do xmls")
-    list_files_xmls = files.list_dir(config.get("SOURCE_PATH"))
+    list_files_xmls = files.xml_files_list(config.get("SOURCE_PATH"))
     for file_xml in list_files_xmls:
 
         try:

--- a/documentstore_migracao/processing/generation.py
+++ b/documentstore_migracao/processing/generation.py
@@ -42,17 +42,18 @@ def article_html_generator(file_xml_path):
 
 
 def article_ALL_html_generator():
+    paths = [config.get("CONVERSION_PATH"),
+             config.get("VALID_XML_PATH")]
+    paths = [path for path in paths if path]
+    logger.info("Iniciando Geração dos HTMLs")
+    for path in paths:
+        list_files_xmls = files.xml_files_list(path)
+        for file_xml in list_files_xmls:
 
-    logger.info("Iniciando Geração dos dos HTMLs")
-    list_files_xmls = files.list_dir(config.get("CONVERSION_PATH"))
-    for file_xml in list_files_xmls:
+            try:
+                article_html_generator(os.path.join(path, file_xml))
 
-        try:
-            article_html_generator(
-                os.path.join(config.get("CONVERSION_PATH"), file_xml)
-            )
-
-        except Exception as ex:
-            logger.error(file_xml)
-            logger.exception(ex)
-            # raise
+            except Exception as ex:
+                logger.error(file_xml)
+                logger.exception(ex)
+                # raise

--- a/documentstore_migracao/processing/reading.py
+++ b/documentstore_migracao/processing/reading.py
@@ -29,7 +29,7 @@ def reading_article_xml(file_xml_path, move_success=True):
 def reading_article_ALLxml():
 
     logger.info("Iniciando Leituras do xmls")
-    list_files_xmls = files.list_dir(config.get("CONVERSION_PATH"))
+    list_files_xmls = files.xml_files_list(config.get("CONVERSION_PATH"))
     for file_xml in list_files_xmls:
 
         try:

--- a/documentstore_migracao/utils/dicts.py
+++ b/documentstore_migracao/utils/dicts.py
@@ -7,8 +7,10 @@ def merge(result, key, values):
     result.setdefault(key, {})
     for v_key, v_value in values.items():
         result[key].setdefault(v_key, type(v_value)())
-
-        result[key][v_key] += v_value
+        try:
+            result[key][v_key] += v_value
+        except TypeError:
+            result[key][v_key] = v_value
 
 
 def group(lst, n):

--- a/documentstore_migracao/utils/files.py
+++ b/documentstore_migracao/utils/files.py
@@ -26,9 +26,10 @@ def move_xml_conversion2success(xml_file):
     )
 
 
-def list_dir(path):
-
-    return [f for f in os.listdir(path) if f.endswith(".xml")]
+def xml_files_list(path):
+    if path and os.path.isdir(path):
+        return [f for f in os.listdir(path) if f.endswith(".xml")]
+    return []
 
 
 def read_file(path):

--- a/documentstore_migracao/webserver/views.py
+++ b/documentstore_migracao/webserver/views.py
@@ -13,8 +13,8 @@ from documentstore_migracao import config
     route_name="list_converted_xml", renderer="templates/list_converted_xml.jinja2"
 )
 def list_converted_xml_view(request):
-
-    list_files_xmls = files.list_dir(config.get("CONVERSION_PATH"))
+    list_files_xmls = files.xml_files_list(config.get("CONVERSION_PATH"))
+    list_files_xmls += files.xml_files_list(config.get("VALID_XML_PATH"))
     xmls = Page(
         list_files_xmls,
         page=int(request.params.get("page", 1)),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,7 +39,7 @@ class TestMainProcess(unittest.TestCase):
     def test_arg_validationFiles(self, mk_validator_article_ALLxml):
 
         process(["--validationFiles"])
-        mk_validator_article_ALLxml.assert_called_once_with()
+        mk_validator_article_ALLxml.assert_called_once_with(False, False)
 
     @patch("documentstore_migracao.processing.generation.article_ALL_html_generator")
     def test_arg_generationFiles(self, mk_article_ALL_html_generator):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -147,9 +147,12 @@ class TestProcessingGeneration(unittest.TestCase):
             self.assertIn("S0044-59672003000300001", text)
 
     @patch("documentstore_migracao.processing.generation.article_html_generator")
-    def test_reading_article_ALLxml(self, mk_article_html_generator):
+    def test_article_ALL_html_generator(self, mk_article_html_generator):
 
-        with utils.environ(CONVERSION_PATH=SAMPLES_PATH):
+        with utils.environ(
+                CONVERSION_PATH=SAMPLES_PATH,
+                VALID_XML_PATH=''
+                ):
             generation.article_ALL_html_generator()
             mk_article_html_generator.assert_called_with(ANY)
             self.assertEqual(
@@ -157,10 +160,13 @@ class TestProcessingGeneration(unittest.TestCase):
             )
 
     @patch("documentstore_migracao.processing.generation.article_html_generator")
-    def test_reading_article_ALLxml_with_exception(self, mk_article_html_generator):
+    def test_article_ALL_html_generator_with_exception(self, mk_article_html_generator):
 
         mk_article_html_generator.side_effect = KeyError("Test Error - Generation")
-        with utils.environ(CONVERSION_PATH=SAMPLES_PATH):
+        with utils.environ(
+                CONVERSION_PATH=SAMPLES_PATH,
+                VALID_XML_PATH=''
+                ):
 
             with self.assertLogs("documentstore_migracao.processing.generation") as log:
                 generation.article_ALL_html_generator()
@@ -241,13 +247,17 @@ class TestProcessingValidation(unittest.TestCase):
         mk_validator_article_xml.return_value = {
             "Element p is not declared in p list of possible children": {
                 "count": 2,
-                "files": (
-                    410,
-                    os.path.join(SAMPLES_PATH, "S0044-59672003000300001.pt.xml"),
-                    419,
-                    os.path.join(SAMPLES_PATH, "S0044-59672003000300001.pt.xml"),
-                ),
-            }
+                "lineno": [410, 419],
+                "filename": {
+                    os.path.join(
+                        SAMPLES_PATH, "S0044-59672003000300001.pt.xml")
+                    },
+                "message": ["Element p is not declared in p"
+                            " list of possible children",
+                            "Element p is not declared in p"
+                            " list of possible children"
+                           ]
+                },
         }
         list_files_xmls = [
             "S0044-59672003000300001.pt.xml",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,8 +8,8 @@ from . import SAMPLES_PATH, COUNT_SAMPLES_FILES
 
 
 class TestUtilsFiles(unittest.TestCase):
-    def test_list_dir(self):
-        self.assertEqual(len(files.list_dir(SAMPLES_PATH)), COUNT_SAMPLES_FILES)
+    def test_xml_files_list(self):
+        self.assertEqual(len(files.xml_files_list(SAMPLES_PATH)), COUNT_SAMPLES_FILES)
 
     def test_read_file(self):
         data = files.read_file(

--- a/tests/test_webserver.py
+++ b/tests/test_webserver.py
@@ -15,7 +15,7 @@ class ViewTests(unittest.TestCase):
     def test_list_converted_xml_view(self):
 
         request = testing.DummyRequest()
-        with utils.environ(CONVERSION_PATH=SAMPLES_PATH):
+        with utils.environ(CONVERSION_PATH=SAMPLES_PATH, VALID_XML_PATH=''):
             info = views.list_converted_xml_view(request)
             self.assertEqual(info["page_title"], "Lista de XMLS Convertidos")
             self.assertEqual(len(info["xmls"]), COUNT_SAMPLES_FILES)
@@ -26,7 +26,7 @@ class ViewTests(unittest.TestCase):
             "file_xml": "S0044-59672003000300001.pt.xml",
             "language": "pt",
         }
-        with utils.environ(CONVERSION_PATH=SAMPLES_PATH):
+        with utils.environ(CONVERSION_PATH=SAMPLES_PATH, VALID_XML_PATH=''):
             info = views.render_html_converted_view(request)
             self.assertIn("Luiz Antonio de Oliveira", str(info))
 
@@ -37,6 +37,6 @@ class FunctionalTests(unittest.TestCase):
         self.testapp = TestApp(app)
 
     def test_root(self):
-        with utils.environ(CONVERSION_PATH=SAMPLES_PATH):
+        with utils.environ(CONVERSION_PATH=SAMPLES_PATH, VALID_XML_PATH=''):
             res = self.testapp.get("/", status=200)
             self.assertTrue(b"Lista de XMLS Convertidos" in res.body)


### PR DESCRIPTION
#### O que esse PR faz?
Reorganiza os arquivos XML em pastas de acordo com a sua situação nas etapas de migração. 
Após validar o XML, dependendo do resultado, há movimentações de arquivos para pastas correspondentes.

**1. Novos items no config**
 - **PROCESSED_SOURCE_PATH**: arquivos movidos de `SOURCE_PATH`, se após convertidos para SPS estão sem erro.
 - **VALID_XML_PATH**: arquivos "XML SPS" sem erros.
 - **XML_ERRORS_PATH**: arquivos .err cujo conteúdo é XML + mensagens de erro.
 - **SPS_PKG_PATH**: pacotes sps validados e nomeados de acordo com as recomendações.

**2. CONVERSION_PATH e VALID_XML_PATH**
Onde a pasta `CONVERSION_PATH` era entrada, a pasta `VALID_XML_PATH` também foi incluída como entrada, pois os XML válidos que estavam em `CONVERSION_PATH` foram movidos para a pasta `VALID_XML_PATH`.

**3. XML_ERRORS**
Quando é executado a validação do XML e este contiver erros, é gerado um arquivo de relatório.


```
    extract                  conversion        validation       SPS package generation

 +----------------+   +---------+   +------------+   +-----------+   +-------------+
 |                |   |         |   |            |   |           |   |             |
 | Article Meta   +-->+ SOURCE  +-->+ CONVERSION +-->+ VALID XML +-->+ SPS PACKAGE |
 |                |   |         |   |            |   |           |   |             |
 +----------------+   +---------+   +-----+------+   +-----------+   +-------------+
                                          |
                                          v           Na etapa "validation":
                                     +----+------+    - se o XML é válido segundo o SPS,
                                     | XML ERRORS|      é movido de CONVERSION para VALID XML,
                                     |           |      o XML é movido de SOURCE para PROCESSED SOURCE.
                                     +-----------+    - se o XML não é válido segundo o SPS,
                                                        é gerado um relatório em XML ERRORS.


```

#### Onde a revisão poderia começar?
documentstore_migracao/config.py
documentstore_migracao/main.py
documentstore_migracao/processing/validation.py

#### Como este poderia ser testado manualmente?
python setup.py test

#### Algum cenário de contexto que queira dar?
N/A

#### Screenshots
N/A

#### Quais são tickets relevantes?
Relacionado com https://github.com/scieloorg/document-store/issues/2

### Referências
N/A




