### PR TITLE
Adiciona carga de periódicos para o MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ migrate_isis extract /home/user/bases/title/title.mst --output /home/user/jsons/
 ```
 O comando acima executa a extração do arquivo `/home/user/bases/title/title.mst` e salva o seu resultado na pasta `/home/user/jsons/title.json`.
 
+##### Importando entidades para o MongoDB
+
+Esta é uma fase importante da etapa de migração onde as entidades previamente extraídas em formato JSON serão processadas e importadas no formato **Kernel** em uma base MongoDB. Para visualizar informações de ajuda digite:
+
+```shell
+migrate_isis import -h
+```
+
+Serão listadas todos os argumentos necessários para realizar a operação de importação. Um exemplo de importação segue o comando abaixo:
+
+```shell
+migrate_isis import /home/user/jsons/title.json --type journal --uri "mongodb://usuario:senha@localhost/?authSource=admin" --db document-store
+```
+
+- Este comando executa a importação do arquivo `/home/user/jsons/title.json`, que contem periódicos (`--type journal`), inserindo em uma base chamada *document-store* (`--db document-store`) com os devidos parâmetros para conexão com o banco (`--uri "mongodb://usuario:senha@localhost/?authSource=admin"`).
+
+
+#### Informações gerais
+
 Para visualizar todas as opções e a ajuda digite:
 ```shell
 migrate_isis --help

--- a/documentstore_migracao/__init__.py
+++ b/documentstore_migracao/__init__.py
@@ -5,7 +5,6 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from documentstore_migracao.utils import logger, files
 from documentstore_migracao import config
-from documentstore import adapters
 
 
 # SET LOGGER
@@ -13,11 +12,3 @@ logger.configure_logger()
 
 # SET FOLDER PROCESSOR
 files.setup_processing_folder()
-
-# SET DATABASE CONNECTION
-mongo = adapters.MongoDB(
-    uri=config.get("DATABASE_URI"), dbname=config.get("DATABASE_NAME")
-)
-
-Session = adapters.Session.partial(mongo)
-session = Session()

--- a/documentstore_migracao/processing/pipeline.py
+++ b/documentstore_migracao/processing/pipeline.py
@@ -4,12 +4,31 @@ import os
 from documentstore_migracao import exceptions, config
 from documentstore_migracao.utils import extract_isis
 from documentstore_migracao.processing import reading, conversion
+from documentstore.interfaces import Session
+from documentstore.domain import utcnow
+from documentstore.exceptions import AlreadyExists
 
 
 logger = logging.getLogger(__name__)
 
 
-def import_journals(json_file: str):
+class ManifestDomainAdapter:
+    """Complementa o manifesto produzido na fase de transformação
+    para o formato exigido pelos adapters do Kernel para
+    realizar a inserção no MongoDB"""
+
+    def __init__(self, manifest):
+        self._manifest = manifest
+
+    def id(self) -> str:
+        return self.manifest["id"]
+
+    @property
+    def manifest(self) -> dict:
+        return self._manifest
+
+
+def import_journals(json_file: str, session: Session):
     """Fachada com passo a passo de processamento e carga de periódicos
     em formato JSON para a base Kernel"""
 
@@ -19,6 +38,15 @@ def import_journals(json_file: str):
             journals=journals_as_json
         )
 
-        # TODO: LOAD journals into Kernel DB
+        for journal in journals_as_kernel:
+            manifest = ManifestDomainAdapter(manifest=journal)
+
+            try:
+                session.journals.add(data=manifest)
+                session.changes.add(
+                    {"timestamp": utcnow(), "entity": "Journal", "id": manifest.id()}
+                )
+            except AlreadyExists as exc:
+                logger.info(str(exc))
     except (FileNotFoundError, ValueError) as exc:
         logger.debug(str(exc))

--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -1,0 +1,117 @@
+from collections import OrderedDict
+
+from documentstore import interfaces, exceptions, domain
+
+
+class Session(interfaces.Session):
+    def __init__(self):
+        self._documents = InMemoryDocumentStore()
+        self._documents_bundles = InMemoryDocumentsBundleStore()
+        self._journals = InMemoryJournalStore()
+        self._changes = InMemoryChangesDataStore()
+
+    @property
+    def documents(self):
+        return self._documents
+
+    @property
+    def documents_bundles(self):
+        return self._documents_bundles
+
+    @property
+    def journals(self):
+        return self._journals
+
+    @property
+    def changes(self):
+        return self._changes
+
+
+class InMemoryDataStore(interfaces.DataStore):
+    def __init__(self):
+        self._data_store = {}
+
+    def add(self, data):
+        id = data.id()
+        if id in self._data_store:
+            raise exceptions.AlreadyExists()
+        else:
+            self.update(data)
+
+    def update(self, data):
+        _manifest = data.manifest
+        id = data.id()
+        self._data_store[id] = _manifest
+
+    def fetch(self, id):
+        manifest = self._data_store.get(id)
+        if manifest:
+            return self.DomainClass(manifest=manifest)
+        else:
+            raise exceptions.DoesNotExist()
+
+
+class InMemoryDocumentStore(InMemoryDataStore):
+    DomainClass = domain.Document
+
+
+class InMemoryDocumentsBundleStore(InMemoryDataStore):
+    DomainClass = domain.DocumentsBundle
+
+
+class InMemoryJournalStore(InMemoryDataStore):
+    DomainClass = domain.Journal
+
+
+class InMemoryChangesDataStore(interfaces.ChangesDataStore):
+    def __init__(self):
+        self._data_store = OrderedDict()
+
+    def add(self, change: dict):
+
+        if change["timestamp"] in self._data_store:
+            raise exceptions.AlreadyExists()
+        else:
+            self._data_store[change["timestamp"]] = change
+
+    def filter(self, since: str = "", limit: int = 500):
+
+        return [
+            change
+            for timestamp, change in self._data_store.items()
+            if timestamp >= since
+        ][:limit]
+
+
+class MongoDBCollectionStub:
+    def __init__(self):
+        self._mongo_store = OrderedDict()
+
+    def insert_one(self, data):
+        import pymongo
+
+        if data["_id"] in self._mongo_store:
+            raise pymongo.errors.DuplicateKeyError("")
+        else:
+            self._mongo_store[data["_id"]] = data
+
+    def find(self, query, sort=None, projection=None):
+        since = query["_id"]["$gte"]
+
+        first = 0
+        for i, change_key in enumerate(self._mongo_store):
+            if self._mongo_store[change_key]["_id"] < since:
+                continue
+            else:
+                first = i
+                break
+
+        return SliceResultStub(list(self._mongo_store.values())[first:])
+
+
+class SliceResultStub:
+    def __init__(self, data):
+        self._data = data
+
+    def limit(self, val):
+        return self._data[:val]

--- a/tests/test_migrate_isis.py
+++ b/tests/test_migrate_isis.py
@@ -6,6 +6,9 @@ from documentstore_migracao.utils import extract_isis
 from documentstore_migracao.processing import pipeline
 from documentstore_migracao import exceptions, main, config
 from . import SAMPLES_PATH
+from .apptesting import Session
+from . import SAMPLE_KERNEL_JOURNAL
+from documentstore.exceptions import AlreadyExists
 
 
 class ExtractIsisTests(unittest.TestCase):
@@ -56,12 +59,14 @@ class TestJournalPipeline(unittest.TestCase):
             SAMPLES_PATH, "base-isis-sample", "title", "title.mst"
         )
 
+        self.session = Session()
+
     @mock.patch("documentstore_migracao.processing.reading.read_json_file")
     @mock.patch("documentstore_migracao.processing.pipeline.extract_isis")
     def test_pipeline_must_run_extract_when_it_asked_for(
         self, extract_isis_mock, read_json_file_mock
     ):
-        pipeline.import_journals("~/json/title.json")
+        pipeline.import_journals("~/json/title.json", self.session)
         read_json_file_mock.assert_called_once_with("~/json/title.json")
 
     @mock.patch("documentstore_migracao.processing.reading.read_json_file")
@@ -69,8 +74,49 @@ class TestJournalPipeline(unittest.TestCase):
         read_json_file_mock.side_effect = FileNotFoundError
 
         with self.assertLogs(level="DEBUG") as log:
-            pipeline.import_journals("~/json/title.json")
+            pipeline.import_journals("~/json/title.json", self.session)
             self.assertIn("DEBUG", log.output[0])
+
+    @mock.patch("documentstore_migracao.processing.reading.read_json_file")
+    @mock.patch(
+        "documentstore_migracao.processing.conversion.conversion_journals_to_kernel"
+    )
+    def test_should_import_journal(self, journals_to_kernel_mock, read_json_mock):
+        journals_to_kernel_mock.return_value = [SAMPLE_KERNEL_JOURNAL]
+        pipeline.import_journals("~/json/title.json", self.session)
+
+        expected = SAMPLE_KERNEL_JOURNAL["_id"]
+        self.assertEqual(expected, self.session.journals.fetch(expected).id())
+
+    @mock.patch("documentstore_migracao.processing.reading.read_json_file")
+    @mock.patch(
+        "documentstore_migracao.processing.conversion.conversion_journals_to_kernel"
+    )
+    def test_should_raise_already_exists_if_insert_journal_with_same_id(
+        self, journals_to_kernel_mock, read_json_mock
+    ):
+        journals_to_kernel_mock.return_value = [SAMPLE_KERNEL_JOURNAL]
+
+        with self.assertLogs(level="INFO") as log:
+            pipeline.import_journals("~/json/title.json", self.session)
+            pipeline.import_journals("~/json/title.json", self.session)
+            self.assertIn("pipeline", log[1][0])
+
+    @mock.patch("documentstore_migracao.processing.reading.read_json_file")
+    @mock.patch(
+        "documentstore_migracao.processing.conversion.conversion_journals_to_kernel"
+    )
+    def test_should_add_journal_in_changes(
+        self, journals_to_kernel_mock, read_json_mock
+    ):
+        journals_to_kernel_mock.return_value = [SAMPLE_KERNEL_JOURNAL]
+        pipeline.import_journals("~/json/title.json", self.session)
+
+        _id_expected = SAMPLE_KERNEL_JOURNAL["id"]
+        _changes = self.session.changes.filter()
+
+        self.assertEqual(1, len(_changes))
+        self.assertEqual(_id_expected, _changes[0]["id"])
 
 
 class IsisCommandLineTests(unittest.TestCase):

--- a/tests/test_migrate_isis.py
+++ b/tests/test_migrate_isis.py
@@ -120,6 +120,9 @@ class TestJournalPipeline(unittest.TestCase):
 
 
 class IsisCommandLineTests(unittest.TestCase):
+    def setUp(self):
+        self.session = Session
+
     @mock.patch("documentstore_migracao.main.extract_isis")
     @mock.patch("documentstore_migracao.main.argparse.ArgumentParser.error")
     def test_extract_subparser_requires_mst_file_path_and_output_file(
@@ -144,13 +147,16 @@ class IsisCommandLineTests(unittest.TestCase):
     def test_import_journals_requires_json_path_and_type_of_entity(self, error_mock):
         main.migrate_isis("import".split())
         error_mock.assert_called_with(
-            "the following arguments are required: file, --type"
+            "the following arguments are required: --uri, --db, file, --type"
         )
 
     @mock.patch("documentstore_migracao.main.pipeline.import_journals")
     def test_import_journals_should_call_pipeline(self, import_journals_mock):
-        main.migrate_isis("import /jsons/file.json --type journal".split())
-        import_journals_mock.assert_called_once_with("/jsons/file.json")
+        main.migrate_isis(
+            """import /jsons/file.json --type journal
+            --uri mongodb://uri --db db-name""".split()
+        )
+        import_journals_mock.assert_called_once()
 
     @mock.patch("documentstore_migracao.main.argparse.ArgumentParser.print_help")
     def test_should_print_help_if_arguments_does_not_match(self, print_help_mock):


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request adiciona o código necessário para que os periódicos extraídos de um arquivo MST sejam inseridos em uma base MongoDB.

#### Onde a revisão poderia começar?
- `documentstore_migracao/main.py` linhas `127`, `155` e `176`
 
#### Como este poderia ser testado manualmente?
Para testar manualmente deve-se:
- Realizar a extração de uma base MST para o formato JSON
- Executar o comando `migrate_isis import -h`
- Configurar os parâmetros adequados de banco de dados
- Verificar no MongoDB se os dados foram importados com sucesso.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
close https://github.com/scieloorg/document-store/issues/138

### Referências
N/A
