### PR TITLE
Corrige o EmptyPipe que remove tags vazias

### DIFF
--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -27,14 +27,72 @@ class TestHTML2SPSPipeline(unittest.TestCase):
         raw, xml = pipeline.SetupPipe().transform(expected_text)
         self.assertIn(expected_text, str(etree.tostring(xml)))
 
-    def test_pipe_remove_empty(self):
-        text = '<root><p>texto<br/><hr/></p><p> <img align="x" src="a04qdr04.gif"/></p><p/><br/><hr/> <img align="x" src="a04qdr04.gif"/></root>'
-        raw, transformed = self._transform(text, self.pipeline.RemoveEmptyPipe())
+    def test_pipe_remove_empty_do_not_remove_img(self):
+        text = '<root><p> <img align="x" src="a04qdr04.gif"/> </p> </root>'
+        expected = '<root><p> <img align="x" src="a04qdr04.gif"/> </p> </root>'
+        raw, transformed = self._transform(
+            text, self.pipeline.RemoveEmptyPipe())
+        resultado = etree.tostring(transformed, encoding="unicode")
         self.assertEqual(
-            etree.tostring(transformed),
-            b'<root><p>texto<br/><hr/></p><p> <img align="x" src="a04qdr04.gif"/></p><br/><hr/> <img align="x" src="a04qdr04.gif"/></root>',
+            expected.replace('>', '>[BREAK]').split('[BREAK]'),
+            resultado.replace('>', '>[BREAK]').split('[BREAK]'),
         )
 
+    def test_pipe_remove_empty_do_not_remove_a(self):
+        text = '<root><p> <a align="x" src="a04qdr04.gif"/> </p> </root>'
+        expected = '<root><p> <a align="x" src="a04qdr04.gif"/> </p> </root>'
+        raw, transformed = self._transform(
+            text, self.pipeline.RemoveEmptyPipe())
+        resultado = etree.tostring(transformed, encoding="unicode")
+        self.assertEqual(
+            expected.replace('>', '>[BREAK]').split('[BREAK]'),
+            resultado.replace('>', '>[BREAK]').split('[BREAK]'),
+        )
+
+    def test_pipe_remove_empty_do_not_remove_hr(self):
+        text = '<root><p> <hr align="x" src="a04qdr04.gif"/> </p> </root>'
+        expected = '<root><p> <hr align="x" src="a04qdr04.gif"/> </p> </root>'
+        raw, transformed = self._transform(
+            text, self.pipeline.RemoveEmptyPipe())
+        resultado = etree.tostring(transformed, encoding="unicode")
+        self.assertEqual(
+            expected.replace('>', '>[BREAK]').split('[BREAK]'),
+            resultado.replace('>', '>[BREAK]').split('[BREAK]'),
+        )
+
+    def test_pipe_remove_empty_do_not_remove_br(self):
+        text = '<root><p> <br align="x" src="a04qdr04.gif"/> </p> </root>'
+        expected = '<root><p> <br align="x" src="a04qdr04.gif"/> </p> </root>'
+        raw, transformed = self._transform(
+            text, self.pipeline.RemoveEmptyPipe())
+        resultado = etree.tostring(transformed, encoding="unicode")
+        self.assertEqual(
+            expected.replace('>', '>[BREAK]').split('[BREAK]'),
+            resultado.replace('>', '>[BREAK]').split('[BREAK]'),
+        )
+
+    def test_pipe_remove_empty_p(self):
+        text = '<root><p>Colonização micorrízica e concentração de nutrientes em três cultivares de bananeiras em um latossolo amarelo da Amazônia central</p> <p/> </root>'
+        expected = '<root><p>Colonização micorrízica e concentração de nutrientes em três cultivares de bananeiras em um latossolo amarelo da Amazônia central</p>  </root>'
+        raw, transformed = self._transform(
+            text, self.pipeline.RemoveEmptyPipe())
+        resultado = etree.tostring(transformed, encoding="unicode")
+        self.assertEqual(
+            expected.replace('>', '>[BREAK]').split('[BREAK]'),
+            resultado.replace('>', '>[BREAK]').split('[BREAK]'),
+        )
+
+    def test_pipe_remove_empty_bold(self):
+        text = '<root><p>Colonização micorrízica e concentração de nutrientes <bold> </bold> em três cultivares de bananeiras em um latossolo amarelo</p> </root>'
+        expected = '<root><p>Colonização micorrízica e concentração de nutrientes  em três cultivares de bananeiras em um latossolo amarelo</p> </root>'
+        raw, transformed = self._transform(
+            text, self.pipeline.RemoveEmptyPipe())
+
+        resultado = etree.tostring(transformed, encoding="unicode")
+        self.assertEqual(
+            expected.replace('>', '>[BREAK]').split('[BREAK]'),
+            resultado.replace('>', '>[BREAK]').split('[BREAK]'),
+        )
     def test_pipe_remove_attribute_style(self):
         text = '<root><p style="x">texto <b style="x"></b></p> <td style="bla"><caption style="x"/></td></root>'
         raw, transformed = self._transform(


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o EmptyPipe que remove tags vazias pois está removendo conteúdo além do desejado.

#### Onde a revisão poderia começar?
documentstore_migracao/utils/convert_html_body.py
tests/test_convert_html_body.py
 
#### Como este poderia ser testado manualmente?
```python setup.py test -s tests/test_convert_html_body.py```

#### Algum cenário de contexto que queira dar?
 Quando há elementos que são compostos por elementos e textos:
```xml
<root><p> texto <elemento/> texto 2</p></root>
```

```python
>>> p.text
' texto '

>>> elemento.tail
' texto 2'

>>> elemento.text
None

>>> p.remove(elemento)
>>> etree.tostring(p)
b'<p> texto </p>'
```
porque ' texto 2' é parte de elemento.

### Screenshots
N/A

#### Quais são tickets relevantes?
#38

### Referências
https://lxml.de/api/index.html
