### PR TITLE
Adiciona utilitário para importar Issues

### DIFF
--- a/documentstore_migracao/main.py
+++ b/documentstore_migracao/main.py
@@ -163,7 +163,7 @@ def migrate_isis(sargs):
     import_parser.add_argument(
         "--type",
         help="Type of JSON file that will load into Kernel database",
-        choices=["journal"],
+        choices=["journal", "issue"],
         required=True,
     )
 
@@ -178,6 +178,8 @@ def migrate_isis(sargs):
 
         if args.type == "journal":
             pipeline.import_journals(args.import_file, session=Session())
+        elif args.type == "issue":
+            pipeline.import_issues(args.import_file, session=Session())
     else:
         parser.print_help()
 

--- a/documentstore_migracao/processing/conversion.py
+++ b/documentstore_migracao/processing/conversion.py
@@ -5,7 +5,7 @@ from lxml import etree
 from typing import List
 from documentstore_migracao.utils import files, xml, string
 from documentstore_migracao import config
-from xylose.scielodocument import Journal
+from xylose.scielodocument import Journal, Issue
 from documentstore_migracao.utils import xylose_converter
 
 logger = logging.getLogger(__name__)
@@ -82,3 +82,17 @@ def conversion_journals_to_kernel(journals: list) -> list:
 
     logger.info("Convertendo %d periódicos para formato Kernel" % (len(journals)))
     return [conversion_journal_to_bundle(journal) for journal in journals]
+
+
+def conversion_issues_to_xylose(issues: List[dict]) -> List[Issue]:
+    """Converte uma lista de issues em formato JSON para uma
+    lista de issues em formato xylose"""
+
+    return [Issue({"issue": issue}) for issue in issues]
+
+
+def conversion_issues_to_kernel(issues: List[Issue]) -> List[dict]:
+    """Converte uma lista de issues em formato xylose para uma lista
+    de issues em formato Kernel"""
+
+    return [xylose_converter.issue_to_kernel(issue) for issue in issues]

--- a/documentstore_migracao/utils/isis2json/isis2json.py
+++ b/documentstore_migracao/utils/isis2json/isis2json.py
@@ -24,6 +24,7 @@ import sys
 import argparse
 from uuid import uuid4
 import os
+from string import ascii_lowercase, digits
 
 try:
     import json
@@ -39,6 +40,7 @@ ISIS_MFN_KEY = 'mfn'
 ISIS_ACTIVE_KEY = 'active'
 SUBFIELD_DELIMITER = '^'
 INPUT_ENCODING = 'cp1252'
+SUBFIELD_KEYS = "".join([ascii_lowercase, digits, "_"])
 
 def iterMstRecords(master_file_name, isis_json_type):
     try:
@@ -65,7 +67,7 @@ def iterMstRecords(master_file_name, isis_json_type):
                     if subfield_key == '*':
                         content['_'] = subfield.getContent()
                     else:
-                        if subfield_key in "_tlabcde":
+                        if subfield_key in SUBFIELD_KEYS:
                             content.setdefault(subfield_key, subfield.getContent())
                         else:
                             subfield_occurrences = content.setdefault(subfield_key,[])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -412,4 +412,87 @@ SAMPLE_KERNEL_JOURNAL = {
     "_id": "10000-000A",
 }
 
+SAMPLE_ISSUES_JSON = [
+    {
+        "v6": [{"_": "001"}],
+        "v122": [{"_": "16"}],
+        "v130": [{"_": "Revista de Microbiologia"}],
+        "v230": [{"_": "Journal of the Brazilian Society for Microbiology"}],
+        "v91": [{"_": "19990226"}],
+        "v706": [{"_": "i"}],
+        "v30": [{"_": "Rev. Microbiol."}],
+        "mfn": 1,
+        "v701": [{"_": "1"}],
+        "v32": [{"_": "3"}],
+        "v43": [
+            {
+                "a": "1998",
+                "c": "São Paulo",
+                "l": "pt",
+                "m": "Set.",
+                "n": ["n. 3"],
+                "t": "Rev. Microbiol.",
+                "v": ["v. 29"],
+            },
+            {
+                "a": "1998",
+                "c": "São Paulo",
+                "l": "en",
+                "m": "Sept.",
+                "n": ["n. 3"],
+                "t": "Rev. Microbiol.",
+                "v": ["vol. 29"],
+            },
+            {
+                "a": "1998",
+                "c": "São Paulo",
+                "l": "es",
+                "m": "Sept.",
+                "n": ["n. 3"],
+                "t": "Rev. Microbiol.",
+                "v": ["v. 29"],
+            },
+        ],
+        "v65": [{"_": "19980900"}],
+        "v31": [{"_": "29"}],
+        "v42": [{"_": "1"}],
+        "v64": [{"a": "1998", "m": "09"}],
+        "v930": [{"_": "RM"}],
+        "v700": [{"_": "0"}],
+        "v36": [{"_": "19983"}],
+        "v35": [{"_": "0001-3714"}],
+        "v49": [
+            {"c": "RM110", "l": "en", "t": "Soil and Environmental Microbiology"},
+            {"c": "RM090", "l": "en", "t": "Medical Microbiology"},
+            {"c": "RM060", "l": "en", "t": "Micology"},
+            {"c": "RM020", "l": "en", "t": "Industrial Microbiology"},
+            {"c": "RM080", "l": "en", "t": "Virology"},
+            {"c": "RM120", "l": "en", "t": "Food Microbiology"},
+            {"c": "RM030", "l": "en", "t": "Veterinarian Microbiology"},
+            {"c": "RM100", "l": "en", "t": "Errata"},
+        ],
+        "v48": [
+            {"h": ["Sumário"], "l": "pt"},
+            {"h": ["Table of Contents"], "l": "en"},
+            {"h": ["Sumario"], "l": "es"},
+        ],
+    }
+]
+
+SAMPLE_ISSUES_KERNEL = [
+    {
+        "created": "1998-09-01T00:00:00.000000Z",
+        "updated": "1998-09-01T00:00:00.000000Z",
+        "items": [],
+        "metadata": {
+            "publication_year": [["1998-09-01T00:00:00.000000Z", "1998"]],
+            "publication_month": [["1998-09-01T00:00:00.000000Z", "9"]],
+            "volume": [["1998-09-01T00:00:00.000000Z", "29"]],
+            "number": [["1998-09-01T00:00:00.000000Z", "3"]],
+            "publication_season": [["1998-09-01T00:00:00.000000Z", [9]]],
+        },
+        "_id": "0001-3714-1998-v29-n3",
+        "id": "0001-3714-1998-v29-n3",
+    }
+]
 COUNT_SAMPLES_FILES = 9

--- a/tests/test_migrate_isis.py
+++ b/tests/test_migrate_isis.py
@@ -167,6 +167,16 @@ class IsisCommandLineTests(unittest.TestCase):
         main.migrate_isis([])
         print_help_mock.assert_called()
 
+    @mock.patch("documentstore_migracao.main.pipeline.import_issues")
+    def test_import_should_call_issues_pipeline_when_import_type_is_issue(
+        self, import_issues_mock
+    ):
+        main.migrate_isis(
+            """import /jsons/file.json --type issue
+            --uri mongodb://uri --db db-name""".split()
+        )
+        import_issues_mock.assert_called_once()
+
 
 class TestIssuePipeline(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request adiciona o código necessário para realizar a importação de arquivos `json` contendo uma lista com `um` ou `mais`  fascículos.

#### Onde a revisão poderia começar?
- `documentstore_migracao/main.py` linha `181`

#### Como este poderia ser testado manualmente?
Para realizar testes manuais deve-se:
- Realizar a extração de uma base de fascículos no formato `MST` (anexo [1])
- Executar o comando `migrate_isis import -h`
- Configurar os parâmetros adequados de localização do arquivo `json` e parâmetros adequados para conexão com o banco de dados MongoDB.

#### Algum cenário de contexto que queira dar?
Tomando como principio a necessidade de realizar as importações das bases ISIS, este comando concretiza a importação das bases de fascículos. O processo de importação pode ser realizado a partir do parâmetro `import` do utilitário de migração e a ajuda deve está clara o suficiente pra auxiliar nas execuções dos passos (por favor apontar falhas de usabilidade).

### Screenshots
N/A

#### Quais são tickets relevantes?
scieloorg/document-store/issues/143

### Referências

[[1] - issues-examplo.txt](https://github.com/scieloorg/document-store-migracao/files/3085315/issues-examplo.txt)
