### PR TITLE
Refatora comando de migração para bases ISIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,53 @@
 # Document Store (Kernel) - Migração
 
 
-[![Build Status](https://travis-ci.org/cesarbruschetta/document-store-migracao.svg?branch=master)](https://travis-ci.org/cesarbruschetta/document-store-migracao)
+[![Build Status](https://travis-ci.org/scieloorg/document-store-migracao.svg?branch=master)](https://travis-ci.org/scieloorg/document-store-migracao)
 
-[![codecov](https://codecov.io/gh/cesarbruschetta/document-store-migracao/branch/master/graph/badge.svg)](https://codecov.io/gh/cesarbruschetta/document-store-migracao)
+[![codecov](https://codecov.io/gh/scieloorg/document-store-migracao/branch/master/graph/badge.svg)](https://codecov.io/gh/scieloorg/document-store-migracao)
 
+
+## Migração ISIS
+
+Esta ferramenta possui a capacidade de migrar dados de bases ISIS (title e issue) em formato MST para o formato aceito pelo **Kernel**. A utilização de ferramentas externas se fez necessário com o intuito de garantir a máxima integralidade de dados entre as duas bases.
+
+#### Dependências
+Antes de executar a ferramenta de migração observe se as seguintes dependências estão presentes:
+
+- Java `>= 1.8`
+- [Jython](http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.5.3/jython-installer-2.5.3.jar) `== 2.5.x`
+- Python `== 3.6.x`
+
+#### Configuração
+
+Para o devido funcionamento desta ferramenta é necessário que algumas configurações sejam feitas, siga as seguintes instruções:
+
+1. Instale o Java.
+2. Instale o Jython.
+3. Instale o Python.
+4. Instale os utilitários de migração
+
+```shell
+python setup.py install
+```
+
+Este comando possibilitará que os utilitários de migração estejam disponíveis no seu `path` de execução.
+
+
+#### Execução da fase ISIS
+
+Após realizar a configurações descritas logo acima o sistema está apto para executar as fases de extração e carga na base de dados.
+
+##### Extração de bases
+
+```shell
+migrate_isis extract /home/user/bases/title/title.mst --output /home/user/jsons/title.json
+```
+O comando acima executa a extração do arquivo `/home/user/bases/title/title.mst` e salva o seu resultado na pasta `/home/user/jsons/title.json`.
+
+Para visualizar todas as opções e a ajuda digite:
+```shell
+migrate_isis --help
+```
 
 ## Getting Started Pyramid
 ---------------

--- a/documentstore_migracao/export/journal.py
+++ b/documentstore_migracao/export/journal.py
@@ -41,10 +41,3 @@ def get_journals():
 
     cl = RestfulClient()
     return cl.journals(collection=config.get("SCIELO_COLLECTION"))
-
-
-def extract_journals_from_isis():
-    """Inicia a extração de dados a partir de uma base ISIS
-    """
-    logger.info("Iniciando extração journal")
-    extract_isis.run(base="title")

--- a/documentstore_migracao/main.py
+++ b/documentstore_migracao/main.py
@@ -2,8 +2,8 @@
 import pkg_resources
 import argparse
 import sys
-import os, logging
-
+import os
+import logging
 
 from documentstore_migracao.processing import (
     extrated,
@@ -13,6 +13,7 @@ from documentstore_migracao.processing import (
     generation,
     pipeline,
 )
+from documentstore_migracao.utils import extract_isis
 
 logger = logging.getLogger(__name__)
 
@@ -117,63 +118,52 @@ def process(args):
     return 0
 
 
-def migrate_journals():
-    """
-    JSON -> Kernel
-    - Ler Dados
-    - Normalizar dados para o Kernel
-        - Isis2Json -> Xylose
-        - SciELO Manager -> JSON
-    - Inserir no MongoDB do Kernel
-    """
-    parser = argparse.ArgumentParser(description="Document Store (Kernel) - Journal Migration")
-    parser.add_argument(
-        "--data_origin",
-        "-d",
-        help="Data origin: ISIS Bases (i) or SciELO Manager (m)",
-        choices=['i', 'm'],
+def migrate_isis(sargs):
+    parser = argparse.ArgumentParser(description="ISIS database migration tool")
+    subparsers = parser.add_subparsers(title="Commands", metavar="", dest="command")
+
+    extract_parser = subparsers.add_parser("extract", help="Extract mst files to json")
+    extract_parser.add_argument(
+        "mst_file_path",
+        metavar="file",
+        help="Path to MST file that will be extracted",
     )
-    parser.add_argument(
-        "--extract",
-        "-e",
-        action='store_true',
-        help="Extract data from ISIS Bases (default: don't extract)",
+    extract_parser.add_argument("--output", required=True, help="The output file path")
+
+    import_parser = subparsers.add_parser(
+        "import", help="Process JSON files then import into Kernel database"
     )
-    parser.add_argument(
-        '--logging_file',
-        '-o',
-        help='Full path to the log file'
+    import_parser.add_argument(
+        "import_file",
+        metavar="file",
+        help="JSON file path that contains mst extraction result, e.g: collection-title.json",
     )
-    parser.add_argument(
-        '--logging_level',
-        '-l',
-        default="INFO",
-        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-        help='Loggin level'
+    import_parser.add_argument(
+        "--type",
+        help="Type of JSON file that will load into Kernel database",
+        choices=["journal"],
+        required=True,
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(sargs)
 
-    # CHANGE LOGGER
-    level = getattr(logging, args.logging_level.upper())
-    logger = logging.getLogger()
-    logger.setLevel(level)
-
-    if args.data_origin == "i":
-        pipeline.process_isis_journal(extract=args.extract)
-    elif args.data_origin == "m":
-        print("Connect to Manager Database")
-        print("Reading Database")
-        print("Normalize data to Kernel")
+    if args.command == "extract":
+        extract_isis.create_output_dir(args.output)
+        extract_isis.run(args.mst_file_path, args.output)
+    elif args.command == "import":
+        if args.type == "journal":
+            pipeline.import_journals(args.import_file)
     else:
-        parser.error("Choose (i)SIS Bases or SciELO (m)anager\n")
-
-    print("Saving data to Kernel")
+        parser.print_help()
 
 
 def main():
     """ method main to script setup.py """
     sys.exit(process(sys.argv[1:]))
+
+
+def main_migrate_isis():
+    sys.exit(migrate_isis(sys.argv[1:]))
 
 
 if __name__ == "__main__":

--- a/documentstore_migracao/processing/pipeline.py
+++ b/documentstore_migracao/processing/pipeline.py
@@ -2,35 +2,23 @@ import logging
 import sys
 import os
 from documentstore_migracao import exceptions, config
-from documentstore_migracao.export import journal as export_journal
+from documentstore_migracao.utils import extract_isis
 from documentstore_migracao.processing import reading, conversion
+
 
 logger = logging.getLogger(__name__)
 
 
-def process_isis_journal(extract=False):
-    """Fachada com passo a passo do processamento que extrai e converte
-    os periódicos de uma base ISIS para a base Kernel"""
-
-    if extract:
-        try:
-            if not "Bruma" in os.environ.get(
-                "CLASSPATH", ""
-            ) or not "jyson" in os.environ.get("CLASSPATH", ""):
-                raise exceptions.ExtractError(
-                    "As bibliotecas Bruma e Jyson precisam estar no CLASSPATH"
-                )
-
-            export_journal.extract_journals_from_isis()
-        except (exceptions.ExtractError, exceptions.FetchEnvVariableError) as exc:
-            logger.error(str(exc))
-            sys.exit(1)
+def import_journals(json_file: str):
+    """Fachada com passo a passo de processamento e carga de periódicos
+    em formato JSON para a base Kernel"""
 
     try:
-        journals_as_json = reading.read_journals_from_json()
+        journals_as_json = reading.read_json_file(json_file)
         journals_as_kernel = conversion.conversion_journals_to_kernel(
             journals=journals_as_json
         )
 
+        # TODO: LOAD journals into Kernel DB
     except (FileNotFoundError, ValueError) as exc:
-        logger.error(str(exc))
+        logger.debug(str(exc))

--- a/documentstore_migracao/processing/reading.py
+++ b/documentstore_migracao/processing/reading.py
@@ -43,13 +43,8 @@ def reading_article_ALLxml():
             logger.exception(ex)
 
 
-def read_journals_from_json(file_path: str = "title.json") -> List[dict]:
-    """Ler um arquivo json contendo uma lista de periódicos e
-    retorna os dados dos periódicos em formato de tipos Python
+def read_json_file(file_path: str) -> List[dict]:
+    """Ler um arquivo JSON e retorna o resultado
+    em formato de estruturas Python"""
 
-    :param `file_path`: Complemento de path para o arquivo json de periódicos
-    """
-
-    json_path = os.path.join(config.get("SOURCE_PATH"), file_path)
-
-    return json.loads(files.read_file(json_path))
+    return json.loads(files.read_file(file_path))

--- a/documentstore_migracao/utils/extract_isis.py
+++ b/documentstore_migracao/utils/extract_isis.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import shlex
 import subprocess
@@ -5,41 +6,37 @@ from documentstore_migracao import config, exceptions
 
 logger = logging.getLogger(__name__)
 
+
 ISIS2JSON_PATH = "%s/documentstore_migracao/utils/isis2json/isis2json.py" % (
     config.BASE_PATH
 )
 
 
-def run(base, base_format="mst"):
+def create_output_dir(path):
+    output_dir = "/".join(path.split("/")[:-1])
+
+    if not os.path.exists(output_dir):
+        logger.debug("Creating folder: %s", output_dir)
+        os.makedirs(output_dir)
+
+
+def run(path: str, output_file: str):
     """Roda um subprocesso com o isis2json de target para extrair dados
-    de uma base ISIS em formato MST ou ISO. O resultado da extração
-    é armazenado em formato JSON em uma pasta determinada pela variável
-    de ambiente `SOURCE_PATH`.
+    de uma base ISIS em formato MST. O resultado da extração
+    é armazenado em formato JSON em arquivo determinado pelo
+    parâmetro output_file.
     """
-    BASE_FILE = "%s/%s/%s.%s" % (config.get("ISIS_BASE_PATH"), base, base, base_format)
-    OUTPUT_FILE = "%s/%s.json" % (config.get("SOURCE_PATH"), base)
 
-    if not config.get("ISIS_BASE_PATH"):
-        raise exceptions.FetchEnvVariableError(
-            "Missing ISIS base path environment variable"
-        )
-
-    command = "jython %s -t 3 -p 'v' -o %s %s" % (
-        ISIS2JSON_PATH,
-        OUTPUT_FILE,
-        BASE_FILE,
-    )
+    command = "jython %s -t 3 -p 'v' -o %s %s" % (ISIS2JSON_PATH, output_file, path)
 
     try:
-        logger.info("Extraindo arquivo %s" % BASE_FILE)
+        logger.debug("Extracting database file: %s" % path)
         subprocess.run(
             shlex.split(command),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             check=True,
         )
-        logger.info("Salvando arquivo %s" % OUTPUT_FILE)
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-        raise exceptions.ExtractError(str(exc))
-    except (FileNotFoundError, IOError) as exc:
-        raise exceptions.ExtractError(str(exc))
+        logger.debug("Writing extracted result as JSON file in: %s" % output_file)
+    except Exception as exc:
+        raise exceptions.ExtractError(str(exc)) from None

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setuptools.setup(
     entry_points="""\
         [console_scripts]
             documentstore_migracao=documentstore_migracao.main:main
-            migrate_journals=documentstore_migracao.main:migrate_journals
+            migrate_isis=documentstore_migracao.main:main_migrate_isis
         [paste.app_factory]
             main=documentstore_migracao.webserver:main
     """,

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -5,7 +5,6 @@ from unittest.mock import patch, ANY
 from xylose.scielodocument import Journal, Article
 from documentstore_migracao.export import journal, article
 from documentstore_migracao import exceptions, config
-from documentstore_migracao.export.journal import extract_journals_from_isis
 from . import SAMPLES_JOURNAL, SAMPLES_ARTICLE, SAMPLES_PATH, utils
 
 
@@ -117,26 +116,3 @@ class TestExportArticle(unittest.TestCase):
         obj = Article(copy_SAMPLES_ARTICLE)
         article.get_not_xml_article(obj)
         mk_ext_article_txt.assert_not_called()
-
-
-class ExportJournalFromIsisTest(unittest.TestCase):
-    def setUp(self):
-        self.journal_sample_mst = os.path.join(
-            SAMPLES_PATH, "base-isis-sample", "title", "title.mst"
-        )
-        self.journal_sample = os.path.join(
-            SAMPLES_PATH, "base-isis-sample", "title", "title.json"
-        )
-        self.source_path = config.get("SOURCE_PATH")
-
-    def test_raise_extract_exception_if_jython_is_not_in_path(self):
-        with utils.environ(PATH="", ISIS_BASE_PATH=self.journal_sample_mst):
-            self.assertRaises(exceptions.ExtractError, extract_journals_from_isis)
-
-    def test_raise_extract_exception_if_base_not_found(self):
-        with utils.environ(ISIS_BASE_PATH="", SOURCE_PATH=self.source_path):
-            self.assertRaises(exceptions.FetchEnvVariableError, extract_journals_from_isis)
-
-    def test_raise_extract_exception_if_source_folder_is_not_accessible(self):
-        with utils.environ(ISIS_BASE_PATH=self.journal_sample_mst, SOURCE_PATH=""):
-            self.assertRaises(exceptions.ExtractError, extract_journals_from_isis)

--- a/tests/test_migrate_isis.py
+++ b/tests/test_migrate_isis.py
@@ -48,3 +48,26 @@ class ExtractIsisTests(unittest.TestCase):
         path_exists_mock.return_value = True
         extract_isis.create_output_dir("/random/dir/file.json")
         makedirs_mock.assert_not_called()
+
+
+class TestJournalPipeline(unittest.TestCase):
+    def setUp(self):
+        self.journal_sample_mst = os.path.join(
+            SAMPLES_PATH, "base-isis-sample", "title", "title.mst"
+        )
+
+    @mock.patch("documentstore_migracao.processing.reading.read_json_file")
+    @mock.patch("documentstore_migracao.processing.pipeline.extract_isis")
+    def test_pipeline_must_run_extract_when_it_asked_for(
+        self, extract_isis_mock, read_json_file_mock
+    ):
+        pipeline.import_journals("~/json/title.json")
+        read_json_file_mock.assert_called_once_with("~/json/title.json")
+
+    @mock.patch("documentstore_migracao.processing.reading.read_json_file")
+    def test_pipeline_should_log_exceptions(self, read_json_file_mock):
+        read_json_file_mock.side_effect = FileNotFoundError
+
+        with self.assertLogs(level="DEBUG") as log:
+            pipeline.import_journals("~/json/title.json")
+            self.assertIn("DEBUG", log.output[0])

--- a/tests/test_migrate_isis.py
+++ b/tests/test_migrate_isis.py
@@ -1,0 +1,50 @@
+import os
+import subprocess
+import unittest
+from unittest import mock
+from documentstore_migracao.utils import extract_isis
+from documentstore_migracao.processing import pipeline
+from documentstore_migracao import exceptions, main, config
+from . import SAMPLES_PATH
+
+
+class ExtractIsisTests(unittest.TestCase):
+    @mock.patch("documentstore_migracao.utils.extract_isis.subprocess")
+    def test_should_raise_file_not_found_exception(self, subprocess_mock):
+        subprocess_mock.run.side_effect = FileNotFoundError
+
+        with self.assertRaises(exceptions.ExtractError):
+            extract_isis.run("file.mst", "file.json")
+
+    @mock.patch("documentstore_migracao.utils.extract_isis.subprocess")
+    def test_extract_isis_should_log_steps(self, subprocess_mock):
+        with self.assertLogs(level="DEBUG") as log:
+            extract_isis.run("file.mst", "file.json")
+            self.assertEqual(2, len(log.output))
+            self.assertIn("Extracting database file: file.mst", log.output[0])
+            self.assertIn(
+                "Writing extracted result as JSON file in: file.json", log.output[1]
+            )
+
+    @mock.patch("documentstore_migracao.utils.extract_isis.subprocess")
+    def teste_should_raise_called_process_erro(self, subprocess_mock):
+        subprocess_mock.run.side_effect = subprocess.CalledProcessError(1, 2)
+
+        with self.assertRaises(exceptions.ExtractError):
+            extract_isis.run("file.mst", "file.json")
+
+    @mock.patch("documentstore_migracao.utils.extract_isis.os.makedirs")
+    @mock.patch("documentstore_migracao.utils.extract_isis.os.path.exists")
+    def test_should_create_an_output_dir(self, path_exists_mock, makedirs_mock):
+        path_exists_mock.return_value = False
+        extract_isis.create_output_dir("/random/dir/file.json")
+        makedirs_mock.assert_called_once_with("/random/dir")
+
+    @mock.patch("documentstore_migracao.utils.extract_isis.os.makedirs")
+    @mock.patch("documentstore_migracao.utils.extract_isis.os.path.exists")
+    def test_should_not_try_to_create_an_existing_dir(
+        self, path_exists_mock, makedirs_mock
+    ):
+        path_exists_mock.return_value = True
+        extract_isis.create_output_dir("/random/dir/file.json")
+        makedirs_mock.assert_not_called()

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -181,20 +181,19 @@ class TestProcessingGeneration(unittest.TestCase):
 class TestReadingJournals(unittest.TestCase):
     def setUp(self):
         self.journals_json_path = os.path.join(
-            SAMPLES_PATH, "base-isis-sample", "title"
+            SAMPLES_PATH, "base-isis-sample", "title", "title.json"
         )
 
     def test_should_load_file_successfull(self):
-        with utils.environ(SOURCE_PATH=self.journals_json_path):
-            data = reading.read_journals_from_json("title.json")
+        data = reading.read_json_file(self.journals_json_path)
 
-            self.assertTrue(type(data), list)
-            self.assertEqual(
-                data[0].get("v140")[0]["_"],
-                "Colégio Brasileiro de Cirurgia Digestiva - CBCD",
-            )
+        self.assertTrue(type(data), list)
+        self.assertEqual(
+            data[0].get("v140")[0]["_"],
+            "Colégio Brasileiro de Cirurgia Digestiva - CBCD",
+        )
 
-            self.assertEqual(len(data), 3)
+        self.assertEqual(len(data), 3)
 
 
 class TestConversionJournalJson(unittest.TestCase):


### PR DESCRIPTION
### O que este PR faz?

Este pull request refatora o comando de migração da base ISIS com o intuito de possibilitar ao usuário uma maior flexibilidade e controle sobre as opções disponíveis pela ferramenta de linha de comando.

### Onde a revisão deve começar?
- `documentstore_migracao/main.py` linha `122`

### Como testar este PR manualmente?
Deve-se:
- Executar o comando `migrate_isis -h` e experimentar as opções apresentadas pela ferramenta.

### Algum contexto que queira dar ao revisor?
N/A

### Algum ticket relevante?
https://github.com/scieloorg/document-store/issues/143

### Refefências
N/A