### PR TITLE
[document-store-migracao] Nomeador dos ativos digitais

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -1,3 +1,5 @@
+import os
+
 
 def parse_value(value):
     value = value.lower()
@@ -86,3 +88,12 @@ class SPS_Package:
         items = [self.issn, self.acron]
         items += [data[k] for k in labels if k in data_labels]
         return '-'.join(items)
+
+    def asset_package_name(self, original_document_filename, img_filename):
+        filename, ext = os.path.splitext(original_document_filename)
+        suffix = img_filename
+        if img_filename.startswith(filename):
+            suffix = img_filename[len(filename):]
+        return '-g'.join([self.package_name, suffix])
+
+

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -107,6 +107,18 @@ class Test_SPS_Package_VolNumFpageLpage(unittest.TestCase):
             '1234-5678-acron-volume-05-fpage-lpage'
         )
 
+    def test_asset_package_name_f01(self):
+        self.assertEqual(
+            self.sps_package.asset_package_name('a01.htm', 'a01f01.jpg'),
+            '1234-5678-acron-volume-05-fpage-lpage-gf01.jpg'
+        )
+
+    def test_asset_package_name_any_img(self):
+        self.assertEqual(
+            self.sps_package.asset_package_name('a01.htm', 'img.jpg'),
+            '1234-5678-acron-volume-05-fpage-lpage-gimg.jpg'
+        )
+
 
 class Test_SPS_Package_VolFpageLpage(unittest.TestCase):
     def setUp(self):
@@ -505,4 +517,3 @@ class Test_SPS_Package_Article_HTML(unittest.TestCase):
             self.sps_package.package_name,
             '1234-5678-acron-20-00006'
         )
-


### PR DESCRIPTION
#### O que esse PR faz?
Acrescenta funcionalidade de retornar nome para os ativos digitais

#### Onde a revisão poderia começar?
documentstore_migracao/export/sps_package.py
documentstore_migracao/tests/test_sps_package.py

#### Como este poderia ser testado manualmente?
```python setup.py test -s tests/test_sps_package.py```

#### Algum cenário de contexto que queira dar?
Adotado o ```-g``` para gerar o nome da imagem. Por exemplo:

- nome do arquivo do documento: a01.html
- nome do ativo do documento: a01f01.jpg
- novo nome: ```<novo nome>```-gf01.jpg
- nome do ativo do documento: img.jpg
- novo nome: ```<novo nome>```-gimg.jpg

### Screenshots
N/A

#### Quais são tickets relevantes?
#26 

### Referências
baseado em: 
https://www.ncbi.nlm.nih.gov/pmc/pub/filespec-delivery/
https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt_BR/latest/narr/regra-nomeacao.html#nomeacao-de-arquivos
