### PR TITLE
Produz de pacotes SciELO PS

### DIFF
--- a/documentstore_migracao/config.py
+++ b/documentstore_migracao/config.py
@@ -18,6 +18,8 @@ XML_ERRORS_PATH:
     arquivos .err cujo conteúdo é XML + mensagens de erro
 SPS_PKG_PATH:
     pacotes de XML validados e nomeados de acordo com SPS
+INCOMPLETE_SPS_PKG_PATH:
+    pacotes de XML validados e nomeados de acordo com SPS, mas com ativos digitais faltantes
 """
 
 _default = dict(
@@ -34,7 +36,8 @@ _default = dict(
     DOWNLOAD_PATH=os.path.join(BASE_PATH, "xml/download"),
     LOGGER_PATH=os.path.join(BASE_PATH, ""),
     ISIS_BASE_PATH=os.environ.get("ISIS_BASE_PATH"),
-    SPS_PKG_PATH=os.environ.get("SPS_PKG_PATH"),
+    SPS_PKG_PATH=os.path.join(BASE_PATH, "xml/sps_packages"),
+    INCOMPLETE_SPS_PKG_PATH=os.path.join(BASE_PATH, "xml/incomplete_sps_packages"),
     DATABASE_URI=os.environ.get("DATABASE_URI", "localhost:27017"),
     DATABASE_NAME=os.environ.get("DATABASE_NAME", "document-store"),
 )

--- a/documentstore_migracao/main.py
+++ b/documentstore_migracao/main.py
@@ -2,7 +2,6 @@
 import pkg_resources
 import argparse
 import sys
-import os
 import logging
 
 from documentstore import adapters
@@ -11,6 +10,7 @@ from documentstore_migracao.processing import (
     reading,
     conversion,
     validation,
+    packing,
     generation,
     pipeline,
 )
@@ -62,6 +62,12 @@ def process(args):
         help="Move os arquivos válidos de 'conversion' para 'valid_xml'",
     )
     parser.add_argument(
+        "--packFiles",
+        "-P",
+        action="store_true",
+        help="Processa todos os arquivos XML baixados",
+    )
+    parser.add_argument(
         "--generationFiles",
         "-G",
         action="store_true",
@@ -75,6 +81,7 @@ def process(args):
         "--convetFile", "-c", help="Transformar somente o arquivos XML imformado"
     )
     parser.add_argument("--readFile", "-r", help="Ler somente o arquivos XML imformado")
+    parser.add_argument("--packFile", "-p", help="Empacotar somente o documento XML imformado")
     parser.add_argument(
         "--valideFile", "-v", help="Valida somente o arquivos XML imformado"
     )
@@ -102,6 +109,8 @@ def process(args):
         validation.validator_article_ALLxml(
             args.move_to_processed_source, args.move_to_valid_xml
         )
+    elif args.packFiles:
+        packing.packing_article_ALLxml()
 
     elif args.generationFiles:
         generation.article_ALL_html_generator()
@@ -114,6 +123,9 @@ def process(args):
 
     elif args.readFile:
         reading.reading_article_xml(args.readFile, False)
+
+    elif args.packFile:
+        packing.packing_article_xml(args.packFile)
 
     elif args.issn_journal:
         extrated.extrated_selected_journal(args.issn_journal)

--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -1,0 +1,116 @@
+import os
+import shutil
+import logging
+
+from requests.compat import urljoin
+from requests.exceptions import HTTPError
+from lxml import etree
+from documentstore_migracao.utils import (
+    files,
+    request,
+    xml,
+)
+from documentstore_migracao import (
+    config,
+)
+from documentstore_migracao.export.sps_package import SPS_Package
+
+
+logger = logging.getLogger(__name__)
+
+
+def packing_article_xml(file_xml_path):
+    original_filename, ign = files.extract_filename_ext_by_path(file_xml_path)
+
+    obj_xml = xml.file2objXML(file_xml_path)
+
+    sps_package = SPS_Package(obj_xml, original_filename)
+
+    SPS_PKG_PATH = config.get("SPS_PKG_PATH")
+    INCOMPLETE_SPS_PKG_PATH = config.get("INCOMPLETE_SPS_PKG_PATH")
+
+    pkg_path = os.path.join(SPS_PKG_PATH, original_filename)
+    bad_pkg_path = os.path.join(INCOMPLETE_SPS_PKG_PATH, original_filename)
+
+    files.make_empty_dir(pkg_path)
+
+    asset_replacements = list(set(sps_package.replace_assets_names()))
+    logger.info(
+        "%s possui %s ativos digitais", file_xml_path, len(asset_replacements))
+
+    package_path = packing_assets(
+        asset_replacements, pkg_path, bad_pkg_path, sps_package.package_name)
+    
+    xml.objXML2file(
+        os.path.join(package_path, "%s.xml" % (sps_package.package_name)),
+        obj_xml
+    )
+
+
+def packing_article_ALLxml():
+
+    logger.info("Empacotando os documentos XML")
+    list_files_xmls = files.xml_files_list(config.get("VALID_XML_PATH"))
+    for file_xml in list_files_xmls:
+
+        try:
+            packing_article_xml(
+                os.path.join(config.get("VALID_XML_PATH"), file_xml)
+            )
+
+        except (PermissionError, OSError, etree.Error) as ex:
+            logger.error('Falha no empacotamento de %s' % file_xml)
+            logger.exception(ex)
+
+
+def download_asset(old_path, new_fname, dest_path):
+    """Returns msg, if error"""
+    location = urljoin(config.get("STATIC_URL_FILE"), old_path)
+    try:
+        request_file = request.get(
+            location, timeout=int(config.get("TIMEOUT") or 10))
+    except HTTPError as e:
+        try:
+            msg = str(e)
+        except TypeError:
+            msg = 'Unknown error'
+        logger.error(e)
+        return msg
+    else:
+        filename_m, ext_m = files.extract_filename_ext_by_path(old_path)
+        files.write_file_binary(
+            os.path.join(dest_path, "%s%s" % (new_fname, ext_m)),
+            request_file.content,
+        )
+
+
+def packing_assets(asset_replacements, pkg_path, bad_pkg_path, pkg_name):
+    """
+    Retorna o caminho do pacote (pkg_path ou bad_pkg_path)
+    """
+    errors = []
+    if not os.path.isdir(pkg_path):
+        files.make_empty_dir(pkg_path)
+
+    for old_path, new_fname in asset_replacements:
+        error = download_asset(old_path, new_fname, pkg_path)
+        if error:
+            errors.append((old_path, new_fname, error))
+
+    if len(errors) > 0:
+        # garante que existe pastas diferentes para
+        # pacotes completos e incompletos
+        if pkg_path == bad_pkg_path:
+            bad_pkg_path += '_INCOMPLETE'
+        # move pacote incompleto para a pasta de pacotes incompletos
+        files.make_empty_dir(bad_pkg_path)
+        for item in os.listdir(pkg_path):
+            shutil.move(os.path.join(pkg_path, item), bad_pkg_path)
+        shutil.rmtree(pkg_path)
+        # gera relatorio de erros
+        errors_filename = os.path.join(bad_pkg_path, "%s.err" % pkg_name)
+        if len(errors) > 0:
+            error_messages = '\n'.join(['%s %s %s' % _err for _err in errors])
+            files.write_file(errors_filename, error_messages)
+        return bad_pkg_path
+    return pkg_path

--- a/documentstore_migracao/processing/reading.py
+++ b/documentstore_migracao/processing/reading.py
@@ -33,14 +33,14 @@ def reading_article_xml(file_xml_path, move_success=True):
                 request_file = request.get(
                     urljoin(config.get("STATIC_URL_FILE"), media)
                 )
-                filename_m, ext_m = string.extract_filename_ext_by_path(media)
-                files.write_file_bynary(
+                filename_m, ext_m = files.extract_filename_ext_by_path(media)
+                files.write_file_binary(
                     os.path.join(dest_path, "%s%s" % (filename_m, ext_m)),
                     request_file.content,
                 )
 
     if is_media and dest_path:
-        filename, _ = string.extract_filename_ext_by_path(file_xml_path)
+        filename, _ = files.extract_filename_ext_by_path(file_xml_path)
         files.write_file(
             os.path.join(dest_path, "%s.xml" % (filename)),
             xml.prettyPrint_format(

--- a/documentstore_migracao/processing/validation.py
+++ b/documentstore_migracao/processing/validation.py
@@ -4,7 +4,7 @@ import shutil
 
 from packtools import XMLValidator, exceptions
 
-from documentstore_migracao.utils import files, dicts, string
+from documentstore_migracao.utils import files, dicts
 from documentstore_migracao import config
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ def validator_article_ALLxml(move_to_processed_source=False, move_to_valid_xml=F
     result = {}
     for file_xml in list_files_xmls:
 
-        filename, _ = string.extract_filename_ext_by_path(file_xml)
+        filename, _ = files.extract_filename_ext_by_path(file_xml)
         converted_file = os.path.join(config.get("CONVERSION_PATH"), file_xml)
 
         try:

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -4,7 +4,7 @@ import html
 from lxml import etree
 from copy import deepcopy
 from documentstore_migracao.utils import xml as utils_xml
-from documentstore_migracao import config
+
 
 logger = logging.getLogger(__name__)
 

--- a/documentstore_migracao/utils/files.py
+++ b/documentstore_migracao/utils/files.py
@@ -5,7 +5,6 @@ import shutil
 import logging
 
 from documentstore_migracao import config
-from documentstore_migracao.utils import string
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +14,14 @@ def setup_processing_folder():
     paths = config.INITIAL_PATH
     for path in paths:
         create_dir(path)
+
+
+def extract_filename_ext_by_path(inputFilepath):
+
+    filename_w_ext = os.path.basename(inputFilepath)
+    c_filename, file_extension = os.path.splitext(filename_w_ext)
+    filename, _ = os.path.splitext(c_filename)
+    return filename, file_extension
 
 
 def move_xml_to(xml_file, source_path, destiny_path):
@@ -30,9 +37,21 @@ def create_dir(path):
         os.makedirs(path)
 
 
+def make_empty_dir(path):
+    if os.path.isdir(path):
+        for item in os.listdir(path):
+            file_path = os.path.join(path, item)
+            try:
+                os.unlink(file_path)
+            except OSError:
+                raise
+    else:
+        os.makedirs(path)
+
+
 def create_path_by_file(path, file_xml_path):
 
-    filename, _ = string.extract_filename_ext_by_path(file_xml_path)
+    filename, _ = extract_filename_ext_by_path(file_xml_path)
     dest_path = os.path.join(path, filename)
     create_dir(dest_path)
     return dest_path
@@ -60,7 +79,7 @@ def write_file(path, source):
         f.write(source)
 
 
-def write_file_bynary(path, source):
+def write_file_binary(path, source):
     logger.debug("Gravando arquivo binario: %s", path)
     with open(path, "wb") as f:
         f.write(source)

--- a/documentstore_migracao/utils/string.py
+++ b/documentstore_migracao/utils/string.py
@@ -1,7 +1,5 @@
 """ module to methods to string format """
-import os
 import re
-import logging
 import unicodedata
 
 
@@ -13,11 +11,3 @@ def normalize(string):
 def remove_spaces(string):
 
     return re.sub(" +", " ", string).strip()
-
-
-def extract_filename_ext_by_path(inputFilepath):
-
-    filename_w_ext = os.path.basename(inputFilepath)
-    c_filename, file_extension = os.path.splitext(filename_w_ext)
-    filename, _ = os.path.splitext(c_filename)
-    return filename, file_extension

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,9 @@
 import os
 
+
 SAMPLES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "samples")
+TEMP_TEST_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "temp")
+
 
 SAMPLES_JOURNAL = {
     "v64": [{"_": "spm@insp3.insp.mx"}],
@@ -495,4 +498,4 @@ SAMPLE_ISSUES_KERNEL = [
         "id": "0001-3714-1998-v29-n3",
     }
 ]
-COUNT_SAMPLES_FILES = 9
+COUNT_SAMPLES_FILES = 13

--- a/tests/samples/S0044-59672003000300002_sps_completo.xml
+++ b/tests/samples/S0044-59672003000300002_sps_completo.xml
@@ -1,0 +1,4669 @@
+<?xml version="1.0" ?>
+<!DOCTYPE article
+  PUBLIC '-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN'
+  'JATS-journalpublishing1.dtd'>
+<article article-type="research-article" dtd-version="1.1" specific-use="sps-1.8" xml:lang="pt" xmlns:xlink="http://www.w3.org/1999/xlink">
+	
+ 
+	<front>
+		
+ 
+		<journal-meta>
+			
+ 
+			<journal-id journal-id-type="publisher-id">aa</journal-id>
+			
+ 
+			<journal-title-group>
+				
+ 
+				<journal-title>Acta Amazonica</journal-title>
+				
+ 
+				<abbrev-journal-title abbrev-type="publisher">Acta Amaz.</abbrev-journal-title>
+				
+ 
+			</journal-title-group>
+			
+ 
+			<issn pub-type="ppub">0044-5967</issn>
+			
+ 
+			<issn pub-type="epub">1809-4392</issn>
+			
+ 
+			<publisher>
+				
+ 
+				<publisher-name>Instituto Nacional de Pesquisas da Amazônia</publisher-name>
+				
+ 
+				<publisher-loc>Manaus, AM, Brazil</publisher-loc>
+				
+ 
+			</publisher>
+			
+ 
+		</journal-meta>
+		
+ 
+		<article-meta>
+			
+ 
+			<article-id pub-id-type="publisher-id">S0044-59672003000300002</article-id>
+			
+ 
+			<article-id pub-id-type="doi">10.1590/S0044-59672003000300002</article-id>
+			
+ 
+			<title-group>
+				
+ 
+				<article-title>Plantas invasoras em sistemas agroflorestais com cupuaçuzeiro no município de Presidente Figueiredo (Amazonas, Brasil)</article-title>
+				
+ 
+				<trans-title-group xml:lang="en">
+					
+ 
+					<trans-title>Weedy plants in agroforestry systems with cupuassu in the municipality of Presidente Figueiredo (Amazonas, Brazil)</trans-title>
+					
+ 
+				</trans-title-group>
+				
+ 
+			</title-group>
+			
+ 
+			<contrib-group>
+				
+ 
+				<contrib contrib-type="author">
+					
+ 
+					<name>
+						
+ 
+						<surname>Sousa</surname>
+						
+ 
+						<given-names>Gladys Ferreira de</given-names>
+						
+ 
+					</name>
+					
+ 
+					<role>ND</role>
+					
+ 
+					<xref ref-type="aff" rid="aff01"/>
+					
+ 
+				</contrib>
+				
+ 
+				<contrib contrib-type="author">
+					
+ 
+					<name>
+						
+ 
+						<surname>Oliveira</surname>
+						
+ 
+						<given-names>Luiz Antonio de</given-names>
+						
+ 
+					</name>
+					
+ 
+					<role>ND</role>
+					
+ 
+					<xref ref-type="aff" rid="aff02"/>
+					
+ 
+				</contrib>
+				
+ 
+				<contrib contrib-type="author">
+					
+ 
+					<name>
+						
+ 
+						<surname>Silva</surname>
+						
+ 
+						<given-names>José Ferreira da</given-names>
+						
+ 
+					</name>
+					
+ 
+					<role>ND</role>
+					
+ 
+					<xref ref-type="aff" rid="aff03"/>
+					
+ 
+				</contrib>
+				
+ 
+			</contrib-group>
+			
+ 
+			<aff id="aff01">
+				
+ 
+				<addr-line>
+					
+ 
+					<named-content content-type="city">Belém</named-content>
+					
+ 
+					<named-content content-type="state"/>
+					
+ 
+				</addr-line>
+				
+ 
+				<institution content-type="orgname">Embrapa</institution>
+				
+ 
+				<country country="BR">Brazil</country>
+				
+ 
+				<email>gladysfs@cpatu.embrapa.br</email>
+				
+ 
+			</aff>
+			
+ 
+			<aff id="aff03">
+				
+ 
+				<addr-line>
+					
+ 
+					<named-content content-type="city">Manaus</named-content>
+					
+ 
+					<named-content content-type="state"/>
+					
+ 
+				</addr-line>
+				
+ 
+				<institution content-type="orgname">Universidade Federal do Amazonas</institution>
+				
+ 
+				<country country="BR">Brazil</country>
+				
+ 
+				<email>jfsilva@ufam.edu.br</email>
+				
+ 
+			</aff>
+			
+ 
+			<aff id="aff02">
+				
+ 
+				<addr-line>
+					
+ 
+					<named-content content-type="city">Manaus</named-content>
+					
+ 
+					<named-content content-type="state"/>
+					
+ 
+				</addr-line>
+				
+ 
+				<institution content-type="orgname">Instituto Nacional de Pesquisas da Amazônia</institution>
+				
+ 
+				<country country="BR">Brazil</country>
+				
+ 
+				<email>luizoli@inpa.gov.br</email>
+				
+ 
+			</aff>
+			
+ 
+			<pub-date pub-type="epub-ppub">
+				
+ 
+				<year>2003</year>
+				
+ 
+			</pub-date>
+			
+ 
+			<volume>33</volume>
+			
+ 
+			<issue>3</issue>
+			
+ 
+			<fpage>353</fpage>
+			
+ 
+			<lpage>370</lpage>
+			
+ 
+			<history>
+				
+ 
+				<date date-type="received">
+					
+ 
+					<day>06</day>
+					
+ 
+					<month>07</month>
+					
+ 
+					<year>2002</year>
+					
+ 
+				</date>
+				
+ 
+				<date date-type="accepted">
+					
+ 
+					<day>10</day>
+					
+ 
+					<month>03</month>
+					
+ 
+					<year>2003</year>
+					
+ 
+				</date>
+				
+ 
+			</history>
+			
+ 
+			<permissions>
+				
+ 
+				<license license-type="open-access" xlink:href="http://creativecommons.org/licenses/by-nc/4.0/" xml:lang="en">
+					
+ 
+					<license-p>This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License.</license-p>
+					
+ 
+				</license>
+				
+ 
+			</permissions>
+			
+ 
+			<abstract>
+				
+ 
+				<p>A infestação crescente de plantas invasoras nos sistemas agrícolas causa prejuízos às lavouras, com decréscimos acentuados da produtividade, quer pela competição direta pelos fatores de produção, quer pelos compostos alelopáticos liberados. Este trabalho consistiu de um levantamento e análise fitossociológica de alguns aspectos de espécies de invasoras que ocorrem em sistemas agroflorestais com cupuaçuzeiro, em três arranjos de culturas (mandioca+fruteiras; anuais+fruteiras; maracujá+fruteiras), sob três sistemas de adubação (NPK+MO, adubação com Fósforo e Fósforo+leguminosa). As coletas das plantas invasoras feitas em seis amostras de 0,25 m² por parcela foram posteriormente levadas ao laboratório para identificação. As 55 espécies identificadas estavam distribuídas em 23 famílias botânicas, sendo 43 espécies de dicotiledôneas (78,2%), 11 de monocotiledôneas (20,0%) e uma de pteridófita (1,8%). As famílias Poaceae (monocotiledônea) e Asteraceae (dicotiledônea) foram as mais freqüentes e com maior número de indivíduos. As espécies mais freqüentes e com maior número de plantas por m² foram Paspalum conjugatum P.J. Bergius (área A) e Homolepis aturensis (Kunth) Chase (área B), ambas da família Poaceae; Ageratum conyzoides L. da família Asteraceae, apresentou a maior densidade. Os coeficientes de similaridade variaram entre as áreas amostradas, sendo os maiores índices observados nos tratamentos que receberam adubação com matéria orgânica, particularmente nos sistemas mandioca+fruteiras. As práticas agrícolas e os sistemas de manejo do solo e das lavouras exerceram influência na composição florística e no tamanho das comunidades de plantas invasoras em cada local. O número de monocotiledôneas foi menor no tratamento com adubação NPK+MO.</p>
+				
+ 
+			</abstract>
+			
+ 
+			<trans-abstract xml:lang="en">
+				
+ 
+				<p>The increase of weed infestation on agricultural systems cause damages to the crops, decreasing plant productivity by the direct competition or by alelopathy. This work have undertaken a survey and phytosociological analysis of some aspects of weed species that occur in agroforestry systems with cupuassu. The treatments consisted of three crops arrangements (cassava+fruit trees; annuals crops+fruit trees; passion fruit+fruit trees), and three fertilizer management (NPK+OM, with Phosphorus and Phosphorus+leguminous). Three harvests of weed plants were accomplished, being six samples of 0,25 m² per plot. The identification of the species of the weed plants were carried out in the laboratory. The 55 weed species identified were distributed in 23 botanical families, being 43 of dicotyledonous species, 11 of monocotyledonous, and one of pteridophyta. The families Poaceae (monocotyledonous) and Asteraceae (dicotyledonous) were the most frequent and with large number of individuals. The most frequent species and with large number of plants per m² were Paspalum conjugatum P.J. Bergius (area A) and Homolepis aturensis (Kunth) Chase (area B) of the Poaceae family; Ageratum conyzoides L. of the Asteraceae family, presented the largest density. The similarity coefficients varied among the areas studied, being the largest indexes observed in the treatments that received fertilizers with organic matter (NPK+OM), particularly in the system cassava+fruit trees. The agricultural practices and the soil and crops management systems, had a great influence to the flora composition and in the weed plants communities size in each local area. The number of monocotyledonous was smaller in the treatment with NPK+OM than in the other treatments.</p>
+				
+ 
+			</trans-abstract>
+			
+ 
+			<kwd-group kwd-group-type="author-generated" xml:lang="en">
+				
+ 
+				<kwd>Theobroma grandiflorum</kwd>
+				
+ 
+				<kwd>weeds</kwd>
+				
+ 
+				<kwd>monocotyledonous</kwd>
+				
+ 
+				<kwd>dicotyledonous</kwd>
+				
+ 
+			</kwd-group>
+			
+ 
+			<kwd-group kwd-group-type="author-generated" xml:lang="pt">
+				
+ 
+				<kwd>Theobroma grandiflorum</kwd>
+				
+ 
+				<kwd>plantas daninhas</kwd>
+				
+ 
+				<kwd>monocotiledôneas</kwd>
+				
+ 
+				<kwd>dicotiledôneas</kwd>
+				
+ 
+			</kwd-group>
+			
+ 
+			<counts>
+				
+ 
+				<fig-count count="0"/>
+				
+ 
+				<table-count count="0"/>
+				
+ 
+				<equation-count count="0"/>
+				
+ 
+				<ref-count count="51"/>
+				
+ 
+				<page-count count="18"/>
+				
+ 
+			</counts>
+			
+ 
+		</article-meta>
+		
+ 
+	</front>
+	
+ 
+	<body>
+		<p>
+			<bold>
+				<sup>
+					<xref>1</xref>
+				</sup>
+			</bold>
+		</p>
+		 
+		<p>
+			<bold>Weedy plants in agroforestry systems with cupuassu in the municipality of Presidente Figueiredo (Amazonas, Brazil)</bold>
+		</p>
+		 
+		<p>
+			<bold>
+				Gladys Ferreira de Sousa
+				<sup>I</sup>
+				; Luiz Antonio de Oliveira
+				<sup>II</sup>
+				; José Ferreira da Silva
+				<sup>III</sup>
+			</bold>
+		</p>
+		 
+		<p>
+			<sup>I</sup>
+			Pesquisadora da Embrapa. Caixa Postal 48 CEP 66 095-100, Belém-PA (
+			<ext-link ext-link-type="email" xlink:href="mailto:gladysfs@cpatu.embrapa.br">gladysfs@cpatu.embrapa.br</ext-link>
+			) 
+		</p>
+		<p>
+			<sup>II</sup>
+			Pesquisador do INPA. Caixa Postal 478 , CEP 69 011- 970, Manaus (AM). (
+			<ext-link ext-link-type="email" xlink:href="mailto:luizoli@inpa.gov.br">luizoli@inpa.gov.br</ext-link>
+			), bolsista do CNPQ 
+		</p>
+		<p>
+			<sup>III</sup>
+			Professor da Universidade Federal do Amazonas. Av. Gal. Rodrigo Otávio, 3000, CEP 69077-000, Manaus (AM) (
+			<ext-link ext-link-type="email" xlink:href="mailto:jfsilva@ufam.edu.br">jfsilva@ufam.edu.br</ext-link>
+			)
+		</p>
+		 
+		<p>
+			<bold>RESUMO </bold>
+		</p>
+		 
+		<p>
+			 A infestação crescente de plantas invasoras nos sistemas agrícolas causa prejuízos às lavouras, com decréscimos acentuados da produtividade, quer pela competição direta pelos fatores de produção, quer pelos compostos alelopáticos liberados. Este trabalho consistiu de um levantamento e análise fitossociológica de alguns aspectos de espécies de invasoras que ocorrem em sistemas agroflorestais com cupuaçuzeiro, em três arranjos de culturas (mandioca+fruteiras; anuais+fruteiras; maracujá+fruteiras), sob três sistemas de adubação (NPK+MO, adubação com Fósforo e Fósforo+leguminosa). As coletas das plantas invasoras feitas em seis amostras de 0,25 m
+			<sup>2</sup>
+			 por parcela foram posteriormente levadas ao laboratório para identificação. As 55 espécies identificadas estavam distribuídas em 23 famílias botânicas, sendo 43 espécies de dicotiledôneas (78,2%), 11 de monocotiledôneas (20,0%) e uma de pteridófita (1,8%). As famílias Poaceae (monocotiledônea) e Asteraceae (dicotiledônea) foram as mais freqüentes e com maior número de indivíduos. As espécies mais freqüentes e com maior número de plantas por m
+			<sup>2</sup>
+			 foram 
+			<italic>Paspalum conjugatum</italic>
+			 P.J. Bergius (área A) e 
+			<italic>Homolepis aturensis </italic>
+			(Kunth) Chase (área B), ambas da família Poaceae; 
+			<italic>Ageratum conyzoides</italic>
+			 L. da família Asteraceae, apresentou a maior densidade. Os coeficientes de similaridade variaram entre as áreas amostradas, sendo os maiores índices observados nos tratamentos que receberam adubação com matéria orgânica, particularmente nos sistemas mandioca+fruteiras. As práticas agrícolas e os sistemas de manejo do solo e das lavouras exerceram influência na composição florística e no tamanho das comunidades de plantas invasoras em cada local. O número de monocotiledôneas foi menor no tratamento com adubação NPK+MO. 
+		</p>
+		 
+		<p>
+			<bold>Palavras-chave: </bold>
+			<italic>Theobroma grandiflorum</italic>
+			, plantas daninhas, monocotiledôneas, dicotiledôneas 
+		</p>
+		 
+		<p>
+			<bold>ABSTRACT </bold>
+		</p>
+		 
+		<p>
+			The increase of weed infestation on agricultural systems cause damages to the crops, decreasing plant productivity by the direct competition or by alelopathy. This work have undertaken a survey and phytosociological analysis of some aspects of weed species that occur in agroforestry systems with cupuassu. The treatments consisted of three crops arrangements (cassava+fruit trees; annuals crops+fruit trees; passion fruit+fruit trees), and three fertilizer management (NPK+OM, with Phosphorus and Phosphorus+leguminous). Three harvests of weed plants were accomplished, being six samples of 0,25 m
+			<sup>2</sup>
+			 per plot. The identification of the species of the weed plants were carried out in the laboratory. The 55 weed species identified were distributed in 23 botanical families, being 43 of dicotyledonous species, 11 of monocotyledonous, and one of pteridophyta. The families Poaceae (monocotyledonous) and Asteraceae (dicotyledonous) were the most frequent and with large number of individuals. The most frequent species and with large number of plants per m
+			<sup>2</sup>
+			 were 
+			<italic>Paspalum conjugatum</italic>
+			 P.J. Bergius (area A) and 
+			<italic>Homolepis aturensis</italic>
+			 (Kunth) Chase (area B) of the Poaceae family; 
+			<italic>Ageratum conyzoides</italic>
+			 L. of the Asteraceae family, presented the largest density. The similarity coefficients varied among the areas studied, being the largest indexes observed in the treatments that received fertilizers with organic matter (NPK+OM), particularly in the system cassava+fruit trees. The agricultural practices and the soil and crops management systems, had a great influence to the flora composition and in the weed plants communities size in each local area. The number of monocotyledonous was smaller in the treatment with NPK+OM than in the other treatments. 
+		</p>
+		 
+		<p>
+			<bold>Key-words: </bold>
+			 
+			<italic>Theobroma grandiflorum</italic>
+			, weeds, monocotyledonous, dicotyledonous 
+		</p>
+		 
+		<p>
+			<bold>INTRODUÇÃO</bold>
+			 
+		</p>
+		 
+		<p>
+			A infestação crescente de plantas invasoras nos sistemas agrícolas causa prejuízos às lavouras, com decréscimos acentuados da produtividade, quer pela competição direta pelos fatores de produção, quer pelos compostos alelopáticos liberados (Akobundu, 1987; Almeida, 1988; Martins &amp;amp; Pitelli, 1994; Saavedra, 1994; Souza Filho 
+			<italic>et al</italic>
+			., 1997; Vangessel 
+			<italic>et al.</italic>
+			, 1995). As comunidades de plantas invasoras geralmente resultam das alterações ecológicas pela ação antrópica. Porém, os danos causados são reduzidos quando manejadas adequadamente (Primavesi, 1992a, b). 
+		</p>
+		 
+		<p>
+			As necessidades de mão de obra para controle das plantas invasoras aumentam com a continuidade dos cultivos, tendo sido estimado em cerca de 30 a 40% dos custos totais de produção em plantios de mandioca (Alcântara &amp;amp; Carvalho, 1983) e na maioria dos cultivos nos trópicos (Yamoah 
+			<italic>et al.</italic>
+			, 1986). 
+		</p>
+		 
+		<p>
+			No Brasil, as plantas invasoras são responsáveis pela redução na produção de milho em cerca de 25 a 30 % e de 50 a 70 % em arroz de sequeiro (Lorenzi, 1980; Domingues 
+			<italic>et al.,</italic>
+			 1982). 
+		</p>
+		 
+		<p>Uma importante razão para o sucesso das invasoras é a sua capacidade de adaptação às condições dos agrossistemas, levando à ocupação e exploração eficiente do ambiente (Dias Filho, 1990). Ao manterem uma alta diversidade de espécies, inclusive dentro da mesma população, elas competem com maior sucesso com outras espécies. A heterogeneidade nas populações permite explorar recursos e adaptar-se à qualquer mudança de práticas culturais ou ambientais, enquanto as plantas cultivadas evoluem para a homogeneidade, visto ser a demanda a produtividade individual (Dekker, 1997). </p>
+		 
+		<p>
+			As práticas culturais e a intensificação dos cultivos provocam desequilíbrio nas populações de invasoras (Derksen 
+			<italic>et al</italic>
+			., 1993). Desse modo, alterações na diversidade de comunidades de plantas invasoras podem estar relacionadas com o histórico de manejo do solo e das culturas (Vinha 
+			<italic>et al.</italic>
+			, 1982; Derksen 
+			<italic>et al</italic>
+			., 1993). Stevensen 
+			<italic>et al</italic>
+			. (1997) observaram efeito significativo da interação rotação x tratos culturais na diversidade de invasoras. Para McCloskey 
+			<italic>et al.</italic>
+			 (1996) os tratos culturais são as práticas mais importantes que afetam a densidade das plantas invasoras. 
+		</p>
+		 
+		<p>
+			Nos sistemas agroflorestais, onde geralmente a área é mais intensamente ocupada por espécies cultivadas, os arranjos de culturas podem exercer um controle mais eficiente das plantas invasoras. Como observado por Sousa (1995), algumas combinações de culturas nos sistemas agroflorestais influenciaram na densidade, freqüência e fitomassa aérea das plantas invasoras, podendo também, minimizar a competição e otimizar a produção das áreas cultivadas (Schulz 
+			<italic>et al.</italic>
+			, 1994). 
+		</p>
+		 
+		<p>O trabalho objetivou identificar a composição florística das comunidades de plantas invasoras em sistemas agroflorestais com cupuaçuzeiro, procurando-se determinar o grau de infestação e distribuição das populações nas diferentes épocas do ano, de acordo com os diferentes arranjos dos componentes do sistema. Procurou-se determinar se diferentes níveis de fertilidade de solo influenciaram na diminuição ou aumento de espécies de monocotiledôneas e dicotiledôneas na área estudada. </p>
+		 
+		<p>
+			<bold>MATERIAL E MÉTODOS</bold>
+		</p>
+		 
+		<p>Área de estudo</p>
+		 
+		<p>
+			O trabalho foi conduzido no período de dezembro de 1996 a dezembro de 1998, em propriedades de pequenos produtores no município de Presidente Figueiredo, Estado do Amazonas, localizado a 107 km da cidade de Manaus. Geograficamente, este município se situa entre as coordenadas cartesianas de latitude sul 2
+			<sup>0</sup>
+			 14' 26&quot; e aproximadamente entre os graus 60
+			<sup>0 </sup>
+			a 61
+			<sup>0</sup>
+			 de longitude W. Gr, numa altitude de 92,9 metros acima do nível do mar. 
+		</p>
+		 
+		<p>
+			O clima da região é quente e úmido, classificado como Ami, segundo Köppen. Caracteriza-se pela temperatura média do mês mais frio nunca inferior a 18oC e a precipitação do mês mais seco, acima de 60 mm. A precipitação pluviométrica média anual é sempre superior a 2000 mm e distribuída em duas estações bem distintas: uma com alta precipitação pluviométrica, que vai de novembro a maio e a outra, de menor precipitação pluviométrica, vai de junho a outubro. O período de maior estiagem ocorre freqüentemente de julho a setembro (SUDAM, 1984; EMBRAPA, 1998a, b). O regime climático observado na época em que o trabalho foi desenvolvido apresentou, respectivamente, um total pluviométrico de 2.585 mm, 2.243 mm e 2.546 mm para os três anos. A temperatura média anual foi de 26,7oC, com a máxima em torno de 31,2
+			<sup>0</sup>
+			C e a mínima em torno de 23,5oC. A umidade relativa do ar é bastante elevada em toda a região, variando entre 71 % a 91 %, com média de cerca de 86 % (SUDAM, 1984; EMBRAPA, 1998a, b). 
+		</p>
+		 
+		<p>A economia do município é calcada nas atividades do setor secundário, com destaque para a mineração, e do setor primário, com o extrativismo (madeira, pedras, minério e pescado) e a agricultura. Esta é baseada no cultivo do arroz, mandioca (basicamente para produção de farinha), cupuaçu, macaxeira, cana-de-açúcar, guaraná e outras frutas como banana, mamão, laranja, etc. A pecuária, constituída pela exploração de bovinos, é também destaque no município (ICOTI, 1992; CPRM, 1998). </p>
+		 
+		<p>As duas propriedades em estudo localizam-se entre os km 13 e 51 na rodovia estadual AM-240, nas comunidades Marcos Freire (km 13) e São Francisco de Assis (km 22), situadas em assentamentos do INCRA. </p>
+		 
+		<p>
+			As principais unidades de solo que predominam na região são o Latossolo Amarelo, textura muito argilosa, distrófico, o Podzólico Vermelho Amarelo, textura média, distrófico e o Podzólico Vermelho Amarelo, textura pesada, distrófico (IPEAAOC, 1971; 1972). O relevo é suavemente ondulado em algumas áreas, existindo outras com relevo ondulado a muito ondulado. Os solos fazem parte do ecossistema de terra firme de formação recente, originados de sedimentos argilosos do Terciário, representados pela série Barreiras (BRASIL, 1978). O solo das áreas selecionadas para estudo é o Latossolo Amarelo, de textura muito pesada, encontrando-se em relevo plano. Amostras de solo das áreas foram coletadas, secadas ao ar, moídas e passadas em peneira de 2 mm para uniformização. A composição química e granulométrica encontra-se na 
+			<xref>Tabela 1</xref>
+			, sendo as determinações efetuadas pelos métodos de análises em uso no laboratório de solos da EMBRAPA Amazônia Ocidental (EMBRAPA, 1997). 
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/a02tab01a.gif"/>
+		</p>
+		<p>
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/a02tab01b.gif"/>
+		</p>
+		 
+		<p>Por ocasião da implantação dos sistemas, as áreas encontravam-se com vegetação secundária (capoeira) de aproximadamente dois anos, tendo sido realizado um levantamento florístico antes da implantação dos sistemas. </p>
+		 
+		<p>
+			<bold>Sistemas agroflorestais estudados</bold>
+			 
+		</p>
+		 
+		<p>Estudou-se a composição florística e a distribuição das plantas invasoras em três sistemas agroflorestais, os quais haviam sido implantados em 1994 e conduzidos em um projeto participativo entre a EMBRAPA/INPA/UA/IDAM e os pequenos produtores de agricultura itinerante. </p>
+		 
+		<p>
+			Os três sistemas agroflorestais estudados foram constituídos por: 1. Mandioca + fruteiras; 2. Cultivos anuais+fruteiras e 3. Maracujá+fruteiras. Os componentes fruteiras foram cupuaçuzeiro (
+			<italic>Theobroma grandiflorum</italic>
+			 (Willd. ex Spreng.) Schum.), bananeira (
+			<italic>Musa</italic>
+			 spp), pupunheira (
+			<italic>Bactris gasipaes </italic>
+			Kunth
+			<italic>)</italic>
+			 e ingazeiro (
+			<italic>Inga edulis </italic>
+			Mart.). 
+		</p>
+		 
+		<p>
+			<bold>Métodos de estudo</bold>
+			 
+		</p>
+		 
+		<p>
+			Os sistemas foram testados com três tratamentos de manejo de solos: (1) com adubação NPK+Matéria Orgânica (MO), (2) adubação com fósforo e (3) fósforo+leguminosa de cobertura (
+			<italic>Mucuna pruriens </italic>
+			(L.) DC.. 
+		</p>
+		 
+		<p>
+			Os níveis de adubação orgânica foram constituídos por: 3 litros/cova de esterco de galinha aplicado nas covas do maracujazeiro (
+			<italic>Passiflora actinia</italic>
+			 Hook.) e 12 litros nas linhas de plantio das plantas anuais: feijão-caupi - 
+			<italic>Vigna unguiculata</italic>
+			 (L.) Walp. e mandioca (
+			<italic>Manihot esculenta</italic>
+			 L.), aplicadas em uma única vez. A adubação química correspondeu a 70 g de uréia, 145 g de superfosfato triplo e 96 g de cloreto de potássio em cada cova das plantas de maracujá ou 144 g, 264 g e 216 g de uréia, superfosfato triplo e KCl, respectivamente, nas linhas de plantio das plantas anuais, sendo a aplicação feita anualmente. Uma dose de calcário dolomítico equivalente a 1,5 t ha
+			<sup>-1</sup>
+			 foi utilizada a lanço em todas as parcelas e a incorporação efetuada com enxada. A quantidade de esterco de galinha foi equivalente a 7 t ha
+			<sup>-1</sup>
+			 e a adubação química, a 40 kg de N ha
+			<sup>-1</sup>
+			, 35 kg de P ha
+			<sup>-1</sup>
+			 e 67 kg de K ha
+			<sup>-1</sup>
+			. O P foi aplicado de uma só vez no plantio das lavouras. O N e o K foram aplicados metade por ocasião do plantio e a outra metade conforme a cultura entre 45 e 60 dias após o plantio. Para as espécies já implantadas, os adubos foram aplicados em cobertura próximo à planta, sendo o fósforo usado de uma única vez e o nitrogênio e potássio em duas aplicações anuais. A mucuna foi semeada no final do ciclo da primeira lavoura anual. 
+		</p>
+		 
+		<p>Os sistemas foram implantados em módulos de 54 m x 72 m, em duas propriedades rurais (A e B). Cada parcela correspondeu a 18 m x 24 m. O delineamento experimental utilizado foi o de blocos ao acaso, em faixas, com seis repetições. A análise de variância dos resultados seguiu modelo proposto por Pimentel Gomes (1982). </p>
+		 
+		<p>
+			As plantas invasoras foram coletadas em três períodos, sendo o primeiro em fevereiro de 1997, na época chuvosa, antes do plantio das espécies anuais e semi-perene e antes da aplicação dos tratamentos de adubação. Os outros períodos foram novembro/97 (época seca) e janeiro-fevereiro/98 (época chuvosa). As plantas foram coletadas em cada parcela e identificadas. As amostragens corresponderam a seis amostras de 0,25 m
+			<sup>2</sup>
+			 cada, por parcela, distribuídas aleatoriamente, usando-se um quadrado de madeira de 50 cm x 50 cm. As seis áreas amostradas eqüivaliam a 1% da área útil de cada parcela. 
+		</p>
+		 
+		<p>Após a identificação preliminar feita pelos botânicos no campo, e a estimativa do grau de infestação, as plantas invasoras foram cortadas rente ao solo, separadas por classe em monocotiledôneas e dicotiledôneas, levadas para o laboratório para completar o trabalho de separação por espécie e identificação. Após a separação das plantas por espécie, foi feita a contagem de todos os indivíduos em cada sub-área amostrada, inclusive plântulas, quando era possível se distinguir. </p>
+		 
+		<p>Para facilitar a identificação botânica, foram preparadas, ainda no campo, exsicatas de todas as espécies encontradas. Procedeu-se uma breve descrição das principais características das plantas, tais como porte da espécie, altura, tipo de folha e de flores, quando encontradas. Foram preparadas fichas para catalogação, onde foram anotados nome comum e científico, data e local da coleta. </p>
+		 
+		<p>
+			O trabalho de identificação foi feito, em princípio, por comparação, utilizando-se as seguintes referências (Leitão Filho 
+			<italic>et al.</italic>
+			, 1972; Albuquerque, 1980; Kissmann &amp; Groth, 1993; Lorenzi, 1994; Le Bourgeois &amp; Merlier, 1995). Quando não foi possível, ou havia dúvidas, contou-se com a colaboração de um especialista ou em alguns casos foram citados apenas em nível de gênero e/ou família. As duplicatas das exsicatas de todas as espécies foram depositadas no herbário da EMBRAPA Amazônia Ocidental/Manaus. 
+		</p>
+		 
+		<p>A avaliação de comunidades de plantas invasoras e do seu comportamento nos diferentes hábitats foi feita usando-se variáveis como freqüência, coeficiente de similaridade, matéria seca e abundância (Carvalho &amp;amp; Pitelli, 1992). </p>
+		 
+		<p>Para o estudo quantitativo, foi efetuada a contagem do número de plantas de cada espécie, a partir do que realizaram-se os cálculos de freqüência de ocorrência, usando-se a fórmula a seguir, sendo os resultados dados em percentagem (Carvalho &amp;amp; Pitelli, 1992; Sousa, 1995). </p>
+		 
+		<p>F = Po x100/PT </p>
+		 
+		<p>F = Freqüência (%) </p>
+		 
+		<p>Po = número de parcelas ocupadas, isto é, em que ocorre uma dada espécie </p>
+		 
+		<p>PT = número total de parcelas amostradas. </p>
+		 
+		<p>A densidade foi definida como o número de indivíduos por metro quadrado, sendo determinada para cada espécie pela fórmula descrita por Carvalho &amp;amp; Pitelli (1992) e Sousa (1995): </p>
+		 
+		<p>
+			DA= n/m
+			<sup>2</sup>
+			 onde: 
+		</p>
+		 
+		<p>DA = densidade absoluta </p>
+		 
+		<p>n = número total de indivíduos de uma dada espécie </p>
+		 
+		<p>
+			m
+			<sup>2</sup>
+			 = metros quadrados. 
+		</p>
+		 
+		<p>O coeficiente de similaridade foi calculado baseando-se na seguinte fórmula: CS=2C x 100/A+B, proposta por Sorensen (1948), apud Carvalho &amp;amp; Pitelli (1992) e Sousa (1995), onde: </p>
+		 
+		<p>CS = Coeficiente de Similaridade (%) </p>
+		 
+		<p>A= número de espécies do hábitat A; </p>
+		 
+		<p>B= número de espécies do hábitat B; </p>
+		 
+		<p>C= número de espécies comuns aos dois hábitats. </p>
+		 
+		<p>
+			Os dados do número de plantas invasoras foram transformados em 
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/a02fr01.gif"/>
+			, para efeito da análise de variância. A significância para a análise de variância foi feita pelo teste &quot;F&quot; a 5% de probabilidade. As comparações entre as médias foram feitas pelo teste de &quot;Tukey&quot;, também a 5% de probabilidade. Os cálculos do desvio padrão (s) e erro padrão da média (s
+			<sub>m</sub>
+			) foram conforme Pimentel Gomes (1982). 
+		</p>
+		 
+		<p>
+			<bold>RESULTADOS E DISCUSSÃO </bold>
+		</p>
+		 
+		<p>Caracterização das Plantas Invasoras nos Sistemas de uso da terra</p>
+		 
+		<p>
+			Foram identificadas 55 espécies de plantas invasoras, distribuídas em 23 famílias botânicas (
+			<xref>Tabela 2</xref>
+			). Destas espécies, 43 são dicotiledôneas (78,2 %), 11 monocotiledôneas (20,0%) e uma pteridófita (1,8%). Na 
+			<xref>Tabela 2</xref>
+			 foram relacionadas todas as espécies encontradas nas duas áreas e identificadas pelos seus nomes científico e vulgar, quando conhecidos, segundo Silva 
+			<italic>et al.</italic>
+			 (1977); Silva 
+			<italic>et al.</italic>
+			 (1988), Mori 
+			<italic>et al.</italic>
+			 (1980), Lorenzi (1994). 
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/a02tab02.gif"/>
+		</p>
+		 
+		<p>
+			Observa-se também na 
+			<xref>Tabela 2</xref>
+			, que as espécies com maiores médias de densidades, ou seja, com maior número de plantas por m
+			<sup>2</sup>
+			 foram 
+			<italic>Paspalum conjugatum</italic>
+			 P.J. Bergius e 
+			<italic>Ageratum conyzoides</italic>
+			 L. na área A, com 66,81 e 44,67 plantas m
+			<sup>-2</sup>
+			, respectivamente. Na área B, as espécies com maiores densidades foram 
+			<italic>Homolepis aturensis </italic>
+			(Kunth) Chase e 
+			<italic>Ageratum conyzoides</italic>
+			 L., com 41,95 e 35,36 plantas m
+			<sup>-2</sup>
+			, respectivamente. 
+		</p>
+		 
+		<p>
+			As dez espécies mais importantes em número de indivíduos por m
+			<sup>2</sup>
+			 corresponderam a 86,34% na área A e 89,95% na área B. Destas, verifica-se que as famílias Poaceae (área A), Poaceae e Cyperaceae (área B) representam 42,91% e 60,88% nas áreas A e B, respectivamente. Pleasant 
+			<italic>et al.</italic>
+			 (1990), estudando medidas de controle de invasoras em sistemas de cultivo contínuo de lavouras anuais, mostraram que 60% das invasoras na primeira cultura eram constituídas por Poaceae, contra 15% de dicotiledôneas e 25% de Cyperaceae. Já no sexto cultivo, as Poaceae compunham 80% da população de invasoras. 
+		</p>
+		 
+		<p>
+			Conforme a densidade da comunidade em nível de grupo, nota-se que as monocotiledôneas foram superiores em relação ao número de indivíduos por metro quadrado, particularmente na área B. O número total de indivíduos de Poaceae e Cyperaceae por m
+			<sup>2</sup>
+			 na área B foi de 93,2 plantas m
+			<sup>-2</sup>
+			, enquanto o número de dicotiledôneas foi de 55,1 plantas m
+			<sup>-2</sup>
+			 (
+			<xref>Tabela 2</xref>
+			). Na área A, as monocotiledôneas estavam constituídas somente por Poaceae, com 113,0 indivíduos por m
+			<sup>2</sup>
+			, sendo um número bastante expressivo quando comparado a 138,6 plantas m
+			<sup>-2</sup>
+			 das 43 espécies dicotiledôneas. Mori 
+			<italic>et al.</italic>
+			 (1980) observaram que a ocorrência de dicotiledôneas foi maior que as monocotiledôneas (46 vs. 26 espécies). No entanto, as monocotiledôneas apresentaram maior biomassa, indicando que foram quase duas vezes mais prejudiciais aos cultivos que as dicotiledôneas. 
+		</p>
+		 
+		<p>
+			As famílias Poaceae e Asteraceae apresentaram maior número de espécies, ambas com 10, destacando-se 
+			<italic>Paspalum conjugatum</italic>
+			 P.J. Bergius, na área A, e 
+			<italic>Homolepis aturensis </italic>
+			(Kunth) Chase, na área B, como as mais freqüentes da família Poaceae. 
+			<italic>Panicum laxum</italic>
+			 Sw., a terceira espécie mais freqüente da família Poaceae, teve freqüência de somente 9,29% e 7,22% nas áreas A e B, respectivamente. Na família Asteraceae, destacaram-se 
+			<italic>Ageratum conyzoides</italic>
+			 nas áreas A e B, e 
+			<italic>Emilia coccinea</italic>
+			, na área A como as mais freqüentes. Outras famílias com menor número de espécies foram Euphorbiaceae (6), Rubiaceae (5), Verbenaceae (3) e Cecropiaceae (3). As demais apresentaram apenas uma espécie. 
+		</p>
+		 
+		<p>
+			Comparando-se com os dados do levantamento florístico realizado na área em 1994, antes da implantação dos sistemas, verifica-se que os cultivos modificaram a diversidade das espécies da vegetação invasora. Neste levantamento identificou-se cerca de 18 espécies, representadas por 16 famílias. As espécies com maior número de indivíduos encontradas na área, com vegetação de capoeira de aproximadamente dois anos, pertenciam às famílias Cecropiaceae (15), Melastomataceae (6) e Rubiaceae (5), que provavelmente compunham 80% do total de indivíduos de arbóreas. Também, foram encontradas espécies das famílias: Gleicheniaceae (2), Burseraceae (2), Sapindaceae (2), Fabaceae (2), Solanaceae (1), entre outras. Diferentemente, em áreas de floresta primária, Klinge 
+			<italic>et al.</italic>
+			 (1975) mostraram que a maior riqueza de espécies pertence às famílias 
+			<italic>Leguminosae</italic>
+			 (ocorrendo em todos os estratos), 
+			<italic>Sapotaceae, Lauraceae, Chrysobalanaceae e Rubiaceae</italic>
+			. 
+		</p>
+		 
+		<p>
+			Observa-se na 
+			<xref>Tabela 2</xref>
+			, que algumas dessas famílias não foram encontradas nesta avaliação e mesmo as que ocorreram não foram as mais freqüentes, geralmente apresentando-se com poucas espécies e poucos indivíduos, exceção feita apenas à família Rubiaceae, a terceira mais freqüente das dicotiledôneas, apresentando-se com cinco espécies. Estes resultados mostram a alteração na diversidade da composição florística das áreas com o uso. Souza, Silva &amp; Figueiredo (1998), comparando áreas de cultivo com áreas de pousio, também observaram redução na diversidade de espécies nas áreas de cultivo. Famílias como Malpighiaceae, Cecropiaceae, Euphorbiaceae, Cyperaceae, Poaceae, entre outras, foram também encontradas em áreas experimentais na EMBRAPA Amazônia Ocidental e em áreas cultivadas com cupuaçuzeiro (Silva, 1999). 
+		</p>
+		 
+		<p>O grupo das monocotiledôneas foi formado por somente duas famílias, Poaceae e Cyperaceae, representando 20% do total das espécies registradas. No entanto, o número de indivíduos por família foi muito maior, correspondendo a 49,3% da família Poaceae, contra 31% da família Asteraceae, a maior representante das dicotiledôneas. </p>
+		 
+		<p>
+			A maior freqüência de espécies das Poaceae pode ser justificada pelo manejo do solo (Kissmann &amp;amp; Groth, 1993) e, possivelmente, pela diminuição da fertilidade deste com os cultivos sucessivos, principalmente nos tratamentos sem adubação completa. Neste caso, a ocorrência de monocotiledôneas em maior quantidade indica também a maior eficiência destas espécies na exploração dos fatores de produção (Silva 
+			<italic>et al.</italic>
+			, 1988 ). 
+		</p>
+		 
+		<p>
+			Trabalhos conduzidos em áreas da região amazônica têm mostrado a família Poaceae e principalmente a espécie 
+			<italic>Paspalum conjugatum</italic>
+			 como mais freqüentes (Souza Filho, 1995; Souza 
+			<italic>et al.</italic>
+			, 1998). Alcântara &amp; Carvalho (1983), nos estudos de invasoras em plantios de mandioca, identificaram, também, as famílias Poaceae e Asteraceae como as mais freqüentes. De igual modo, áreas ocupadas com plantios de cacau, bananeira e com leguminosas de cobertura de solo foram encontradas proliferando por invasoras mais freqüentes, tais como espécies de Poaceae, como 
+			<italic>Paspalum conjugatum</italic>
+			, além de outras importantes citadas neste estudo (Lisboa &amp; Vinha, 1982; Silva 
+			<italic>et al.</italic>
+			, 1988; Valenzuela, 1990). Esta espécie se adapta às condições de baixa luminosidade, além de vegetar em solos de fertilidade média, razão portanto, de ser encontrada com maior freqüência em áreas bastante sombreadas (Lisboa &amp; Vinha, 1982). Assim, também, pode-se justificar a maior freqüência desta espécie e de outras Poaceae nos sistemas agroflorestais, onde há maior ocupação das áreas com plantas perenes arbóreas e, consequentemente, menor incidência de luz. 
+		</p>
+		 
+		<p>
+			A distribuição das dicotiledôneas foi generalizada nas áreas e nos tratamentos estudados. Observou-se, no entanto, maior ocorrência na área A que na B e geralmente, enquanto aumentava o número de dicotiledôneas decrescia o número de monocotiledôneas (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/aa/v33n3/a02fig01.gif">Figura 1</ext-link>
+			, 
+			<xref>Tabela 3</xref>
+			). 
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/a02tab03.gif"/>
+		</p>
+		 
+		<p>
+			O número de monocotiledôneas foi menor no tratamento com adubação completa (NPK+MO) e maior nos demais tratamentos, ou seja, com P e P+Leguminosa, em ambas as áreas (
+			<xref>Tabela 3</xref>
+			). Com as dicotiledôneas, no entanto, o processo foi inverso; nas áreas com adubação NPK+MO, no solo com fertilidade mais elevada (
+			<xref>Tabela 1</xref>
+			), o número de dicotiledôneas foi 113% (área A) e 17% (área B) maior que as monocotiledôneas, decrescendo nos tratamentos P e P+Leguminosa e, com menos adubação. O maior número de plantas deste grupo pode estar relacionado à maior diversidade de dicotiledôneas, em razão da maioria das famílias botânicas encontrar-se neste grupo (Nee, 1995). Por outro lado, neste grupo também são encontradas as famílias de plantas invasoras consideradas mais agressivas (Sousa, 1995). 
+		</p>
+		 
+		<p>
+			De modo geral, o número total de plantas e de espécies invasoras aumentou com o tempo como pode ser observado na 
+			<xref>Figura 2</xref>
+			 e 
+			<xref>Tabela 4</xref>
+			. O número total de plantas invasoras decresceu na segunda coleta, sendo mais acentuado nos sistemas mandioca+fruteiras e maracujá+fruteiras (
+			<xref>Figura 2</xref>
+			). O número de espécies monocotiledôneas também mostrou um ligeiro decréscimo na segunda coleta de invasoras na área B (
+			<xref>Tabela 4</xref>
+			). Estes decréscimos corresponderam à época mais seca, e conseqüentemente, período de maior deficiência hídrica. 
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/a02fig02.jpg"/>
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/a02tab04.gif"/>
+		</p>
+		<p/>
+		 
+		<p>
+			Os dados da 
+			<xref>Tabela 4</xref>
+			 mostram um acréscimo de 42% e 26% ocorrido no número total de espécies invasoras da primeira para a terceira coleta (fev/97 para fev/98) nas áreas B e A, respectivamente, sendo 22% e 50% o aumento de espécies dicotiledôneas e 40% e 25% o de monocotiledôneas. Os dados totais de espécies que ocorreram nas áreas A e B (
+			<xref>Tabela 4</xref>
+			) evidenciam o número expressivo de espécies dicotiledôneas em relação às monocotiledôneas, 29 versus 9 na área A e 35 versus 11 na área B, assim como mostram a maior diversidade da área B (46 versus 38 espécies), o que pode estar relacionado ao banco de sementes do solo diferente para cada área. 
+		</p>
+		 
+		<p>
+			No sistema anuais+fruteiras, as monocotiledôneas tiveram um aumento contínuo, o que pode ter sido em razão dos cultivos anuais mais freqüentes e que permitiram maior movimentação do solo (
+			<xref>Figura 2</xref>
+			). Estes dados concordam com resultados anteriores relatados, que concluíram pela menor perturbação do solo como responsáveis pela redução da reinfestação das plantas invasoras, incluindo espécies da família Poaceae (McCloskey 
+			<italic>et al.,</italic>
+			 1996). 
+		</p>
+		 
+		<p>
+			Nos agrossistemas tropicais, as comunidades de plantas invasoras dominantes são formadas por espécies nativas e cosmopolitas. Os resultados deste estudo mostram que as práticas agrícolas e os sistemas de manejo do solo e das culturas exercem influência acentuada na composição florística e no tamanho das comunidades de plantas invasoras em cada local. Estes resultados corroboram outros trabalhos com plantas invasoras (Kellman, 1980; Derksen 
+			<italic>et al</italic>
+			., 1993; Dekker, 1997). 
+		</p>
+		 
+		<p>Variação da comunidade de plantas invasoras nos sistemas agroflorestais estudados. </p>
+		 
+		<p>
+			Verifica-se pelos coeficientes de similaridade dos locais e tratamentos estudados que algumas áreas mostram maiores semelhanças em termos de espécies que outras (
+			<xref>Tabela 5</xref>
+			). No entanto, as similaridades entre as áreas com os sistemas são todas menores que 50%. 
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/a02tab05.gif"/>
+		</p>
+		 
+		<p>Os maiores coeficientes de similaridade, entre as duas áreas, foram observados nos tratamentos que receberam adubação com matéria orgânica (NPK+MO), particularmente nos sistemas mandioca+fruteiras (44,0%), anuais+fruteiras (42,1%) e maracujá+fruteiras (46,3%). Este último apresenta o maior coeficiente de similaridade entre as áreas A e B, provavelmente em razão da menor movimentação do solo com o cultivo do maracujá, o qual tem ciclo mais longo que as culturas anuais e a mandioca. Os menores coeficientes foram observados no sistema anuais+fruteiras com NPK+MO (18,8%), P (15,6%) e P+Leguminosa (20,7%) na área A e maracujá+fruteiras com P, na B. De modo geral, os menores coeficientes de similaridade entre as áreas A e B em qualquer dos sistemas envolviam os tratamentos com P e P+Leguminosa. Estes variaram entre 20,0% a 38,9% (P e P+leguminosa, no sistema mandioca+fruteiras&amp;lt;anuais+fruteiras&amp;lt; maracujá+fruteiras); entre 21,2% a 21,9% (P+leguminosa e P, no sistema mandioca+fruteiras e anuais+fruteiras &amp;lt; anuais+fruteiras e maracujá+fruteiras &amp;lt;mandioca+fruteiras e maracujá+fruteiras). Dessa forma, comparando-se os dados das duas áreas, verifica-se que as maiores similaridades ocorreram nos três sistemas maracujá+fruteiras com NPK+MO, mandioca+fruteiras com NPK+MO e anuais+fruteiras com NPK+MO, cada um com o seu tratamento correspondente na outra área, cujos coeficientes foram de 46,3%, 44,0% e 42,1%, respectivamente. </p>
+		 
+		<p>
+			O índice de similaridade medido pelo número de espécies comuns nas diferentes áreas mostram a intensificação do uso das áreas, indicando o tipo de manejo do solo pelo tipo de comunidades de invasoras ocorrentes. Odum 
+			<italic>et al.</italic>
+			 (1994), comparando a vegetação entre áreas de cultivo e áreas mais antigas, mostraram a grande diferença existente entre as áreas; obtiveram coeficientes de similaridade entre 1-18%. Os mesmos autores mostraram que as seis espécies mais dominantes nas áreas antigas não foram encontradas nas de cultivo, enquanto que invasoras de cultivo foram encontradas apenas esparsamente nas áreas antigas. Notaram também, que as maiores semelhanças foram entre as áreas de plantio direto e as antigas adubadas (18%), concluindo que as invasoras prejudiciais à agricultura são realmente aquelas que se adaptam aos fertilizantes, desenvolvem resistência ao herbicida e geralmente não ocorrem nos ecossistemas naturais. Carvalho &amp; Pitelli (1992) mostraram que os coeficientes de similaridade não estão relacionados aos solos ou distância entre as áreas, mas podem estar mais ligados às formas de manejo dadas às diferentes áreas. 
+		</p>
+		 
+		<p>Sousa (1995) mostrou que as comunidades de plantas invasoras em áreas de pastagem foram diferentes das ocorrentes nos sistemas agroflorestais. Nesses, a similaridade entre as comunidades de plantas invasoras que ocorreram no estrato inferior dos diferentes sistemas agroflorestais foram semelhantes em 50 a mais de 60%. Isso indica, também, que o manejo dado ao solo é fator importante no aparecimento das comunidades de invasoras. </p>
+		 
+		<p>
+			Os resultados do presente trabalho mostraram os maiores coeficientes de similaridade nas áreas onde os sistemas de manejo do solo foram mais semelhantes, principalmente nos locais em que o tratamento NPK+MO foi utilizado (
+			<xref>Tabela 5</xref>
+			). Assim, o manejo contínuo do solo alterou as comunidades de plantas invasoras nas áreas do estudo, quando comparadas com as áreas originais utilizadas anteriormente. 
+		</p>
+		 
+		<p>
+			<bold>CONCLUSÕES</bold>
+			 
+		</p>
+		 
+		<p>A diversificação nas áreas de cultivo, aliada às práticas de manejo do solo, influencia na vegetação invasora dos cultivos, alterando as comunidades de plantas invasoras. </p>
+		 
+		<p>Nas duas áreas estudadas, as espécies da família Poaceae são mais eficientes na exploração do solo de baixa fertilidade, necessitando de manejo mais intensivo para seu controle. </p>
+		 
+		<p>As práticas agrícolas e os sistemas de manejo do solo e das culturas afetam a composição florística e o tamanho das comunidades de plantas invasoras em cada local. </p>
+		 
+		<p>O número de plantas monocotiledôneas foi menor no tratamento com adubação completa (NPK+MO), enquanto o número de dicotiledôneas foi 74% maior neste tratamento. </p>
+		 
+		<p>
+			As espécies com maiores médias de densidades por m
+			<sup>2</sup>
+			 foram 
+			<italic>Paspalum conjugatum</italic>
+			 e 
+			<italic>Ageratum conyzoides</italic>
+			 na área A. Na área B, as espécies com maiores densidades foram 
+			<italic>Homolepis aturensis </italic>
+			e 
+			<italic>Ageratum conyzoides</italic>
+			. 
+		</p>
+		 
+		<p>Os maiores coeficientes de similaridade obtidos nas duas áreas mostram que o manejo contínuo do solo altera fortemente as comunidades de plantas invasoras nas áreas, sendo atualmente bem diferentes das áreas originais, e mais representativo na presença de MO. </p>
+		 
+		<p>
+			<bold>BIBLIOGRAFIA CITADA </bold>
+			 
+		</p>
+		 
+		<p>
+			Akobundu, I.O. 1987. Weed science in integrated pest management. 
+			<italic>In</italic>
+			: Klingman, G.C.; Noordhoff, F.M. (Eds). 
+			<italic>Weed science in the tropics. Principles and practices.</italic>
+			 New York: John Willey. p.1-22. 
+		</p>
+		 
+		<p>
+			Albuquerque, J.M. 1980. Identificação de plantas invasoras de cultura na região de Manaus. 
+			<italic>Acta Amazonica, </italic>
+			10(1): 47-95. 
+		</p>
+		 
+		<p>
+			Alcântara, E.N.; Carvalho, D.A. 1983. Plantas daninhas em mandiocais (
+			<italic>Manihot esculenta</italic>
+			 Crantz) na região mineradora de Diamantina (Alto Jequitinhonha), Minas Gerais. 
+			<italic>Planta Daninha,</italic>
+			 6(2): 138-143. 
+		</p>
+		 
+		<p>
+			Almeida, F.S. 1988. 
+			<italic>A alelopatia e as plantas</italic>
+			. IAPAR Circular, 53. Londrina, 60 p. 
+		</p>
+		 
+		<p>
+			Brasil. 1978. 
+			<italic>Projeto RADAMBRASIL</italic>
+			. 
+			<italic>Folha SA. 20 Manaus: geologia, geomorfologia, pedologia, vegetação e uso potencial da terra</italic>
+			. Departamento Nacional de Produção Mineral, Rio de Janeiro, (Levantamento de Recursos Naturais, 18), 628 p. 
+		</p>
+		 
+		<p>
+			Carsky, R.J; Tarawall, S.A.; Becker, M.; Chikoye, D.; Tian, G.; Sanginga, N. 1998. 
+			<italic>Mucuna- herbaceous cover legume with potential for multiple uses. </italic>
+			Ibadan: International Institute of Tropical Agriculture. Monograph 25. 52.p 
+		</p>
+		<p>
+			Carvalho, S.L.; Pitelli, R.A. 1992. Comportamento e análise fitossociológica das principais espécies de plantas daninhas de pastagens da região de Selvia (MS). 
+			<italic>Planta Daninha,</italic>
+			 10(1-2): 25-32. 
+		</p>
+		 
+		<p>
+			CPRM. 1998. - Serviço Geológico do Brasil. Superintendência Regional de Manaus. 
+			<italic>Potencial turístico do município de Presidente Figueiredo</italic>
+			. 
+			<italic>Programa de Integração Mineral em municípios da Amazônia - Primaz de Presidente Figueiredo</italic>
+			. Companhia de Pesquisa de Recursos Minerais, Manaus, Amazonas. 63 p. 
+		</p>
+		 
+		<p>
+			Dekker, J. 1997. Weed diversity and weed management. Symposium: Importance of weed biology to weed management. Weed Science Society of America, Norfolk, Virginia, 
+			<italic>Weed Science,</italic>
+			 45: 357-363. 
+		</p>
+		 
+		<p>
+			Derksen, D.A.; Lafond, G.P.; Thomas, A.G.; Loeppky, H.A.; Swanton, C.J. 1993. Impact of agronomic practices on weed communities: Tillage systems. 
+			<italic>Weed Science,</italic>
+			 41(3): 409-17 
+		</p>
+		<p>
+			Dias Filho, M.B. 1990. 
+			<italic>Plantas invasoras em pastagens cultivadas da Amazônia: estratégias de manejo e controle</italic>
+			. EMBRAPA-CPATU. Documentos, 52. 103 p. 
+		</p>
+		 
+		<p>
+			Domingues, E.P.; Velline, R.A.; Pitelli, R.A.; Pacheco, P.A.C. 1982. Efeito do matocompetição sobre a produtividade da cultura do arroz de sequeiro 
+			<italic>(Oriza sativa L.)</italic>
+			; em diferentes condições de espaçamento e de fertilização nitrogenada em cobertura. 
+			<italic>In: Resumos do 6 Congresso Brasileira de Herbicida e Plantas Daninhas</italic>
+			. ALAM/SBHED, Campinas, 33 p. 
+		</p>
+		 
+		<p>
+			EMBRAPA. 1997. 
+			<italic>Manual de métodos de análise de solo.</italic>
+			 Centro Nacional de Pesquisa de Solos. - 2. ed. rev. atual. - Rio de Janeiro, 1997. 212. (EMBRAP A-CNPS. Documentos; 1). 
+		</p>
+		 
+		<p>
+			EMBRAPA, 1998a. 
+			<italic>Boletim Agrometeo-rológico</italic>
+			. EMBRAPA/CPAA, Manaus. 23 p
+			<italic>. </italic>
+			 
+		</p>
+		 
+		<p>
+			EMBRAPA, 1998b. 
+			<italic>Boletim Agrometeo-rológico</italic>
+			. EMBRAPA/CPAA, Manaus. 19 p 
+			<italic>. </italic>
+			 
+		</p>
+		 
+		<p>
+			ICOTI. 1992
+			<italic>.</italic>
+			 Instituto de Cooperação Técnica Intermunicipal. 
+			<italic>Informações básicas do município de Presidente Figueiredo</italic>
+			. ICOTI, Manaus, 58 p. 
+		</p>
+		 
+		<p>
+			IPEAAOC. 1971. Instituto de Pesquisa Agropecuária da Amazônia Ocidental. Convênio para levantamento da área do distrito Agropecuário da SUFRAMA, IPEAN e IPEAAOc
+			<italic>. Solos do Distrito Agropecuário da SUFRAMA</italic>
+			. IPEAAOc, Manaus, 99 p. 
+		</p>
+		 
+		<p>
+			IPEAAOC. 1972. Instituto de Pesquisa Agropecuária da Amazônia Ocidental. Levantamento detalhado dos solos do IPEAAOc. 
+			<italic>Boletim Técnico,</italic>
+			 3. IPEAAOc, Manaus, 63 p. 
+		</p>
+		 
+		<p>
+			Kellman, M. 1980. Geographic patterning. 
+			<italic>In: </italic>
+			Tropical weed communities and early secondary succession. 
+			<italic>Biotropica, </italic>
+			12: 34-39. (supl. 
+		</p>
+		 
+		<p>
+			Kissmann, K.G.; Groth, D. 1993.
+			<italic> Plantas infestantes e nocivas</italic>
+			. BASF, São Paulo, Tomo 4, 798 p. 
+		</p>
+		 
+		<p>
+			Klinge, H.; Rodrigues, W.A.; Brunig, E.F.; Fittkau, E.J. 1975. Biomass and structure in a Central Amazonian rain forest.
+			<italic> In</italic>
+			: Golley, F.F.; Medina, E. (Eds). 
+			<italic>Tropical Ecological Systems 11. Trends in Terrestrial and Aquatic Ecology.</italic>
+			 New York, Springer-Verlag Berlin. p.115-122. 
+		</p>
+		 
+		<p>
+			Le Bourgeois, T. Merlier, H. 1995. 
+			<italic>Adventrop. Les adventices d&amp;#x27;Afrique soudane-sahélienne</italic>
+			. Montpellier, France, Cirad - CA (ed.), 640 p. 
+		</p>
+		 
+		<p>
+			Leitão Filho, H.F.; Aranha, C.; Bacchi, O. 1972. 
+			<italic>Plantas invasoras de culturas</italic>
+			. Vol. 1. 
+		</p>
+		 
+		<p>
+			Lisboa, G. Vinha, S.G. 1982. Plantas indesejáveis em cacauais de idades diferentes na área do Centro de Pesquisas do Cacau (CEPEC), 
+			<italic>Revista Theobroma</italic>
+			, 12(3): 135-140. 
+		</p>
+		 
+		<p>
+			Lorenzi, H. 1980. Plantas daninhas na cultura do milho. 
+			<italic>Divulgação Agronômica Shell,</italic>
+			 São Paulo, 47: 1-9. 
+		</p>
+		 
+		<p>
+			Lorenzi, H. 1994. 
+			<italic>Manual de identificação e controle de plantas daninhas, plantio direto e convencional</italic>
+			 4.ed. Nova Odessa: Plantarum. 299 p. 
+		</p>
+		 
+		<p>
+			Martins, D.; Pitelli, R.A. 1994. Influência das plantas daninhas na cultura do amendoim das águas: Efeitos de espaçamentos, variedades e períodos de convivência. 
+			<italic>Planta Daninha,</italic>
+			 12(2): 87-92. 
+		</p>
+		 
+		<p>
+			McCloskey, M.; Firbank, L.G.; Watkinson, A.R.; Webb, D.J. 1996. The dynamics of experimental arable weed communities under different management practices. 
+			<italic>J. Veg. Sci., </italic>
+			7: 799-808. 
+		</p>
+		 
+		<p>
+			Mori, S.A.; Silva, A.A.M.; Lisboa, G.; Pereira, R.C.; Santos, T.S. 1980. Subsídios para estudos de plantas invasoras no sul da Bahia. I. Produtividade e Fenologia. 
+			<italic>Boletim Técnico 73</italic>
+			. Ilhéus, Comissão Executiva do Plano da Lavoura Cacaueira, 1980. 18 p. 
+		</p>
+		 
+		<p>
+			Nee, M. 1995. 
+			<italic>Flora Preliminar do Projeto Dinâmica Biológica de Fragmentos Florestais (PDBFF). </italic>
+			New York Botanical Garden; INPA/Smithsonian, Manaus, 264 p. 
+		</p>
+		 
+		<p>
+			Odum, E.P.; Park, T.Y.; Hutcheson, K. 1994. Comparison of the weedy vegetation in old-fields and crop fields on the same site reveals that fallowing crop fields does not result in seedbank buildup of agricultural weeds. 
+			<italic>Agriculture, Ecosystems and Environment,</italic>
+			 49: 247-252. 
+		</p>
+		 
+		<p>
+			Pimentel Gomes F. 1982. 
+			<italic>Curso de estatística experimental</italic>
+			. 10.ed. Piracicaba:ESAL Q. 430 p. 
+		</p>
+		 
+		<p>
+			Pleasant, J.Mt.; McCollum, R.E.; Coble, H.D. 1990. Weed population Dynamics and Weed Control in the Peruvian Amazon. 
+			<italic>Agronomy Journal,</italic>
+			 82:102-112. 
+		</p>
+		 
+		<p>
+			Primavesi, A. 1992a. 
+			<italic>Agricultura sustentável</italic>
+			. São Paulo, Nobel, 141 p. 
+		</p>
+		 
+		<p>
+			Primavesi, A. 1992b. 
+			<italic>Manejo ecológico de pastagens</italic>
+			. São Paulo, Nobel, 95 p. 
+		</p>
+		 
+		<p>
+			Saavedra, M.S. 1994. Dinamica y manejo de poblaciones de malas hierbas. 
+			<italic>Planta Daninha</italic>
+			, 2(1): 29-38. 
+		</p>
+		 
+		<p>
+			Schulz, B.; Becker, B.; Götsch, E. 1994. Indigenous knowledge in a &amp;#x27; modern&amp;#x27; sustainable agroforestry system - a case study from eastern Brazil. 
+			<italic>Agroforestry Systems,</italic>
+			 25: 59-69. 
+		</p>
+		 
+		<p>
+			Silva, M.F.; Lisbôa, P.L.B.; Lisbôa, R.C.L.1977. 
+			<italic>Nome vulgares de plantas amazônicas</italic>
+			. Belém, INPA, 222 p. 
+		</p>
+		 
+		<p>
+			Silva, L.A.M.; Vinha, S.G.; Pereira, R.C. 1988. Gramíneas invasoras de cacauais. 
+			<italic>Boletim Técnico </italic>
+			159. Ilheus, Comissão Executiva do Plano da Lavoura Cacaueira, 1970. 108 p. 
+		</p>
+		 
+		<p>
+			Silva, J.F. 1999. 
+			<italic>Influência de herbicidas no crescimento e anatomia da epiderme foliar de plantas de cupuaçu (Theobroma grandiflorum</italic>
+			 (Willdenow ex Spreng) Schumann)
+			<italic> e leguminosas em consorciação.</italic>
+			 Tese de Doutorado, Instituto Nacional de Pesquisa da Amazônia/Fundação Universidade do Amazonas. Manaus, Amazonas. 171p. 
+		</p>
+		 
+		<p>
+			Sorensen, T. 1948. A method of establishing groups of equal amplitude in plant society based on similarity of species content. 
+			<italic>In: </italic>
+			Odum, E.P. (Ed). 
+			<italic>Ecologia.</italic>
+			 3a ed., México, Interamericana. 1972. 640 p. 
+		</p>
+		 
+		<p>
+			Sousa, S.G.A. 1995. 
+			<italic>Dinâmica de plantas invasoras em sistemas agroflorestais implantados em pastagens degradadas da Amazônia Central. (Região de Manaus-AM).</italic>
+			 Dissertação de Mestrado, Escola Superior de Agricultura &quot;Luiz de Queiroz&quot; (ESALQ), Universidade de São Paulo. Piracicaba, São Paulo. 97p. 
+		</p>
+		 
+		<p>
+			Souza Filho, A.P.S. 1995
+			<italic>. Potencialidades alelopáticas envolvendo gramíneas e leguminosas forrageiras e plantas invasoras de pastagens.</italic>
+			 Dissertação de Mestrado, Faculdade de Ciências Agrárias e Veterinárias, Universidade Estadual Paulista, Campus de Jaboticabal. Jaboticabal. São Paulo. 137p. 
+		</p>
+		 
+		<p>
+			Souza Filho, A.P.S.; Rodrigues, L.R.A.; Rodrigues, T.J.D. 1997. Efeito do potencial alelopático de três leguminosas forrageiras sobre três invasoras de pastagens. 
+			<italic>Pesquisa Agropecuária Brasileira,</italic>
+			 32(2): 165-170. 
+		</p>
+		 
+		<p>
+			Souza, G.F.; Silva, J.F.; Figueiredo, A.F.. 1998. Levantamento de plantas daninhas em áreas com e sem cultivos, em Manaus-AM. 
+			<italic>Revista da Universidade do Amazonas</italic>
+			. Série: Ciências Agrárias, 7(1-2): 33-43. 
+		</p>
+		 
+		<p>
+			Stevensen, E.C.; Légère, A.; Simard, R.R.; Anger, D.A.; Pageau, D.; Lafond, J. 1997. Weed species diversity in spring barley varies with crop rotation and tillage, but not with nutrient source
+			<italic>. Weed Science</italic>
+			, 45: 798-806. 
+		</p>
+		 
+		<p>
+			SUDAM. 1984. 
+			<italic>Atlas Climatológico da Amazônia Brasileira.</italic>
+			 Projeto de Hidrologia e Climatologia da Amazônia. Superintendência de Desenvolvimento da Amazônia, (Public. n
+			<sup>0</sup>
+			 39), Belém, 125 p. 
+		</p>
+		 
+		<p>
+			Valenzuela, J.A.D. 1990. 
+			<italic>Leguminosas de cobertura em cacau (Theobroma cacao L.) y pejibaye (Bactris gasipaes H. B. K.).</italic>
+			 Tese de Mestrado em Fitoprotection, Centro Agronomico Tropical de Investigación y Enseñanza (CATIE). Turrialba, Costa Rica. 85p. 
+		</p>
+		 
+		<p>
+			Vangessel, M.J.; Schweizer, E.E.; Garrett, K.A.; Westra, P. 1995. Influence of weed density and distribution on corn (
+			<italic>Zea mays</italic>
+			) yield. 
+			<italic>Weed Science</italic>
+			, 43: 215-218. 
+		</p>
+		 
+		<p>
+			Yamoah, C.F.; Agboola, A.A.; Mulongoy, K. 1986. Decomposition, nitrogen release and weed control by prunings of selected alley cropping shrubs. 
+			<italic>Agroforestry Systems, </italic>
+			4: 239-246. 
+		</p>
+		 
+		<p>
+			Vinha, S.G.; Pereira, R.C.; Muller, M.W. 1982. Efeito do controle de plantas invasoras sobre uma vegetação na área do CEPEC. 
+			<italic>Revista Theobroma</italic>
+			, 12(3): 123-134. 
+		</p>
+		 
+		<p>Recebido: 06/07/2002 </p>
+		<p> Aceito: 10/03/2003 </p>
+		<p/>
+		 
+		<p>
+			<xref>1</xref>
+			 Parte da Tese de Doutorado submetida, pela autora, ao Instituto Nacional de Pesquisas da Amazônia - INPA.
+		</p>
+	</body>
+	
+ 
+	<back>
+		
+ 
+		<ref-list>
+			
+ 
+			<ref id="B1">
+				
+ 
+				<mixed-citation>
+					Akobundu, I.O. 1987. Weed science in integrated pest management. 
+					<italic>In</italic>
+					: Klingman, G.C.; Noordhoff, F.M. (Eds). 
+					<italic>Weed science in the tropics. Principles and practices.</italic>
+					 New York: John Willey. p.1-22.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Weed science in the tropics: Principles and practices</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1987</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>1</fpage>
+					
+ 
+					<lpage>22</lpage>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Akobundu</surname>
+							
+ 
+							<given-names>I.O.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Klingman</surname>
+							
+ 
+							<given-names>G.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Noordhoff</surname>
+							
+ 
+							<given-names>F.M.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B2">
+				
+ 
+				<mixed-citation>
+					Albuquerque, J.M. 1980. Identificação de plantas invasoras de cultura na região de Manaus. 
+					<italic>Acta Amazonica, </italic>
+					10(1): 47-95.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Identificação de plantas invasoras de cultura na região de Manaus</article-title>
+					
+ 
+					<source>Acta Amazonica,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1980</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>47</fpage>
+					
+ 
+					<lpage>95</lpage>
+					
+ 
+					<issue>1</issue>
+					
+ 
+					<volume>10</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Albuquerque</surname>
+							
+ 
+							<given-names>J.M.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B3">
+				
+ 
+				<mixed-citation>
+					Alcântara, E.N.; Carvalho, D.A. 1983. Plantas daninhas em mandiocais (
+					<italic>Manihot esculenta</italic>
+					 Crantz) na região mineradora de Diamantina (Alto Jequitinhonha), Minas Gerais. 
+					<italic>Planta Daninha,</italic>
+					 6(2): 138-143.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Plantas daninhas em mandiocais (Manihot esculenta Crantz) na região mineradora de Diamantina (Alto Jequitinhonha), Minas Gerais</article-title>
+					
+ 
+					<source>Planta Daninha,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1983</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>138</fpage>
+					
+ 
+					<lpage>143</lpage>
+					
+ 
+					<issue>2</issue>
+					
+ 
+					<volume>6</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Alcântara</surname>
+							
+ 
+							<given-names>E.N.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Carvalho</surname>
+							
+ 
+							<given-names>D.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B4">
+				
+ 
+				<mixed-citation>
+					Almeida, F.S. 1988. 
+					<italic>A alelopatia e as plantas</italic>
+					. IAPAR Circular, 53. Londrina, 60 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>A alelopatia e as plantas</article-title>
+					
+ 
+					<source>IAPAR Circular</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1988</year>
+						
+ 
+					</date>
+					
+ 
+					<volume>53</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Almeida</surname>
+							
+ 
+							<given-names>F.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B5">
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Projeto RADAMBRASIL. Folha SA. 20 Manaus: geologia, geomorfologia, pedologia, vegetação e uso potencial da terra</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1978</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B6">
+				
+ 
+				<mixed-citation>
+					Carsky, R.J; Tarawall, S.A.; Becker, M.; Chikoye, D.; Tian, G.; Sanginga, N. 1998. 
+					<italic>Mucuna- herbaceous cover legume with potential for multiple uses. </italic>
+					Ibadan: International Institute of Tropical Agriculture. Monograph 25. 52.p 
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Mucuna- herbaceous cover legume with potential for multiple uses</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1998</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Carsky</surname>
+							
+ 
+							<given-names>R.J</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Tarawall</surname>
+							
+ 
+							<given-names>S.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Becker</surname>
+							
+ 
+							<given-names>M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Chikoye</surname>
+							
+ 
+							<given-names>D.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Tian</surname>
+							
+ 
+							<given-names>G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Sanginga</surname>
+							
+ 
+							<given-names>N.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B7">
+				
+ 
+				<mixed-citation>
+					Carvalho, S.L.; Pitelli, R.A. 1992. Comportamento e análise fitossociológica das principais espécies de plantas daninhas de pastagens da região de Selvia (MS). 
+					<italic>Planta Daninha,</italic>
+					 10(1-2): 25-32.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Comportamento e análise fitossociológica das principais espécies de plantas daninhas de pastagens da região de Selvia (MS)</article-title>
+					
+ 
+					<source>Planta Daninha,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1992</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>25</fpage>
+					
+ 
+					<lpage>32</lpage>
+					
+ 
+					<issue>1-2</issue>
+					
+ 
+					<volume>10</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Carvalho</surname>
+							
+ 
+							<given-names>S.L.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pitelli</surname>
+							
+ 
+							<given-names>R.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B8">
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Potencial turístico do município de Presidente Figueiredo: Programa de Integração Mineral em municípios da Amazônia - Primaz de Presidente Figueiredo</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1998</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B9">
+				
+ 
+				<mixed-citation>
+					Dekker, J. 1997. Weed diversity and weed management. Symposium: Importance of weed biology to weed management. Weed Science Society of America, Norfolk, Virginia, 
+					<italic>Weed Science,</italic>
+					 45: 357-363.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Weed diversity and weed management</article-title>
+					
+ 
+					<source>Weed Science</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1997</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>357</fpage>
+					
+ 
+					<lpage>363</lpage>
+					
+ 
+					<volume>45</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Dekker</surname>
+							
+ 
+							<given-names>J.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B10">
+				
+ 
+				<mixed-citation>
+					Derksen, D.A.; Lafond, G.P.; Thomas, A.G.; Loeppky, H.A.; Swanton, C.J. 1993. Impact of agronomic practices on weed communities: Tillage systems. 
+					<italic>Weed Science,</italic>
+					 41(3): 409-17 
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Impact of agronomic practices on weed communities: Tillage systems</article-title>
+					
+ 
+					<source>Weed Science</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1993</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>409</fpage>
+					
+ 
+					<lpage>17</lpage>
+					
+ 
+					<issue>3</issue>
+					
+ 
+					<volume>41</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Derksen</surname>
+							
+ 
+							<given-names>D.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Lafond</surname>
+							
+ 
+							<given-names>G.P.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Thomas</surname>
+							
+ 
+							<given-names>A.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Loeppky</surname>
+							
+ 
+							<given-names>H.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Swanton</surname>
+							
+ 
+							<given-names>C.J.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B11">
+				
+ 
+				<mixed-citation>
+					Dias Filho, M.B. 1990. 
+					<italic>Plantas invasoras em pastagens cultivadas da Amazônia: estratégias de manejo e controle</italic>
+					. EMBRAPA-CPATU. Documentos, 52. 103 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Plantas invasoras em pastagens cultivadas da Amazônia: estratégias de manejo e controle</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1990</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Dias Filho</surname>
+							
+ 
+							<given-names>M.B.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B12">
+				
+ 
+				<mixed-citation>
+					Domingues, E.P.; Velline, R.A.; Pitelli, R.A.; Pacheco, P.A.C. 1982. Efeito do matocompetição sobre a produtividade da cultura do arroz de sequeiro 
+					<italic>(Oriza sativa L.)</italic>
+					; em diferentes condições de espaçamento e de fertilização nitrogenada em cobertura. 
+					<italic>In: Resumos do 6 Congresso Brasileira de Herbicida e Plantas Daninhas</italic>
+					. ALAM/SBHED, Campinas, 33 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Resumos do 6 Congresso Brasileira de Herbicida e Plantas Daninhas</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1982</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Domingues</surname>
+							
+ 
+							<given-names>E.P.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Velline</surname>
+							
+ 
+							<given-names>R.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pitelli</surname>
+							
+ 
+							<given-names>R.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pacheco</surname>
+							
+ 
+							<given-names>P.A.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B13">
+				
+ 
+				<mixed-citation>
+					EMBRAPA. 1997. 
+					<italic>Manual de métodos de análise de solo.</italic>
+					 Centro Nacional de Pesquisa de Solos. - 2. ed. rev. atual. - Rio de Janeiro, 1997. 212. (EMBRAP A-CNPS. Documentos; 1).
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Manual de métodos de análise de solo</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1997</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B14">
+				
+ 
+				<mixed-citation>
+					EMBRAPA, 1998a. 
+					<italic>Boletim Agrometeo-rológico</italic>
+					. EMBRAPA/CPAA, Manaus. 23 p
+					<italic>.</italic>
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Boletim Agrometeo-rológico</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1998</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B15">
+				
+ 
+				<mixed-citation>
+					EMBRAPA, 1998b. 
+					<italic>Boletim Agrometeo-rológico</italic>
+					. EMBRAPA/CPAA, Manaus. 19 p 
+					<italic>.</italic>
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Boletim Agrometeo-rológico</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1998</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B16">
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Informações básicas do município de Presidente Figueiredo</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1992</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B17">
+				
+ 
+				<mixed-citation>
+					IPEAAOC. 1971. Instituto de Pesquisa Agropecuária da Amazônia Ocidental. Convênio para levantamento da área do distrito Agropecuário da SUFRAMA, IPEAN e IPEAAOc
+					<italic>. Solos do Distrito Agropecuário da SUFRAMA</italic>
+					. IPEAAOc, Manaus, 99 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Solos do Distrito Agropecuário da SUFRAMA</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1971</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B18">
+				
+ 
+				<mixed-citation>
+					IPEAAOC. 1972. Instituto de Pesquisa Agropecuária da Amazônia Ocidental. Levantamento detalhado dos solos do IPEAAOc. 
+					<italic>Boletim Técnico,</italic>
+					 3. IPEAAOc, Manaus, 63 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Boletim Técnico</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1972</year>
+						
+ 
+					</date>
+					
+ 
+					<volume>3</volume>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B19">
+				
+ 
+				<mixed-citation>
+					Kellman, M. 1980. Geographic patterning. 
+					<italic>In: </italic>
+					Tropical weed communities and early secondary succession. 
+					<italic>Biotropica, </italic>
+					12: 34-39. (supl.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Geographic patterning</article-title>
+					
+ 
+					<source>Biotropica</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1980</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>34</fpage>
+					
+ 
+					<lpage>39</lpage>
+					
+ 
+					<volume>12</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Kellman</surname>
+							
+ 
+							<given-names>M.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B20">
+				
+ 
+				<mixed-citation>
+					Kissmann, K.G.; Groth, D. 1993.
+					<italic> Plantas infestantes e nocivas</italic>
+					. BASF, São Paulo, Tomo 4, 798 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Plantas infestantes e nocivas</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1993</year>
+						
+ 
+					</date>
+					
+ 
+					<volume>4</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Kissmann</surname>
+							
+ 
+							<given-names>K.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Groth</surname>
+							
+ 
+							<given-names>D.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B21">
+				
+ 
+				<mixed-citation>
+					Klinge, H.; Rodrigues, W.A.; Brunig, E.F.; Fittkau, E.J. 1975. Biomass and structure in a Central Amazonian rain forest.
+					<italic> In</italic>
+					: Golley, F.F.; Medina, E. (Eds). 
+					<italic>Tropical Ecological Systems 11. Trends in Terrestrial and Aquatic Ecology.</italic>
+					 New York, Springer-Verlag Berlin. p.115-122.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Tropical Ecological Systems 11: Trends in Terrestrial and Aquatic Ecology</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1975</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>115</fpage>
+					
+ 
+					<lpage>122</lpage>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Klinge</surname>
+							
+ 
+							<given-names>H.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Rodrigues</surname>
+							
+ 
+							<given-names>W.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Brunig</surname>
+							
+ 
+							<given-names>E.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Fittkau</surname>
+							
+ 
+							<given-names>E.J.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Golley</surname>
+							
+ 
+							<given-names>F.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Medina</surname>
+							
+ 
+							<given-names>E.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B22">
+				
+ 
+				<mixed-citation>
+					Le Bourgeois, T. Merlier, H. 1995. 
+					<italic>Adventrop. Les adventices d'Afrique soudane-sahélienne</italic>
+					. Montpellier, France, Cirad - CA (ed.), 640 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Adventrop: Les adventices d'Afrique soudane-sahélienne</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1995</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Le Bourgeois</surname>
+							
+ 
+							<given-names>T.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Merlier</surname>
+							
+ 
+							<given-names>H.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B23">
+				
+ 
+				<mixed-citation>
+					Leitão Filho, H.F.; Aranha, C.; Bacchi, O. 1972. 
+					<italic>Plantas invasoras de culturas</italic>
+					. Vol. 1.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Plantas invasoras de culturas</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1972</year>
+						
+ 
+					</date>
+					
+ 
+					<volume>1</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Leitão Filho</surname>
+							
+ 
+							<given-names>H.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Aranha</surname>
+							
+ 
+							<given-names>C.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Bacchi</surname>
+							
+ 
+							<given-names>O.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B24">
+				
+ 
+				<mixed-citation>
+					Lisboa, G. Vinha, S.G. 1982. Plantas indesejáveis em cacauais de idades diferentes na área do Centro de Pesquisas do Cacau (CEPEC), 
+					<italic>Revista Theobroma</italic>
+					, 12(3): 135-140.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Plantas indesejáveis em cacauais de idades diferentes na área do Centro de Pesquisas do Cacau (CEPEC)</article-title>
+					
+ 
+					<source>Revista Theobroma,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1982</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>135</fpage>
+					
+ 
+					<lpage>140</lpage>
+					
+ 
+					<issue>3</issue>
+					
+ 
+					<volume>12</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Lisboa</surname>
+							
+ 
+							<given-names>G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Vinha</surname>
+							
+ 
+							<given-names>S.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B25">
+				
+ 
+				<mixed-citation>
+					Lorenzi, H. 1980. Plantas daninhas na cultura do milho. 
+					<italic>Divulgação Agronômica Shell,</italic>
+					 São Paulo, 47: 1-9.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Plantas daninhas na cultura do milho</article-title>
+					
+ 
+					<source>Divulgação Agronômica Shell, São Paulo,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1980</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>1</fpage>
+					
+ 
+					<lpage>9</lpage>
+					
+ 
+					<volume>47</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Lorenzi</surname>
+							
+ 
+							<given-names>H.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B26">
+				
+ 
+				<mixed-citation>
+					Lorenzi, H. 1994. 
+					<italic>Manual de identificação e controle de plantas daninhas, plantio direto e convencional</italic>
+					 4.ed. Nova Odessa: Plantarum. 299 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Manual de identificação e controle de plantas daninhas, plantio direto e convencional</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1994</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Lorenzi</surname>
+							
+ 
+							<given-names>H.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B27">
+				
+ 
+				<mixed-citation>
+					Martins, D.; Pitelli, R.A. 1994. Influência das plantas daninhas na cultura do amendoim das águas: Efeitos de espaçamentos, variedades e períodos de convivência. 
+					<italic>Planta Daninha,</italic>
+					 12(2): 87-92.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Influência das plantas daninhas na cultura do amendoim das águas: Efeitos de espaçamentos, variedades e períodos de convivência</article-title>
+					
+ 
+					<source>Planta Daninha,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1994</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>87</fpage>
+					
+ 
+					<lpage>92</lpage>
+					
+ 
+					<issue>2</issue>
+					
+ 
+					<volume>12</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Martins</surname>
+							
+ 
+							<given-names>D.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pitelli</surname>
+							
+ 
+							<given-names>R.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B28">
+				
+ 
+				<mixed-citation>
+					McCloskey, M.; Firbank, L.G.; Watkinson, A.R.; Webb, D.J. 1996. The dynamics of experimental arable weed communities under different management practices. 
+					<italic>J. Veg. Sci., </italic>
+					7: 799-808.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>The dynamics of experimental arable weed communities under different management practices</article-title>
+					
+ 
+					<source>J. Veg. Sci.,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1996</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>799</fpage>
+					
+ 
+					<lpage>808</lpage>
+					
+ 
+					<volume>7</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>McCloskey</surname>
+							
+ 
+							<given-names>M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Firbank</surname>
+							
+ 
+							<given-names>L.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Watkinson</surname>
+							
+ 
+							<given-names>A.R.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Webb</surname>
+							
+ 
+							<given-names>D.J.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B29">
+				
+ 
+				<mixed-citation>
+					Mori, S.A.; Silva, A.A.M.; Lisboa, G.; Pereira, R.C.; Santos, T.S. 1980. Subsídios para estudos de plantas invasoras no sul da Bahia. I. Produtividade e Fenologia. 
+					<italic>Boletim Técnico 73</italic>
+					. Ilhéus, Comissão Executiva do Plano da Lavoura Cacaueira, 1980. 18 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Subsídios para estudos de plantas invasoras no sul da Bahia. I.: Produtividade e Fenologia</article-title>
+					
+ 
+					<source>Boletim Técnico</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1980</year>
+						
+ 
+					</date>
+					
+ 
+					<volume>73</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Mori</surname>
+							
+ 
+							<given-names>S.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Silva</surname>
+							
+ 
+							<given-names>A.A.M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Lisboa</surname>
+							
+ 
+							<given-names>G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pereira</surname>
+							
+ 
+							<given-names>R.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Santos</surname>
+							
+ 
+							<given-names>T.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B30">
+				
+ 
+				<mixed-citation>
+					Nee, M. 1995. 
+					<italic>Flora Preliminar do Projeto Dinâmica Biológica de Fragmentos Florestais (PDBFF). </italic>
+					New York Botanical Garden; INPA/Smithsonian, Manaus, 264 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Flora Preliminar do Projeto Dinâmica Biológica de Fragmentos Florestais (PDBFF)</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1995</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Nee</surname>
+							
+ 
+							<given-names>M.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B31">
+				
+ 
+				<mixed-citation>
+					Odum, E.P.; Park, T.Y.; Hutcheson, K. 1994. Comparison of the weedy vegetation in old-fields and crop fields on the same site reveals that fallowing crop fields does not result in seedbank buildup of agricultural weeds. 
+					<italic>Agriculture, Ecosystems and Environment,</italic>
+					 49: 247-252.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Comparison of the weedy vegetation in old-fields and crop fields on the same site reveals that fallowing crop fields does not result in seedbank buildup of agricultural weeds</article-title>
+					
+ 
+					<source>Agriculture, Ecosystems and Environment,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1994</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>247</fpage>
+					
+ 
+					<lpage>252</lpage>
+					
+ 
+					<volume>49</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Odum</surname>
+							
+ 
+							<given-names>E.P.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Park</surname>
+							
+ 
+							<given-names>T.Y.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Hutcheson</surname>
+							
+ 
+							<given-names>K.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B32">
+				
+ 
+				<mixed-citation>
+					Pimentel Gomes F. 1982. 
+					<italic>Curso de estatística experimental</italic>
+					. 10.ed. Piracicaba:ESAL Q. 430 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Curso de estatística experimental</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1982</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Pimentel Gomes</surname>
+							
+ 
+							<given-names>F.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B33">
+				
+ 
+				<mixed-citation>
+					Pleasant, J.Mt.; McCollum, R.E.; Coble, H.D. 1990. Weed population Dynamics and Weed Control in the Peruvian Amazon. 
+					<italic>Agronomy Journal,</italic>
+					 82:102-112.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Weed population Dynamics and Weed Control in the Peruvian Amazon</article-title>
+					
+ 
+					<source>Agronomy Journal,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1990</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>102</fpage>
+					
+ 
+					<lpage>112</lpage>
+					
+ 
+					<volume>82</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Pleasant</surname>
+							
+ 
+							<given-names>J.Mt.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>McCollum</surname>
+							
+ 
+							<given-names>R.E.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Coble</surname>
+							
+ 
+							<given-names>H.D.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B34">
+				
+ 
+				<mixed-citation>
+					Primavesi, A. 1992a. 
+					<italic>Agricultura sustentável</italic>
+					. São Paulo, Nobel, 141 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Agricultura sustentável</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1992</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Primavesi</surname>
+							
+ 
+							<given-names>A.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B35">
+				
+ 
+				<mixed-citation>
+					Primavesi, A. 1992b. 
+					<italic>Manejo ecológico de pastagens</italic>
+					. São Paulo, Nobel, 95 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Manejo ecológico de pastagens</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1992</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Primavesi</surname>
+							
+ 
+							<given-names>A.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B36">
+				
+ 
+				<mixed-citation>
+					Saavedra, M.S. 1994. Dinamica y manejo de poblaciones de malas hierbas. 
+					<italic>Planta Daninha</italic>
+					, 2(1): 29-38.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Dinamica y manejo de poblaciones de malas hierbas</article-title>
+					
+ 
+					<source>Planta Daninha,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1994</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>29</fpage>
+					
+ 
+					<lpage>38</lpage>
+					
+ 
+					<issue>1</issue>
+					
+ 
+					<volume>2</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Saavedra</surname>
+							
+ 
+							<given-names>M.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B37">
+				
+ 
+				<mixed-citation>
+					Schulz, B.; Becker, B.; Götsch, E. 1994. Indigenous knowledge in a ' modern' sustainable agroforestry system - a case study from eastern Brazil. 
+					<italic>Agroforestry Systems,</italic>
+					 25: 59-69.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Indigenous knowledge in a ' modern' sustainable agroforestry system - a case study from eastern Brazil</article-title>
+					
+ 
+					<source>Agroforestry Systems,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1994</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>59</fpage>
+					
+ 
+					<lpage>69</lpage>
+					
+ 
+					<volume>25</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Schulz</surname>
+							
+ 
+							<given-names>B.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Becker</surname>
+							
+ 
+							<given-names>B.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Götsch</surname>
+							
+ 
+							<given-names>E.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B38">
+				
+ 
+				<mixed-citation>
+					Silva, M.F.; Lisbôa, P.L.B.; Lisbôa, R.C.L.1977. 
+					<italic>Nome vulgares de plantas amazônicas</italic>
+					. Belém, INPA, 222 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Nome vulgares de plantas amazônicas</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1977</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Silva</surname>
+							
+ 
+							<given-names>M.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Lisbôa</surname>
+							
+ 
+							<given-names>P.L.B.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Lisbôa</surname>
+							
+ 
+							<given-names>R.C.L.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B39">
+				
+ 
+				<mixed-citation>
+					Silva, L.A.M.; Vinha, S.G.; Pereira, R.C. 1988. Gramíneas invasoras de cacauais. 
+					<italic>Boletim Técnico </italic>
+					159. Ilheus, Comissão Executiva do Plano da Lavoura Cacaueira, 1970. 108 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Gramíneas invasoras de cacauais</article-title>
+					
+ 
+					<source>Boletim Técnico</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1988</year>
+						
+ 
+					</date>
+					
+ 
+					<volume>159</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Silva</surname>
+							
+ 
+							<given-names>L.A.M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Vinha</surname>
+							
+ 
+							<given-names>S.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pereira</surname>
+							
+ 
+							<given-names>R.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B40">
+				
+ 
+				<mixed-citation>
+					Silva, J.F. 1999. 
+					<italic>Influência de herbicidas no crescimento e anatomia da epiderme foliar de plantas de cupuaçu (Theobroma grandiflorum</italic>
+					 (Willdenow ex Spreng) Schumann)
+					<italic> e leguminosas em consorciação.</italic>
+					 Tese de Doutorado, Instituto Nacional de Pesquisa da Amazônia/Fundação Universidade do Amazonas. Manaus, Amazonas. 171p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="thesis">
+					
+ 
+					<source>de herbicidas no crescimento e anatomia da epiderme foliar de plantas de cupuaçu (Theobroma grandiflorum (Willdenow ex Spreng) Schumann) e leguminosas em consorciação</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1999</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Silva</surname>
+							
+ 
+							<given-names>J.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B41">
+				
+ 
+				<mixed-citation>
+					Sorensen, T. 1948. A method of establishing groups of equal amplitude in plant society based on similarity of species content. 
+					<italic>In: </italic>
+					Odum, E.P. (Ed). 
+					<italic>Ecologia.</italic>
+					 3Ş ed., México, Interamericana. 1972. 640 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Ecologia</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1948</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Sorensen</surname>
+							
+ 
+							<given-names>T.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Odum</surname>
+							
+ 
+							<given-names>E.P.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B42">
+				
+ 
+				<mixed-citation>
+					Sousa, S.G.A. 1995. 
+					<italic>Dinâmica de plantas invasoras em sistemas agroflorestais implantados em pastagens degradadas da Amazônia Central. (Região de Manaus-AM).</italic>
+					 Dissertação de Mestrado, Escola Superior de Agricultura &quot;Luiz de Queiroz&quot; (ESALQ), Universidade de São Paulo. Piracicaba, São Paulo. 97p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="thesis">
+					
+ 
+					<source>Dinâmica de plantas invasoras em sistemas agroflorestais implantados em pastagens degradadas da Amazônia Central. (Região de Manaus-AM)</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1995</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Sousa</surname>
+							
+ 
+							<given-names>S.G.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B43">
+				
+ 
+				<mixed-citation>
+					Souza Filho, A.P.S. 1995
+					<italic>. Potencialidades alelopáticas envolvendo gramíneas e leguminosas forrageiras e plantas invasoras de pastagens.</italic>
+					 Dissertação de Mestrado, Faculdade de Ciências Agrárias e Veterinárias, Universidade Estadual Paulista, Campus de Jaboticabal. Jaboticabal. São Paulo. 137p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="thesis">
+					
+ 
+					<source>Potencialidades alelopáticas envolvendo gramíneas e leguminosas forrageiras e plantas invasoras de pastagens</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1995</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Souza Filho</surname>
+							
+ 
+							<given-names>A.P.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B44">
+				
+ 
+				<mixed-citation>
+					Souza Filho, A.P.S.; Rodrigues, L.R.A.; Rodrigues, T.J.D. 1997. Efeito do potencial alelopático de três leguminosas forrageiras sobre três invasoras de pastagens. 
+					<italic>Pesquisa Agropecuária Brasileira,</italic>
+					 32(2): 165-170.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Efeito do potencial alelopático de três leguminosas forrageiras sobre três invasoras de pastagens</article-title>
+					
+ 
+					<source>Pesquisa Agropecuária Brasileira,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1997</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>165</fpage>
+					
+ 
+					<lpage>170</lpage>
+					
+ 
+					<issue>2</issue>
+					
+ 
+					<volume>32</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Souza Filho</surname>
+							
+ 
+							<given-names>A.P.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Rodrigues</surname>
+							
+ 
+							<given-names>L.R.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Rodrigues</surname>
+							
+ 
+							<given-names>T.J.D.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B45">
+				
+ 
+				<mixed-citation>
+					Souza, G.F.; Silva, J.F.; Figueiredo, A.F.. 1998. Levantamento de plantas daninhas em áreas com e sem cultivos, em Manaus-AM. 
+					<italic>Revista da Universidade do Amazonas</italic>
+					. Série: Ciências Agrárias, 7(1-2): 33-43.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Levantamento de plantas daninhas em áreas com e sem cultivos, em Manaus-AM</article-title>
+					
+ 
+					<source>Revista da Universidade do Amazonas</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1998</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>33</fpage>
+					
+ 
+					<lpage>43</lpage>
+					
+ 
+					<issue>1-2</issue>
+					
+ 
+					<volume>7</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Souza</surname>
+							
+ 
+							<given-names>G.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Silva</surname>
+							
+ 
+							<given-names>J.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Figueiredo</surname>
+							
+ 
+							<given-names>A.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B46">
+				
+ 
+				<mixed-citation>
+					Stevensen, E.C.; Légère, A.; Simard, R.R.; Anger, D.A.; Pageau, D.; Lafond, J. 1997. Weed species diversity in spring barley varies with crop rotation and tillage, but not with nutrient source
+					<italic>. Weed Science</italic>
+					, 45: 798-806.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Weed species diversity in spring barley varies with crop rotation and tillage, but not with nutrient source</article-title>
+					
+ 
+					<source>Weed Science,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1997</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>798</fpage>
+					
+ 
+					<lpage>806</lpage>
+					
+ 
+					<volume>45</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Stevensen</surname>
+							
+ 
+							<given-names>E.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Légère</surname>
+							
+ 
+							<given-names>A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Simard</surname>
+							
+ 
+							<given-names>R.R.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Anger</surname>
+							
+ 
+							<given-names>D.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pageau</surname>
+							
+ 
+							<given-names>D.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Lafond</surname>
+							
+ 
+							<given-names>J.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B47">
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Atlas Climatológico da Amazônia Brasileira: Projeto de Hidrologia e Climatologia da Amazônia</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1984</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B48">
+				
+ 
+				<mixed-citation>
+					Valenzuela, J.A.D. 1990. 
+					<italic>Leguminosas de cobertura em cacau (Theobroma cacao L.) y pejibaye (Bactris gasipaes H. B. K.).</italic>
+					 Tese de Mestrado em Fitoprotection, Centro Agronomico Tropical de Investigación y Enseñanza (CATIE). Turrialba, Costa Rica. 85p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="thesis">
+					
+ 
+					<source>Leguminosas de cobertura em cacau (Theobroma cacao L.) y pejibaye (Bactris gasipaes H. B. K.)</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1990</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Valenzuela</surname>
+							
+ 
+							<given-names>J.A.D.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B49">
+				
+ 
+				<mixed-citation>
+					Vangessel, M.J.; Schweizer, E.E.; Garrett, K.A.; Westra, P. 1995. Influence of weed density and distribution on corn (
+					<italic>Zea mays</italic>
+					) yield. 
+					<italic>Weed Science</italic>
+					, 43: 215-218.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Influence of weed density and distribution on corn (Zea mays) yield</article-title>
+					
+ 
+					<source>Weed Science,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1995</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>215</fpage>
+					
+ 
+					<lpage>218</lpage>
+					
+ 
+					<volume>43</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Vangessel</surname>
+							
+ 
+							<given-names>M.J.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Schweizer</surname>
+							
+ 
+							<given-names>E.E.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Garrett</surname>
+							
+ 
+							<given-names>K.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Westra</surname>
+							
+ 
+							<given-names>P.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B50">
+				
+ 
+				<mixed-citation>
+					Yamoah, C.F.; Agboola, A.A.; Mulongoy, K. 1986. Decomposition, nitrogen release and weed control by prunings of selected alley cropping shrubs. 
+					<italic>Agroforestry Systems, </italic>
+					4: 239-246.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Decomposition, nitrogen release and weed control by prunings of selected alley cropping shrubs</article-title>
+					
+ 
+					<source>Agroforestry Systems,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1986</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>239</fpage>
+					
+ 
+					<lpage>246</lpage>
+					
+ 
+					<volume>4</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Yamoah</surname>
+							
+ 
+							<given-names>C.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Agboola</surname>
+							
+ 
+							<given-names>A.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Mulongoy</surname>
+							
+ 
+							<given-names>K.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B51">
+				
+ 
+				<mixed-citation>
+					Vinha, S.G.; Pereira, R.C.; Muller, M.W. 1982. Efeito do controle de plantas invasoras sobre uma vegetação na área do CEPEC. 
+					<italic>Revista Theobroma</italic>
+					, 12(3): 123-134.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Efeito do controle de plantas invasoras sobre uma vegetação na área do CEPEC</article-title>
+					
+ 
+					<source>Revista Theobroma,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1982</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>123</fpage>
+					
+ 
+					<lpage>134</lpage>
+					
+ 
+					<issue>3</issue>
+					
+ 
+					<volume>12</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Vinha</surname>
+							
+ 
+							<given-names>S.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pereira</surname>
+							
+ 
+							<given-names>R.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Muller</surname>
+							
+ 
+							<given-names>M.W.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+		</ref-list>
+		
+ 
+	</back>
+	
+
+</article>

--- a/tests/samples/S0044-59672003000300002_sps_incompleto.xml
+++ b/tests/samples/S0044-59672003000300002_sps_incompleto.xml
@@ -1,0 +1,4669 @@
+<?xml version="1.0" ?>
+<!DOCTYPE article
+  PUBLIC '-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN'
+  'JATS-journalpublishing1.dtd'>
+<article article-type="research-article" dtd-version="1.1" specific-use="sps-1.8" xml:lang="pt" xmlns:xlink="http://www.w3.org/1999/xlink">
+	
+ 
+	<front>
+		
+ 
+		<journal-meta>
+			
+ 
+			<journal-id journal-id-type="publisher-id">aa</journal-id>
+			
+ 
+			<journal-title-group>
+				
+ 
+				<journal-title>Acta Amazonica</journal-title>
+				
+ 
+				<abbrev-journal-title abbrev-type="publisher">Acta Amaz.</abbrev-journal-title>
+				
+ 
+			</journal-title-group>
+			
+ 
+			<issn pub-type="ppub">0044-5967</issn>
+			
+ 
+			<issn pub-type="epub">1809-4392</issn>
+			
+ 
+			<publisher>
+				
+ 
+				<publisher-name>Instituto Nacional de Pesquisas da Amazônia</publisher-name>
+				
+ 
+				<publisher-loc>Manaus, AM, Brazil</publisher-loc>
+				
+ 
+			</publisher>
+			
+ 
+		</journal-meta>
+		
+ 
+		<article-meta>
+			
+ 
+			<article-id pub-id-type="publisher-id">S0044-59672003000300002</article-id>
+			
+ 
+			<article-id pub-id-type="doi">10.1590/S0044-59672003000300002</article-id>
+			
+ 
+			<title-group>
+				
+ 
+				<article-title>Plantas invasoras em sistemas agroflorestais com cupuaçuzeiro no município de Presidente Figueiredo (Amazonas, Brasil)</article-title>
+				
+ 
+				<trans-title-group xml:lang="en">
+					
+ 
+					<trans-title>Weedy plants in agroforestry systems with cupuassu in the municipality of Presidente Figueiredo (Amazonas, Brazil)</trans-title>
+					
+ 
+				</trans-title-group>
+				
+ 
+			</title-group>
+			
+ 
+			<contrib-group>
+				
+ 
+				<contrib contrib-type="author">
+					
+ 
+					<name>
+						
+ 
+						<surname>Sousa</surname>
+						
+ 
+						<given-names>Gladys Ferreira de</given-names>
+						
+ 
+					</name>
+					
+ 
+					<role>ND</role>
+					
+ 
+					<xref ref-type="aff" rid="aff01"/>
+					
+ 
+				</contrib>
+				
+ 
+				<contrib contrib-type="author">
+					
+ 
+					<name>
+						
+ 
+						<surname>Oliveira</surname>
+						
+ 
+						<given-names>Luiz Antonio de</given-names>
+						
+ 
+					</name>
+					
+ 
+					<role>ND</role>
+					
+ 
+					<xref ref-type="aff" rid="aff02"/>
+					
+ 
+				</contrib>
+				
+ 
+				<contrib contrib-type="author">
+					
+ 
+					<name>
+						
+ 
+						<surname>Silva</surname>
+						
+ 
+						<given-names>José Ferreira da</given-names>
+						
+ 
+					</name>
+					
+ 
+					<role>ND</role>
+					
+ 
+					<xref ref-type="aff" rid="aff03"/>
+					
+ 
+				</contrib>
+				
+ 
+			</contrib-group>
+			
+ 
+			<aff id="aff01">
+				
+ 
+				<addr-line>
+					
+ 
+					<named-content content-type="city">Belém</named-content>
+					
+ 
+					<named-content content-type="state"/>
+					
+ 
+				</addr-line>
+				
+ 
+				<institution content-type="orgname">Embrapa</institution>
+				
+ 
+				<country country="BR">Brazil</country>
+				
+ 
+				<email>gladysfs@cpatu.embrapa.br</email>
+				
+ 
+			</aff>
+			
+ 
+			<aff id="aff03">
+				
+ 
+				<addr-line>
+					
+ 
+					<named-content content-type="city">Manaus</named-content>
+					
+ 
+					<named-content content-type="state"/>
+					
+ 
+				</addr-line>
+				
+ 
+				<institution content-type="orgname">Universidade Federal do Amazonas</institution>
+				
+ 
+				<country country="BR">Brazil</country>
+				
+ 
+				<email>jfsilva@ufam.edu.br</email>
+				
+ 
+			</aff>
+			
+ 
+			<aff id="aff02">
+				
+ 
+				<addr-line>
+					
+ 
+					<named-content content-type="city">Manaus</named-content>
+					
+ 
+					<named-content content-type="state"/>
+					
+ 
+				</addr-line>
+				
+ 
+				<institution content-type="orgname">Instituto Nacional de Pesquisas da Amazônia</institution>
+				
+ 
+				<country country="BR">Brazil</country>
+				
+ 
+				<email>luizoli@inpa.gov.br</email>
+				
+ 
+			</aff>
+			
+ 
+			<pub-date pub-type="epub-ppub">
+				
+ 
+				<year>2003</year>
+				
+ 
+			</pub-date>
+			
+ 
+			<volume>33</volume>
+			
+ 
+			<issue>3</issue>
+			
+ 
+			<fpage>353</fpage>
+			
+ 
+			<lpage>370</lpage>
+			
+ 
+			<history>
+				
+ 
+				<date date-type="received">
+					
+ 
+					<day>06</day>
+					
+ 
+					<month>07</month>
+					
+ 
+					<year>2002</year>
+					
+ 
+				</date>
+				
+ 
+				<date date-type="accepted">
+					
+ 
+					<day>10</day>
+					
+ 
+					<month>03</month>
+					
+ 
+					<year>2003</year>
+					
+ 
+				</date>
+				
+ 
+			</history>
+			
+ 
+			<permissions>
+				
+ 
+				<license license-type="open-access" xlink:href="http://creativecommons.org/licenses/by-nc/4.0/" xml:lang="en">
+					
+ 
+					<license-p>This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License.</license-p>
+					
+ 
+				</license>
+				
+ 
+			</permissions>
+			
+ 
+			<abstract>
+				
+ 
+				<p>A infestação crescente de plantas invasoras nos sistemas agrícolas causa prejuízos às lavouras, com decréscimos acentuados da produtividade, quer pela competição direta pelos fatores de produção, quer pelos compostos alelopáticos liberados. Este trabalho consistiu de um levantamento e análise fitossociológica de alguns aspectos de espécies de invasoras que ocorrem em sistemas agroflorestais com cupuaçuzeiro, em três arranjos de culturas (mandioca+fruteiras; anuais+fruteiras; maracujá+fruteiras), sob três sistemas de adubação (NPK+MO, adubação com Fósforo e Fósforo+leguminosa). As coletas das plantas invasoras feitas em seis amostras de 0,25 m² por parcela foram posteriormente levadas ao laboratório para identificação. As 55 espécies identificadas estavam distribuídas em 23 famílias botânicas, sendo 43 espécies de dicotiledôneas (78,2%), 11 de monocotiledôneas (20,0%) e uma de pteridófita (1,8%). As famílias Poaceae (monocotiledônea) e Asteraceae (dicotiledônea) foram as mais freqüentes e com maior número de indivíduos. As espécies mais freqüentes e com maior número de plantas por m² foram Paspalum conjugatum P.J. Bergius (área A) e Homolepis aturensis (Kunth) Chase (área B), ambas da família Poaceae; Ageratum conyzoides L. da família Asteraceae, apresentou a maior densidade. Os coeficientes de similaridade variaram entre as áreas amostradas, sendo os maiores índices observados nos tratamentos que receberam adubação com matéria orgânica, particularmente nos sistemas mandioca+fruteiras. As práticas agrícolas e os sistemas de manejo do solo e das lavouras exerceram influência na composição florística e no tamanho das comunidades de plantas invasoras em cada local. O número de monocotiledôneas foi menor no tratamento com adubação NPK+MO.</p>
+				
+ 
+			</abstract>
+			
+ 
+			<trans-abstract xml:lang="en">
+				
+ 
+				<p>The increase of weed infestation on agricultural systems cause damages to the crops, decreasing plant productivity by the direct competition or by alelopathy. This work have undertaken a survey and phytosociological analysis of some aspects of weed species that occur in agroforestry systems with cupuassu. The treatments consisted of three crops arrangements (cassava+fruit trees; annuals crops+fruit trees; passion fruit+fruit trees), and three fertilizer management (NPK+OM, with Phosphorus and Phosphorus+leguminous). Three harvests of weed plants were accomplished, being six samples of 0,25 m² per plot. The identification of the species of the weed plants were carried out in the laboratory. The 55 weed species identified were distributed in 23 botanical families, being 43 of dicotyledonous species, 11 of monocotyledonous, and one of pteridophyta. The families Poaceae (monocotyledonous) and Asteraceae (dicotyledonous) were the most frequent and with large number of individuals. The most frequent species and with large number of plants per m² were Paspalum conjugatum P.J. Bergius (area A) and Homolepis aturensis (Kunth) Chase (area B) of the Poaceae family; Ageratum conyzoides L. of the Asteraceae family, presented the largest density. The similarity coefficients varied among the areas studied, being the largest indexes observed in the treatments that received fertilizers with organic matter (NPK+OM), particularly in the system cassava+fruit trees. The agricultural practices and the soil and crops management systems, had a great influence to the flora composition and in the weed plants communities size in each local area. The number of monocotyledonous was smaller in the treatment with NPK+OM than in the other treatments.</p>
+				
+ 
+			</trans-abstract>
+			
+ 
+			<kwd-group kwd-group-type="author-generated" xml:lang="en">
+				
+ 
+				<kwd>Theobroma grandiflorum</kwd>
+				
+ 
+				<kwd>weeds</kwd>
+				
+ 
+				<kwd>monocotyledonous</kwd>
+				
+ 
+				<kwd>dicotyledonous</kwd>
+				
+ 
+			</kwd-group>
+			
+ 
+			<kwd-group kwd-group-type="author-generated" xml:lang="pt">
+				
+ 
+				<kwd>Theobroma grandiflorum</kwd>
+				
+ 
+				<kwd>plantas daninhas</kwd>
+				
+ 
+				<kwd>monocotiledôneas</kwd>
+				
+ 
+				<kwd>dicotiledôneas</kwd>
+				
+ 
+			</kwd-group>
+			
+ 
+			<counts>
+				
+ 
+				<fig-count count="0"/>
+				
+ 
+				<table-count count="0"/>
+				
+ 
+				<equation-count count="0"/>
+				
+ 
+				<ref-count count="51"/>
+				
+ 
+				<page-count count="18"/>
+				
+ 
+			</counts>
+			
+ 
+		</article-meta>
+		
+ 
+	</front>
+	
+ 
+	<body>
+		<p>
+			<bold>
+				<sup>
+					<xref>1</xref>
+				</sup>
+			</bold>
+		</p>
+		 
+		<p>
+			<bold>Weedy plants in agroforestry systems with cupuassu in the municipality of Presidente Figueiredo (Amazonas, Brazil)</bold>
+		</p>
+		 
+		<p>
+			<bold>
+				Gladys Ferreira de Sousa
+				<sup>I</sup>
+				; Luiz Antonio de Oliveira
+				<sup>II</sup>
+				; José Ferreira da Silva
+				<sup>III</sup>
+			</bold>
+		</p>
+		 
+		<p>
+			<sup>I</sup>
+			Pesquisadora da Embrapa. Caixa Postal 48 CEP 66 095-100, Belém-PA (
+			<ext-link ext-link-type="email" xlink:href="mailto:gladysfs@cpatu.embrapa.br">gladysfs@cpatu.embrapa.br</ext-link>
+			) 
+		</p>
+		<p>
+			<sup>II</sup>
+			Pesquisador do INPA. Caixa Postal 478 , CEP 69 011- 970, Manaus (AM). (
+			<ext-link ext-link-type="email" xlink:href="mailto:luizoli@inpa.gov.br">luizoli@inpa.gov.br</ext-link>
+			), bolsista do CNPQ 
+		</p>
+		<p>
+			<sup>III</sup>
+			Professor da Universidade Federal do Amazonas. Av. Gal. Rodrigo Otávio, 3000, CEP 69077-000, Manaus (AM) (
+			<ext-link ext-link-type="email" xlink:href="mailto:jfsilva@ufam.edu.br">jfsilva@ufam.edu.br</ext-link>
+			)
+		</p>
+		 
+		<p>
+			<bold>RESUMO </bold>
+		</p>
+		 
+		<p>
+			 A infestação crescente de plantas invasoras nos sistemas agrícolas causa prejuízos às lavouras, com decréscimos acentuados da produtividade, quer pela competição direta pelos fatores de produção, quer pelos compostos alelopáticos liberados. Este trabalho consistiu de um levantamento e análise fitossociológica de alguns aspectos de espécies de invasoras que ocorrem em sistemas agroflorestais com cupuaçuzeiro, em três arranjos de culturas (mandioca+fruteiras; anuais+fruteiras; maracujá+fruteiras), sob três sistemas de adubação (NPK+MO, adubação com Fósforo e Fósforo+leguminosa). As coletas das plantas invasoras feitas em seis amostras de 0,25 m
+			<sup>2</sup>
+			 por parcela foram posteriormente levadas ao laboratório para identificação. As 55 espécies identificadas estavam distribuídas em 23 famílias botânicas, sendo 43 espécies de dicotiledôneas (78,2%), 11 de monocotiledôneas (20,0%) e uma de pteridófita (1,8%). As famílias Poaceae (monocotiledônea) e Asteraceae (dicotiledônea) foram as mais freqüentes e com maior número de indivíduos. As espécies mais freqüentes e com maior número de plantas por m
+			<sup>2</sup>
+			 foram 
+			<italic>Paspalum conjugatum</italic>
+			 P.J. Bergius (área A) e 
+			<italic>Homolepis aturensis </italic>
+			(Kunth) Chase (área B), ambas da família Poaceae; 
+			<italic>Ageratum conyzoides</italic>
+			 L. da família Asteraceae, apresentou a maior densidade. Os coeficientes de similaridade variaram entre as áreas amostradas, sendo os maiores índices observados nos tratamentos que receberam adubação com matéria orgânica, particularmente nos sistemas mandioca+fruteiras. As práticas agrícolas e os sistemas de manejo do solo e das lavouras exerceram influência na composição florística e no tamanho das comunidades de plantas invasoras em cada local. O número de monocotiledôneas foi menor no tratamento com adubação NPK+MO. 
+		</p>
+		 
+		<p>
+			<bold>Palavras-chave: </bold>
+			<italic>Theobroma grandiflorum</italic>
+			, plantas daninhas, monocotiledôneas, dicotiledôneas 
+		</p>
+		 
+		<p>
+			<bold>ABSTRACT </bold>
+		</p>
+		 
+		<p>
+			The increase of weed infestation on agricultural systems cause damages to the crops, decreasing plant productivity by the direct competition or by alelopathy. This work have undertaken a survey and phytosociological analysis of some aspects of weed species that occur in agroforestry systems with cupuassu. The treatments consisted of three crops arrangements (cassava+fruit trees; annuals crops+fruit trees; passion fruit+fruit trees), and three fertilizer management (NPK+OM, with Phosphorus and Phosphorus+leguminous). Three harvests of weed plants were accomplished, being six samples of 0,25 m
+			<sup>2</sup>
+			 per plot. The identification of the species of the weed plants were carried out in the laboratory. The 55 weed species identified were distributed in 23 botanical families, being 43 of dicotyledonous species, 11 of monocotyledonous, and one of pteridophyta. The families Poaceae (monocotyledonous) and Asteraceae (dicotyledonous) were the most frequent and with large number of individuals. The most frequent species and with large number of plants per m
+			<sup>2</sup>
+			 were 
+			<italic>Paspalum conjugatum</italic>
+			 P.J. Bergius (area A) and 
+			<italic>Homolepis aturensis</italic>
+			 (Kunth) Chase (area B) of the Poaceae family; 
+			<italic>Ageratum conyzoides</italic>
+			 L. of the Asteraceae family, presented the largest density. The similarity coefficients varied among the areas studied, being the largest indexes observed in the treatments that received fertilizers with organic matter (NPK+OM), particularly in the system cassava+fruit trees. The agricultural practices and the soil and crops management systems, had a great influence to the flora composition and in the weed plants communities size in each local area. The number of monocotyledonous was smaller in the treatment with NPK+OM than in the other treatments. 
+		</p>
+		 
+		<p>
+			<bold>Key-words: </bold>
+			 
+			<italic>Theobroma grandiflorum</italic>
+			, weeds, monocotyledonous, dicotyledonous 
+		</p>
+		 
+		<p>
+			<bold>INTRODUÇÃO</bold>
+			 
+		</p>
+		 
+		<p>
+			A infestação crescente de plantas invasoras nos sistemas agrícolas causa prejuízos às lavouras, com decréscimos acentuados da produtividade, quer pela competição direta pelos fatores de produção, quer pelos compostos alelopáticos liberados (Akobundu, 1987; Almeida, 1988; Martins &amp;amp; Pitelli, 1994; Saavedra, 1994; Souza Filho 
+			<italic>et al</italic>
+			., 1997; Vangessel 
+			<italic>et al.</italic>
+			, 1995). As comunidades de plantas invasoras geralmente resultam das alterações ecológicas pela ação antrópica. Porém, os danos causados são reduzidos quando manejadas adequadamente (Primavesi, 1992a, b). 
+		</p>
+		 
+		<p>
+			As necessidades de mão de obra para controle das plantas invasoras aumentam com a continuidade dos cultivos, tendo sido estimado em cerca de 30 a 40% dos custos totais de produção em plantios de mandioca (Alcântara &amp;amp; Carvalho, 1983) e na maioria dos cultivos nos trópicos (Yamoah 
+			<italic>et al.</italic>
+			, 1986). 
+		</p>
+		 
+		<p>
+			No Brasil, as plantas invasoras são responsáveis pela redução na produção de milho em cerca de 25 a 30 % e de 50 a 70 % em arroz de sequeiro (Lorenzi, 1980; Domingues 
+			<italic>et al.,</italic>
+			 1982). 
+		</p>
+		 
+		<p>Uma importante razão para o sucesso das invasoras é a sua capacidade de adaptação às condições dos agrossistemas, levando à ocupação e exploração eficiente do ambiente (Dias Filho, 1990). Ao manterem uma alta diversidade de espécies, inclusive dentro da mesma população, elas competem com maior sucesso com outras espécies. A heterogeneidade nas populações permite explorar recursos e adaptar-se à qualquer mudança de práticas culturais ou ambientais, enquanto as plantas cultivadas evoluem para a homogeneidade, visto ser a demanda a produtividade individual (Dekker, 1997). </p>
+		 
+		<p>
+			As práticas culturais e a intensificação dos cultivos provocam desequilíbrio nas populações de invasoras (Derksen 
+			<italic>et al</italic>
+			., 1993). Desse modo, alterações na diversidade de comunidades de plantas invasoras podem estar relacionadas com o histórico de manejo do solo e das culturas (Vinha 
+			<italic>et al.</italic>
+			, 1982; Derksen 
+			<italic>et al</italic>
+			., 1993). Stevensen 
+			<italic>et al</italic>
+			. (1997) observaram efeito significativo da interação rotação x tratos culturais na diversidade de invasoras. Para McCloskey 
+			<italic>et al.</italic>
+			 (1996) os tratos culturais são as práticas mais importantes que afetam a densidade das plantas invasoras. 
+		</p>
+		 
+		<p>
+			Nos sistemas agroflorestais, onde geralmente a área é mais intensamente ocupada por espécies cultivadas, os arranjos de culturas podem exercer um controle mais eficiente das plantas invasoras. Como observado por Sousa (1995), algumas combinações de culturas nos sistemas agroflorestais influenciaram na densidade, freqüência e fitomassa aérea das plantas invasoras, podendo também, minimizar a competição e otimizar a produção das áreas cultivadas (Schulz 
+			<italic>et al.</italic>
+			, 1994). 
+		</p>
+		 
+		<p>O trabalho objetivou identificar a composição florística das comunidades de plantas invasoras em sistemas agroflorestais com cupuaçuzeiro, procurando-se determinar o grau de infestação e distribuição das populações nas diferentes épocas do ano, de acordo com os diferentes arranjos dos componentes do sistema. Procurou-se determinar se diferentes níveis de fertilidade de solo influenciaram na diminuição ou aumento de espécies de monocotiledôneas e dicotiledôneas na área estudada. </p>
+		 
+		<p>
+			<bold>MATERIAL E MÉTODOS</bold>
+		</p>
+		 
+		<p>Área de estudo</p>
+		 
+		<p>
+			O trabalho foi conduzido no período de dezembro de 1996 a dezembro de 1998, em propriedades de pequenos produtores no município de Presidente Figueiredo, Estado do Amazonas, localizado a 107 km da cidade de Manaus. Geograficamente, este município se situa entre as coordenadas cartesianas de latitude sul 2
+			<sup>0</sup>
+			 14' 26&quot; e aproximadamente entre os graus 60
+			<sup>0 </sup>
+			a 61
+			<sup>0</sup>
+			 de longitude W. Gr, numa altitude de 92,9 metros acima do nível do mar. 
+		</p>
+		 
+		<p>
+			O clima da região é quente e úmido, classificado como Ami, segundo Köppen. Caracteriza-se pela temperatura média do mês mais frio nunca inferior a 18oC e a precipitação do mês mais seco, acima de 60 mm. A precipitação pluviométrica média anual é sempre superior a 2000 mm e distribuída em duas estações bem distintas: uma com alta precipitação pluviométrica, que vai de novembro a maio e a outra, de menor precipitação pluviométrica, vai de junho a outubro. O período de maior estiagem ocorre freqüentemente de julho a setembro (SUDAM, 1984; EMBRAPA, 1998a, b). O regime climático observado na época em que o trabalho foi desenvolvido apresentou, respectivamente, um total pluviométrico de 2.585 mm, 2.243 mm e 2.546 mm para os três anos. A temperatura média anual foi de 26,7oC, com a máxima em torno de 31,2
+			<sup>0</sup>
+			C e a mínima em torno de 23,5oC. A umidade relativa do ar é bastante elevada em toda a região, variando entre 71 % a 91 %, com média de cerca de 86 % (SUDAM, 1984; EMBRAPA, 1998a, b). 
+		</p>
+		 
+		<p>A economia do município é calcada nas atividades do setor secundário, com destaque para a mineração, e do setor primário, com o extrativismo (madeira, pedras, minério e pescado) e a agricultura. Esta é baseada no cultivo do arroz, mandioca (basicamente para produção de farinha), cupuaçu, macaxeira, cana-de-açúcar, guaraná e outras frutas como banana, mamão, laranja, etc. A pecuária, constituída pela exploração de bovinos, é também destaque no município (ICOTI, 1992; CPRM, 1998). </p>
+		 
+		<p>As duas propriedades em estudo localizam-se entre os km 13 e 51 na rodovia estadual AM-240, nas comunidades Marcos Freire (km 13) e São Francisco de Assis (km 22), situadas em assentamentos do INCRA. </p>
+		 
+		<p>
+			As principais unidades de solo que predominam na região são o Latossolo Amarelo, textura muito argilosa, distrófico, o Podzólico Vermelho Amarelo, textura média, distrófico e o Podzólico Vermelho Amarelo, textura pesada, distrófico (IPEAAOC, 1971; 1972). O relevo é suavemente ondulado em algumas áreas, existindo outras com relevo ondulado a muito ondulado. Os solos fazem parte do ecossistema de terra firme de formação recente, originados de sedimentos argilosos do Terciário, representados pela série Barreiras (BRASIL, 1978). O solo das áreas selecionadas para estudo é o Latossolo Amarelo, de textura muito pesada, encontrando-se em relevo plano. Amostras de solo das áreas foram coletadas, secadas ao ar, moídas e passadas em peneira de 2 mm para uniformização. A composição química e granulométrica encontra-se na 
+			<xref>Tabela 1</xref>
+			, sendo as determinações efetuadas pelos métodos de análises em uso no laboratório de solos da EMBRAPA Amazônia Ocidental (EMBRAPA, 1997). 
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/inexistente1.gif"/>
+		</p>
+		<p>
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/inexistente2.gif"/>
+		</p>
+		 
+		<p>Por ocasião da implantação dos sistemas, as áreas encontravam-se com vegetação secundária (capoeira) de aproximadamente dois anos, tendo sido realizado um levantamento florístico antes da implantação dos sistemas. </p>
+		 
+		<p>
+			<bold>Sistemas agroflorestais estudados</bold>
+			 
+		</p>
+		 
+		<p>Estudou-se a composição florística e a distribuição das plantas invasoras em três sistemas agroflorestais, os quais haviam sido implantados em 1994 e conduzidos em um projeto participativo entre a EMBRAPA/INPA/UA/IDAM e os pequenos produtores de agricultura itinerante. </p>
+		 
+		<p>
+			Os três sistemas agroflorestais estudados foram constituídos por: 1. Mandioca + fruteiras; 2. Cultivos anuais+fruteiras e 3. Maracujá+fruteiras. Os componentes fruteiras foram cupuaçuzeiro (
+			<italic>Theobroma grandiflorum</italic>
+			 (Willd. ex Spreng.) Schum.), bananeira (
+			<italic>Musa</italic>
+			 spp), pupunheira (
+			<italic>Bactris gasipaes </italic>
+			Kunth
+			<italic>)</italic>
+			 e ingazeiro (
+			<italic>Inga edulis </italic>
+			Mart.). 
+		</p>
+		 
+		<p>
+			<bold>Métodos de estudo</bold>
+			 
+		</p>
+		 
+		<p>
+			Os sistemas foram testados com três tratamentos de manejo de solos: (1) com adubação NPK+Matéria Orgânica (MO), (2) adubação com fósforo e (3) fósforo+leguminosa de cobertura (
+			<italic>Mucuna pruriens </italic>
+			(L.) DC.. 
+		</p>
+		 
+		<p>
+			Os níveis de adubação orgânica foram constituídos por: 3 litros/cova de esterco de galinha aplicado nas covas do maracujazeiro (
+			<italic>Passiflora actinia</italic>
+			 Hook.) e 12 litros nas linhas de plantio das plantas anuais: feijão-caupi - 
+			<italic>Vigna unguiculata</italic>
+			 (L.) Walp. e mandioca (
+			<italic>Manihot esculenta</italic>
+			 L.), aplicadas em uma única vez. A adubação química correspondeu a 70 g de uréia, 145 g de superfosfato triplo e 96 g de cloreto de potássio em cada cova das plantas de maracujá ou 144 g, 264 g e 216 g de uréia, superfosfato triplo e KCl, respectivamente, nas linhas de plantio das plantas anuais, sendo a aplicação feita anualmente. Uma dose de calcário dolomítico equivalente a 1,5 t ha
+			<sup>-1</sup>
+			 foi utilizada a lanço em todas as parcelas e a incorporação efetuada com enxada. A quantidade de esterco de galinha foi equivalente a 7 t ha
+			<sup>-1</sup>
+			 e a adubação química, a 40 kg de N ha
+			<sup>-1</sup>
+			, 35 kg de P ha
+			<sup>-1</sup>
+			 e 67 kg de K ha
+			<sup>-1</sup>
+			. O P foi aplicado de uma só vez no plantio das lavouras. O N e o K foram aplicados metade por ocasião do plantio e a outra metade conforme a cultura entre 45 e 60 dias após o plantio. Para as espécies já implantadas, os adubos foram aplicados em cobertura próximo à planta, sendo o fósforo usado de uma única vez e o nitrogênio e potássio em duas aplicações anuais. A mucuna foi semeada no final do ciclo da primeira lavoura anual. 
+		</p>
+		 
+		<p>Os sistemas foram implantados em módulos de 54 m x 72 m, em duas propriedades rurais (A e B). Cada parcela correspondeu a 18 m x 24 m. O delineamento experimental utilizado foi o de blocos ao acaso, em faixas, com seis repetições. A análise de variância dos resultados seguiu modelo proposto por Pimentel Gomes (1982). </p>
+		 
+		<p>
+			As plantas invasoras foram coletadas em três períodos, sendo o primeiro em fevereiro de 1997, na época chuvosa, antes do plantio das espécies anuais e semi-perene e antes da aplicação dos tratamentos de adubação. Os outros períodos foram novembro/97 (época seca) e janeiro-fevereiro/98 (época chuvosa). As plantas foram coletadas em cada parcela e identificadas. As amostragens corresponderam a seis amostras de 0,25 m
+			<sup>2</sup>
+			 cada, por parcela, distribuídas aleatoriamente, usando-se um quadrado de madeira de 50 cm x 50 cm. As seis áreas amostradas eqüivaliam a 1% da área útil de cada parcela. 
+		</p>
+		 
+		<p>Após a identificação preliminar feita pelos botânicos no campo, e a estimativa do grau de infestação, as plantas invasoras foram cortadas rente ao solo, separadas por classe em monocotiledôneas e dicotiledôneas, levadas para o laboratório para completar o trabalho de separação por espécie e identificação. Após a separação das plantas por espécie, foi feita a contagem de todos os indivíduos em cada sub-área amostrada, inclusive plântulas, quando era possível se distinguir. </p>
+		 
+		<p>Para facilitar a identificação botânica, foram preparadas, ainda no campo, exsicatas de todas as espécies encontradas. Procedeu-se uma breve descrição das principais características das plantas, tais como porte da espécie, altura, tipo de folha e de flores, quando encontradas. Foram preparadas fichas para catalogação, onde foram anotados nome comum e científico, data e local da coleta. </p>
+		 
+		<p>
+			O trabalho de identificação foi feito, em princípio, por comparação, utilizando-se as seguintes referências (Leitão Filho 
+			<italic>et al.</italic>
+			, 1972; Albuquerque, 1980; Kissmann &amp; Groth, 1993; Lorenzi, 1994; Le Bourgeois &amp; Merlier, 1995). Quando não foi possível, ou havia dúvidas, contou-se com a colaboração de um especialista ou em alguns casos foram citados apenas em nível de gênero e/ou família. As duplicatas das exsicatas de todas as espécies foram depositadas no herbário da EMBRAPA Amazônia Ocidental/Manaus. 
+		</p>
+		 
+		<p>A avaliação de comunidades de plantas invasoras e do seu comportamento nos diferentes hábitats foi feita usando-se variáveis como freqüência, coeficiente de similaridade, matéria seca e abundância (Carvalho &amp;amp; Pitelli, 1992). </p>
+		 
+		<p>Para o estudo quantitativo, foi efetuada a contagem do número de plantas de cada espécie, a partir do que realizaram-se os cálculos de freqüência de ocorrência, usando-se a fórmula a seguir, sendo os resultados dados em percentagem (Carvalho &amp;amp; Pitelli, 1992; Sousa, 1995). </p>
+		 
+		<p>F = Po x100/PT </p>
+		 
+		<p>F = Freqüência (%) </p>
+		 
+		<p>Po = número de parcelas ocupadas, isto é, em que ocorre uma dada espécie </p>
+		 
+		<p>PT = número total de parcelas amostradas. </p>
+		 
+		<p>A densidade foi definida como o número de indivíduos por metro quadrado, sendo determinada para cada espécie pela fórmula descrita por Carvalho &amp;amp; Pitelli (1992) e Sousa (1995): </p>
+		 
+		<p>
+			DA= n/m
+			<sup>2</sup>
+			 onde: 
+		</p>
+		 
+		<p>DA = densidade absoluta </p>
+		 
+		<p>n = número total de indivíduos de uma dada espécie </p>
+		 
+		<p>
+			m
+			<sup>2</sup>
+			 = metros quadrados. 
+		</p>
+		 
+		<p>O coeficiente de similaridade foi calculado baseando-se na seguinte fórmula: CS=2C x 100/A+B, proposta por Sorensen (1948), apud Carvalho &amp;amp; Pitelli (1992) e Sousa (1995), onde: </p>
+		 
+		<p>CS = Coeficiente de Similaridade (%) </p>
+		 
+		<p>A= número de espécies do hábitat A; </p>
+		 
+		<p>B= número de espécies do hábitat B; </p>
+		 
+		<p>C= número de espécies comuns aos dois hábitats. </p>
+		 
+		<p>
+			Os dados do número de plantas invasoras foram transformados em 
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/a02fr01.gif"/>
+			, para efeito da análise de variância. A significância para a análise de variância foi feita pelo teste &quot;F&quot; a 5% de probabilidade. As comparações entre as médias foram feitas pelo teste de &quot;Tukey&quot;, também a 5% de probabilidade. Os cálculos do desvio padrão (s) e erro padrão da média (s
+			<sub>m</sub>
+			) foram conforme Pimentel Gomes (1982). 
+		</p>
+		 
+		<p>
+			<bold>RESULTADOS E DISCUSSÃO </bold>
+		</p>
+		 
+		<p>Caracterização das Plantas Invasoras nos Sistemas de uso da terra</p>
+		 
+		<p>
+			Foram identificadas 55 espécies de plantas invasoras, distribuídas em 23 famílias botânicas (
+			<xref>Tabela 2</xref>
+			). Destas espécies, 43 são dicotiledôneas (78,2 %), 11 monocotiledôneas (20,0%) e uma pteridófita (1,8%). Na 
+			<xref>Tabela 2</xref>
+			 foram relacionadas todas as espécies encontradas nas duas áreas e identificadas pelos seus nomes científico e vulgar, quando conhecidos, segundo Silva 
+			<italic>et al.</italic>
+			 (1977); Silva 
+			<italic>et al.</italic>
+			 (1988), Mori 
+			<italic>et al.</italic>
+			 (1980), Lorenzi (1994). 
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/a02tab02.gif"/>
+		</p>
+		 
+		<p>
+			Observa-se também na 
+			<xref>Tabela 2</xref>
+			, que as espécies com maiores médias de densidades, ou seja, com maior número de plantas por m
+			<sup>2</sup>
+			 foram 
+			<italic>Paspalum conjugatum</italic>
+			 P.J. Bergius e 
+			<italic>Ageratum conyzoides</italic>
+			 L. na área A, com 66,81 e 44,67 plantas m
+			<sup>-2</sup>
+			, respectivamente. Na área B, as espécies com maiores densidades foram 
+			<italic>Homolepis aturensis </italic>
+			(Kunth) Chase e 
+			<italic>Ageratum conyzoides</italic>
+			 L., com 41,95 e 35,36 plantas m
+			<sup>-2</sup>
+			, respectivamente. 
+		</p>
+		 
+		<p>
+			As dez espécies mais importantes em número de indivíduos por m
+			<sup>2</sup>
+			 corresponderam a 86,34% na área A e 89,95% na área B. Destas, verifica-se que as famílias Poaceae (área A), Poaceae e Cyperaceae (área B) representam 42,91% e 60,88% nas áreas A e B, respectivamente. Pleasant 
+			<italic>et al.</italic>
+			 (1990), estudando medidas de controle de invasoras em sistemas de cultivo contínuo de lavouras anuais, mostraram que 60% das invasoras na primeira cultura eram constituídas por Poaceae, contra 15% de dicotiledôneas e 25% de Cyperaceae. Já no sexto cultivo, as Poaceae compunham 80% da população de invasoras. 
+		</p>
+		 
+		<p>
+			Conforme a densidade da comunidade em nível de grupo, nota-se que as monocotiledôneas foram superiores em relação ao número de indivíduos por metro quadrado, particularmente na área B. O número total de indivíduos de Poaceae e Cyperaceae por m
+			<sup>2</sup>
+			 na área B foi de 93,2 plantas m
+			<sup>-2</sup>
+			, enquanto o número de dicotiledôneas foi de 55,1 plantas m
+			<sup>-2</sup>
+			 (
+			<xref>Tabela 2</xref>
+			). Na área A, as monocotiledôneas estavam constituídas somente por Poaceae, com 113,0 indivíduos por m
+			<sup>2</sup>
+			, sendo um número bastante expressivo quando comparado a 138,6 plantas m
+			<sup>-2</sup>
+			 das 43 espécies dicotiledôneas. Mori 
+			<italic>et al.</italic>
+			 (1980) observaram que a ocorrência de dicotiledôneas foi maior que as monocotiledôneas (46 vs. 26 espécies). No entanto, as monocotiledôneas apresentaram maior biomassa, indicando que foram quase duas vezes mais prejudiciais aos cultivos que as dicotiledôneas. 
+		</p>
+		 
+		<p>
+			As famílias Poaceae e Asteraceae apresentaram maior número de espécies, ambas com 10, destacando-se 
+			<italic>Paspalum conjugatum</italic>
+			 P.J. Bergius, na área A, e 
+			<italic>Homolepis aturensis </italic>
+			(Kunth) Chase, na área B, como as mais freqüentes da família Poaceae. 
+			<italic>Panicum laxum</italic>
+			 Sw., a terceira espécie mais freqüente da família Poaceae, teve freqüência de somente 9,29% e 7,22% nas áreas A e B, respectivamente. Na família Asteraceae, destacaram-se 
+			<italic>Ageratum conyzoides</italic>
+			 nas áreas A e B, e 
+			<italic>Emilia coccinea</italic>
+			, na área A como as mais freqüentes. Outras famílias com menor número de espécies foram Euphorbiaceae (6), Rubiaceae (5), Verbenaceae (3) e Cecropiaceae (3). As demais apresentaram apenas uma espécie. 
+		</p>
+		 
+		<p>
+			Comparando-se com os dados do levantamento florístico realizado na área em 1994, antes da implantação dos sistemas, verifica-se que os cultivos modificaram a diversidade das espécies da vegetação invasora. Neste levantamento identificou-se cerca de 18 espécies, representadas por 16 famílias. As espécies com maior número de indivíduos encontradas na área, com vegetação de capoeira de aproximadamente dois anos, pertenciam às famílias Cecropiaceae (15), Melastomataceae (6) e Rubiaceae (5), que provavelmente compunham 80% do total de indivíduos de arbóreas. Também, foram encontradas espécies das famílias: Gleicheniaceae (2), Burseraceae (2), Sapindaceae (2), Fabaceae (2), Solanaceae (1), entre outras. Diferentemente, em áreas de floresta primária, Klinge 
+			<italic>et al.</italic>
+			 (1975) mostraram que a maior riqueza de espécies pertence às famílias 
+			<italic>Leguminosae</italic>
+			 (ocorrendo em todos os estratos), 
+			<italic>Sapotaceae, Lauraceae, Chrysobalanaceae e Rubiaceae</italic>
+			. 
+		</p>
+		 
+		<p>
+			Observa-se na 
+			<xref>Tabela 2</xref>
+			, que algumas dessas famílias não foram encontradas nesta avaliação e mesmo as que ocorreram não foram as mais freqüentes, geralmente apresentando-se com poucas espécies e poucos indivíduos, exceção feita apenas à família Rubiaceae, a terceira mais freqüente das dicotiledôneas, apresentando-se com cinco espécies. Estes resultados mostram a alteração na diversidade da composição florística das áreas com o uso. Souza, Silva &amp; Figueiredo (1998), comparando áreas de cultivo com áreas de pousio, também observaram redução na diversidade de espécies nas áreas de cultivo. Famílias como Malpighiaceae, Cecropiaceae, Euphorbiaceae, Cyperaceae, Poaceae, entre outras, foram também encontradas em áreas experimentais na EMBRAPA Amazônia Ocidental e em áreas cultivadas com cupuaçuzeiro (Silva, 1999). 
+		</p>
+		 
+		<p>O grupo das monocotiledôneas foi formado por somente duas famílias, Poaceae e Cyperaceae, representando 20% do total das espécies registradas. No entanto, o número de indivíduos por família foi muito maior, correspondendo a 49,3% da família Poaceae, contra 31% da família Asteraceae, a maior representante das dicotiledôneas. </p>
+		 
+		<p>
+			A maior freqüência de espécies das Poaceae pode ser justificada pelo manejo do solo (Kissmann &amp;amp; Groth, 1993) e, possivelmente, pela diminuição da fertilidade deste com os cultivos sucessivos, principalmente nos tratamentos sem adubação completa. Neste caso, a ocorrência de monocotiledôneas em maior quantidade indica também a maior eficiência destas espécies na exploração dos fatores de produção (Silva 
+			<italic>et al.</italic>
+			, 1988 ). 
+		</p>
+		 
+		<p>
+			Trabalhos conduzidos em áreas da região amazônica têm mostrado a família Poaceae e principalmente a espécie 
+			<italic>Paspalum conjugatum</italic>
+			 como mais freqüentes (Souza Filho, 1995; Souza 
+			<italic>et al.</italic>
+			, 1998). Alcântara &amp; Carvalho (1983), nos estudos de invasoras em plantios de mandioca, identificaram, também, as famílias Poaceae e Asteraceae como as mais freqüentes. De igual modo, áreas ocupadas com plantios de cacau, bananeira e com leguminosas de cobertura de solo foram encontradas proliferando por invasoras mais freqüentes, tais como espécies de Poaceae, como 
+			<italic>Paspalum conjugatum</italic>
+			, além de outras importantes citadas neste estudo (Lisboa &amp; Vinha, 1982; Silva 
+			<italic>et al.</italic>
+			, 1988; Valenzuela, 1990). Esta espécie se adapta às condições de baixa luminosidade, além de vegetar em solos de fertilidade média, razão portanto, de ser encontrada com maior freqüência em áreas bastante sombreadas (Lisboa &amp; Vinha, 1982). Assim, também, pode-se justificar a maior freqüência desta espécie e de outras Poaceae nos sistemas agroflorestais, onde há maior ocupação das áreas com plantas perenes arbóreas e, consequentemente, menor incidência de luz. 
+		</p>
+		 
+		<p>
+			A distribuição das dicotiledôneas foi generalizada nas áreas e nos tratamentos estudados. Observou-se, no entanto, maior ocorrência na área A que na B e geralmente, enquanto aumentava o número de dicotiledôneas decrescia o número de monocotiledôneas (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/aa/v33n3/a02fig01.gif">Figura 1</ext-link>
+			, 
+			<xref>Tabela 3</xref>
+			). 
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/a02tab03.gif"/>
+		</p>
+		 
+		<p>
+			O número de monocotiledôneas foi menor no tratamento com adubação completa (NPK+MO) e maior nos demais tratamentos, ou seja, com P e P+Leguminosa, em ambas as áreas (
+			<xref>Tabela 3</xref>
+			). Com as dicotiledôneas, no entanto, o processo foi inverso; nas áreas com adubação NPK+MO, no solo com fertilidade mais elevada (
+			<xref>Tabela 1</xref>
+			), o número de dicotiledôneas foi 113% (área A) e 17% (área B) maior que as monocotiledôneas, decrescendo nos tratamentos P e P+Leguminosa e, com menos adubação. O maior número de plantas deste grupo pode estar relacionado à maior diversidade de dicotiledôneas, em razão da maioria das famílias botânicas encontrar-se neste grupo (Nee, 1995). Por outro lado, neste grupo também são encontradas as famílias de plantas invasoras consideradas mais agressivas (Sousa, 1995). 
+		</p>
+		 
+		<p>
+			De modo geral, o número total de plantas e de espécies invasoras aumentou com o tempo como pode ser observado na 
+			<xref>Figura 2</xref>
+			 e 
+			<xref>Tabela 4</xref>
+			. O número total de plantas invasoras decresceu na segunda coleta, sendo mais acentuado nos sistemas mandioca+fruteiras e maracujá+fruteiras (
+			<xref>Figura 2</xref>
+			). O número de espécies monocotiledôneas também mostrou um ligeiro decréscimo na segunda coleta de invasoras na área B (
+			<xref>Tabela 4</xref>
+			). Estes decréscimos corresponderam à época mais seca, e conseqüentemente, período de maior deficiência hídrica. 
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/a02fig02.jpg"/>
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/a02tab04.gif"/>
+		</p>
+		<p/>
+		 
+		<p>
+			Os dados da 
+			<xref>Tabela 4</xref>
+			 mostram um acréscimo de 42% e 26% ocorrido no número total de espécies invasoras da primeira para a terceira coleta (fev/97 para fev/98) nas áreas B e A, respectivamente, sendo 22% e 50% o aumento de espécies dicotiledôneas e 40% e 25% o de monocotiledôneas. Os dados totais de espécies que ocorreram nas áreas A e B (
+			<xref>Tabela 4</xref>
+			) evidenciam o número expressivo de espécies dicotiledôneas em relação às monocotiledôneas, 29 versus 9 na área A e 35 versus 11 na área B, assim como mostram a maior diversidade da área B (46 versus 38 espécies), o que pode estar relacionado ao banco de sementes do solo diferente para cada área. 
+		</p>
+		 
+		<p>
+			No sistema anuais+fruteiras, as monocotiledôneas tiveram um aumento contínuo, o que pode ter sido em razão dos cultivos anuais mais freqüentes e que permitiram maior movimentação do solo (
+			<xref>Figura 2</xref>
+			). Estes dados concordam com resultados anteriores relatados, que concluíram pela menor perturbação do solo como responsáveis pela redução da reinfestação das plantas invasoras, incluindo espécies da família Poaceae (McCloskey 
+			<italic>et al.,</italic>
+			 1996). 
+		</p>
+		 
+		<p>
+			Nos agrossistemas tropicais, as comunidades de plantas invasoras dominantes são formadas por espécies nativas e cosmopolitas. Os resultados deste estudo mostram que as práticas agrícolas e os sistemas de manejo do solo e das culturas exercem influência acentuada na composição florística e no tamanho das comunidades de plantas invasoras em cada local. Estes resultados corroboram outros trabalhos com plantas invasoras (Kellman, 1980; Derksen 
+			<italic>et al</italic>
+			., 1993; Dekker, 1997). 
+		</p>
+		 
+		<p>Variação da comunidade de plantas invasoras nos sistemas agroflorestais estudados. </p>
+		 
+		<p>
+			Verifica-se pelos coeficientes de similaridade dos locais e tratamentos estudados que algumas áreas mostram maiores semelhanças em termos de espécies que outras (
+			<xref>Tabela 5</xref>
+			). No entanto, as similaridades entre as áreas com os sistemas são todas menores que 50%. 
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/aa/v33n3/a02tab05.gif"/>
+		</p>
+		 
+		<p>Os maiores coeficientes de similaridade, entre as duas áreas, foram observados nos tratamentos que receberam adubação com matéria orgânica (NPK+MO), particularmente nos sistemas mandioca+fruteiras (44,0%), anuais+fruteiras (42,1%) e maracujá+fruteiras (46,3%). Este último apresenta o maior coeficiente de similaridade entre as áreas A e B, provavelmente em razão da menor movimentação do solo com o cultivo do maracujá, o qual tem ciclo mais longo que as culturas anuais e a mandioca. Os menores coeficientes foram observados no sistema anuais+fruteiras com NPK+MO (18,8%), P (15,6%) e P+Leguminosa (20,7%) na área A e maracujá+fruteiras com P, na B. De modo geral, os menores coeficientes de similaridade entre as áreas A e B em qualquer dos sistemas envolviam os tratamentos com P e P+Leguminosa. Estes variaram entre 20,0% a 38,9% (P e P+leguminosa, no sistema mandioca+fruteiras&amp;lt;anuais+fruteiras&amp;lt; maracujá+fruteiras); entre 21,2% a 21,9% (P+leguminosa e P, no sistema mandioca+fruteiras e anuais+fruteiras &amp;lt; anuais+fruteiras e maracujá+fruteiras &amp;lt;mandioca+fruteiras e maracujá+fruteiras). Dessa forma, comparando-se os dados das duas áreas, verifica-se que as maiores similaridades ocorreram nos três sistemas maracujá+fruteiras com NPK+MO, mandioca+fruteiras com NPK+MO e anuais+fruteiras com NPK+MO, cada um com o seu tratamento correspondente na outra área, cujos coeficientes foram de 46,3%, 44,0% e 42,1%, respectivamente. </p>
+		 
+		<p>
+			O índice de similaridade medido pelo número de espécies comuns nas diferentes áreas mostram a intensificação do uso das áreas, indicando o tipo de manejo do solo pelo tipo de comunidades de invasoras ocorrentes. Odum 
+			<italic>et al.</italic>
+			 (1994), comparando a vegetação entre áreas de cultivo e áreas mais antigas, mostraram a grande diferença existente entre as áreas; obtiveram coeficientes de similaridade entre 1-18%. Os mesmos autores mostraram que as seis espécies mais dominantes nas áreas antigas não foram encontradas nas de cultivo, enquanto que invasoras de cultivo foram encontradas apenas esparsamente nas áreas antigas. Notaram também, que as maiores semelhanças foram entre as áreas de plantio direto e as antigas adubadas (18%), concluindo que as invasoras prejudiciais à agricultura são realmente aquelas que se adaptam aos fertilizantes, desenvolvem resistência ao herbicida e geralmente não ocorrem nos ecossistemas naturais. Carvalho &amp; Pitelli (1992) mostraram que os coeficientes de similaridade não estão relacionados aos solos ou distância entre as áreas, mas podem estar mais ligados às formas de manejo dadas às diferentes áreas. 
+		</p>
+		 
+		<p>Sousa (1995) mostrou que as comunidades de plantas invasoras em áreas de pastagem foram diferentes das ocorrentes nos sistemas agroflorestais. Nesses, a similaridade entre as comunidades de plantas invasoras que ocorreram no estrato inferior dos diferentes sistemas agroflorestais foram semelhantes em 50 a mais de 60%. Isso indica, também, que o manejo dado ao solo é fator importante no aparecimento das comunidades de invasoras. </p>
+		 
+		<p>
+			Os resultados do presente trabalho mostraram os maiores coeficientes de similaridade nas áreas onde os sistemas de manejo do solo foram mais semelhantes, principalmente nos locais em que o tratamento NPK+MO foi utilizado (
+			<xref>Tabela 5</xref>
+			). Assim, o manejo contínuo do solo alterou as comunidades de plantas invasoras nas áreas do estudo, quando comparadas com as áreas originais utilizadas anteriormente. 
+		</p>
+		 
+		<p>
+			<bold>CONCLUSÕES</bold>
+			 
+		</p>
+		 
+		<p>A diversificação nas áreas de cultivo, aliada às práticas de manejo do solo, influencia na vegetação invasora dos cultivos, alterando as comunidades de plantas invasoras. </p>
+		 
+		<p>Nas duas áreas estudadas, as espécies da família Poaceae são mais eficientes na exploração do solo de baixa fertilidade, necessitando de manejo mais intensivo para seu controle. </p>
+		 
+		<p>As práticas agrícolas e os sistemas de manejo do solo e das culturas afetam a composição florística e o tamanho das comunidades de plantas invasoras em cada local. </p>
+		 
+		<p>O número de plantas monocotiledôneas foi menor no tratamento com adubação completa (NPK+MO), enquanto o número de dicotiledôneas foi 74% maior neste tratamento. </p>
+		 
+		<p>
+			As espécies com maiores médias de densidades por m
+			<sup>2</sup>
+			 foram 
+			<italic>Paspalum conjugatum</italic>
+			 e 
+			<italic>Ageratum conyzoides</italic>
+			 na área A. Na área B, as espécies com maiores densidades foram 
+			<italic>Homolepis aturensis </italic>
+			e 
+			<italic>Ageratum conyzoides</italic>
+			. 
+		</p>
+		 
+		<p>Os maiores coeficientes de similaridade obtidos nas duas áreas mostram que o manejo contínuo do solo altera fortemente as comunidades de plantas invasoras nas áreas, sendo atualmente bem diferentes das áreas originais, e mais representativo na presença de MO. </p>
+		 
+		<p>
+			<bold>BIBLIOGRAFIA CITADA </bold>
+			 
+		</p>
+		 
+		<p>
+			Akobundu, I.O. 1987. Weed science in integrated pest management. 
+			<italic>In</italic>
+			: Klingman, G.C.; Noordhoff, F.M. (Eds). 
+			<italic>Weed science in the tropics. Principles and practices.</italic>
+			 New York: John Willey. p.1-22. 
+		</p>
+		 
+		<p>
+			Albuquerque, J.M. 1980. Identificação de plantas invasoras de cultura na região de Manaus. 
+			<italic>Acta Amazonica, </italic>
+			10(1): 47-95. 
+		</p>
+		 
+		<p>
+			Alcântara, E.N.; Carvalho, D.A. 1983. Plantas daninhas em mandiocais (
+			<italic>Manihot esculenta</italic>
+			 Crantz) na região mineradora de Diamantina (Alto Jequitinhonha), Minas Gerais. 
+			<italic>Planta Daninha,</italic>
+			 6(2): 138-143. 
+		</p>
+		 
+		<p>
+			Almeida, F.S. 1988. 
+			<italic>A alelopatia e as plantas</italic>
+			. IAPAR Circular, 53. Londrina, 60 p. 
+		</p>
+		 
+		<p>
+			Brasil. 1978. 
+			<italic>Projeto RADAMBRASIL</italic>
+			. 
+			<italic>Folha SA. 20 Manaus: geologia, geomorfologia, pedologia, vegetação e uso potencial da terra</italic>
+			. Departamento Nacional de Produção Mineral, Rio de Janeiro, (Levantamento de Recursos Naturais, 18), 628 p. 
+		</p>
+		 
+		<p>
+			Carsky, R.J; Tarawall, S.A.; Becker, M.; Chikoye, D.; Tian, G.; Sanginga, N. 1998. 
+			<italic>Mucuna- herbaceous cover legume with potential for multiple uses. </italic>
+			Ibadan: International Institute of Tropical Agriculture. Monograph 25. 52.p 
+		</p>
+		<p>
+			Carvalho, S.L.; Pitelli, R.A. 1992. Comportamento e análise fitossociológica das principais espécies de plantas daninhas de pastagens da região de Selvia (MS). 
+			<italic>Planta Daninha,</italic>
+			 10(1-2): 25-32. 
+		</p>
+		 
+		<p>
+			CPRM. 1998. - Serviço Geológico do Brasil. Superintendência Regional de Manaus. 
+			<italic>Potencial turístico do município de Presidente Figueiredo</italic>
+			. 
+			<italic>Programa de Integração Mineral em municípios da Amazônia - Primaz de Presidente Figueiredo</italic>
+			. Companhia de Pesquisa de Recursos Minerais, Manaus, Amazonas. 63 p. 
+		</p>
+		 
+		<p>
+			Dekker, J. 1997. Weed diversity and weed management. Symposium: Importance of weed biology to weed management. Weed Science Society of America, Norfolk, Virginia, 
+			<italic>Weed Science,</italic>
+			 45: 357-363. 
+		</p>
+		 
+		<p>
+			Derksen, D.A.; Lafond, G.P.; Thomas, A.G.; Loeppky, H.A.; Swanton, C.J. 1993. Impact of agronomic practices on weed communities: Tillage systems. 
+			<italic>Weed Science,</italic>
+			 41(3): 409-17 
+		</p>
+		<p>
+			Dias Filho, M.B. 1990. 
+			<italic>Plantas invasoras em pastagens cultivadas da Amazônia: estratégias de manejo e controle</italic>
+			. EMBRAPA-CPATU. Documentos, 52. 103 p. 
+		</p>
+		 
+		<p>
+			Domingues, E.P.; Velline, R.A.; Pitelli, R.A.; Pacheco, P.A.C. 1982. Efeito do matocompetição sobre a produtividade da cultura do arroz de sequeiro 
+			<italic>(Oriza sativa L.)</italic>
+			; em diferentes condições de espaçamento e de fertilização nitrogenada em cobertura. 
+			<italic>In: Resumos do 6 Congresso Brasileira de Herbicida e Plantas Daninhas</italic>
+			. ALAM/SBHED, Campinas, 33 p. 
+		</p>
+		 
+		<p>
+			EMBRAPA. 1997. 
+			<italic>Manual de métodos de análise de solo.</italic>
+			 Centro Nacional de Pesquisa de Solos. - 2. ed. rev. atual. - Rio de Janeiro, 1997. 212. (EMBRAP A-CNPS. Documentos; 1). 
+		</p>
+		 
+		<p>
+			EMBRAPA, 1998a. 
+			<italic>Boletim Agrometeo-rológico</italic>
+			. EMBRAPA/CPAA, Manaus. 23 p
+			<italic>. </italic>
+			 
+		</p>
+		 
+		<p>
+			EMBRAPA, 1998b. 
+			<italic>Boletim Agrometeo-rológico</italic>
+			. EMBRAPA/CPAA, Manaus. 19 p 
+			<italic>. </italic>
+			 
+		</p>
+		 
+		<p>
+			ICOTI. 1992
+			<italic>.</italic>
+			 Instituto de Cooperação Técnica Intermunicipal. 
+			<italic>Informações básicas do município de Presidente Figueiredo</italic>
+			. ICOTI, Manaus, 58 p. 
+		</p>
+		 
+		<p>
+			IPEAAOC. 1971. Instituto de Pesquisa Agropecuária da Amazônia Ocidental. Convênio para levantamento da área do distrito Agropecuário da SUFRAMA, IPEAN e IPEAAOc
+			<italic>. Solos do Distrito Agropecuário da SUFRAMA</italic>
+			. IPEAAOc, Manaus, 99 p. 
+		</p>
+		 
+		<p>
+			IPEAAOC. 1972. Instituto de Pesquisa Agropecuária da Amazônia Ocidental. Levantamento detalhado dos solos do IPEAAOc. 
+			<italic>Boletim Técnico,</italic>
+			 3. IPEAAOc, Manaus, 63 p. 
+		</p>
+		 
+		<p>
+			Kellman, M. 1980. Geographic patterning. 
+			<italic>In: </italic>
+			Tropical weed communities and early secondary succession. 
+			<italic>Biotropica, </italic>
+			12: 34-39. (supl. 
+		</p>
+		 
+		<p>
+			Kissmann, K.G.; Groth, D. 1993.
+			<italic> Plantas infestantes e nocivas</italic>
+			. BASF, São Paulo, Tomo 4, 798 p. 
+		</p>
+		 
+		<p>
+			Klinge, H.; Rodrigues, W.A.; Brunig, E.F.; Fittkau, E.J. 1975. Biomass and structure in a Central Amazonian rain forest.
+			<italic> In</italic>
+			: Golley, F.F.; Medina, E. (Eds). 
+			<italic>Tropical Ecological Systems 11. Trends in Terrestrial and Aquatic Ecology.</italic>
+			 New York, Springer-Verlag Berlin. p.115-122. 
+		</p>
+		 
+		<p>
+			Le Bourgeois, T. Merlier, H. 1995. 
+			<italic>Adventrop. Les adventices d&amp;#x27;Afrique soudane-sahélienne</italic>
+			. Montpellier, France, Cirad - CA (ed.), 640 p. 
+		</p>
+		 
+		<p>
+			Leitão Filho, H.F.; Aranha, C.; Bacchi, O. 1972. 
+			<italic>Plantas invasoras de culturas</italic>
+			. Vol. 1. 
+		</p>
+		 
+		<p>
+			Lisboa, G. Vinha, S.G. 1982. Plantas indesejáveis em cacauais de idades diferentes na área do Centro de Pesquisas do Cacau (CEPEC), 
+			<italic>Revista Theobroma</italic>
+			, 12(3): 135-140. 
+		</p>
+		 
+		<p>
+			Lorenzi, H. 1980. Plantas daninhas na cultura do milho. 
+			<italic>Divulgação Agronômica Shell,</italic>
+			 São Paulo, 47: 1-9. 
+		</p>
+		 
+		<p>
+			Lorenzi, H. 1994. 
+			<italic>Manual de identificação e controle de plantas daninhas, plantio direto e convencional</italic>
+			 4.ed. Nova Odessa: Plantarum. 299 p. 
+		</p>
+		 
+		<p>
+			Martins, D.; Pitelli, R.A. 1994. Influência das plantas daninhas na cultura do amendoim das águas: Efeitos de espaçamentos, variedades e períodos de convivência. 
+			<italic>Planta Daninha,</italic>
+			 12(2): 87-92. 
+		</p>
+		 
+		<p>
+			McCloskey, M.; Firbank, L.G.; Watkinson, A.R.; Webb, D.J. 1996. The dynamics of experimental arable weed communities under different management practices. 
+			<italic>J. Veg. Sci., </italic>
+			7: 799-808. 
+		</p>
+		 
+		<p>
+			Mori, S.A.; Silva, A.A.M.; Lisboa, G.; Pereira, R.C.; Santos, T.S. 1980. Subsídios para estudos de plantas invasoras no sul da Bahia. I. Produtividade e Fenologia. 
+			<italic>Boletim Técnico 73</italic>
+			. Ilhéus, Comissão Executiva do Plano da Lavoura Cacaueira, 1980. 18 p. 
+		</p>
+		 
+		<p>
+			Nee, M. 1995. 
+			<italic>Flora Preliminar do Projeto Dinâmica Biológica de Fragmentos Florestais (PDBFF). </italic>
+			New York Botanical Garden; INPA/Smithsonian, Manaus, 264 p. 
+		</p>
+		 
+		<p>
+			Odum, E.P.; Park, T.Y.; Hutcheson, K. 1994. Comparison of the weedy vegetation in old-fields and crop fields on the same site reveals that fallowing crop fields does not result in seedbank buildup of agricultural weeds. 
+			<italic>Agriculture, Ecosystems and Environment,</italic>
+			 49: 247-252. 
+		</p>
+		 
+		<p>
+			Pimentel Gomes F. 1982. 
+			<italic>Curso de estatística experimental</italic>
+			. 10.ed. Piracicaba:ESAL Q. 430 p. 
+		</p>
+		 
+		<p>
+			Pleasant, J.Mt.; McCollum, R.E.; Coble, H.D. 1990. Weed population Dynamics and Weed Control in the Peruvian Amazon. 
+			<italic>Agronomy Journal,</italic>
+			 82:102-112. 
+		</p>
+		 
+		<p>
+			Primavesi, A. 1992a. 
+			<italic>Agricultura sustentável</italic>
+			. São Paulo, Nobel, 141 p. 
+		</p>
+		 
+		<p>
+			Primavesi, A. 1992b. 
+			<italic>Manejo ecológico de pastagens</italic>
+			. São Paulo, Nobel, 95 p. 
+		</p>
+		 
+		<p>
+			Saavedra, M.S. 1994. Dinamica y manejo de poblaciones de malas hierbas. 
+			<italic>Planta Daninha</italic>
+			, 2(1): 29-38. 
+		</p>
+		 
+		<p>
+			Schulz, B.; Becker, B.; Götsch, E. 1994. Indigenous knowledge in a &amp;#x27; modern&amp;#x27; sustainable agroforestry system - a case study from eastern Brazil. 
+			<italic>Agroforestry Systems,</italic>
+			 25: 59-69. 
+		</p>
+		 
+		<p>
+			Silva, M.F.; Lisbôa, P.L.B.; Lisbôa, R.C.L.1977. 
+			<italic>Nome vulgares de plantas amazônicas</italic>
+			. Belém, INPA, 222 p. 
+		</p>
+		 
+		<p>
+			Silva, L.A.M.; Vinha, S.G.; Pereira, R.C. 1988. Gramíneas invasoras de cacauais. 
+			<italic>Boletim Técnico </italic>
+			159. Ilheus, Comissão Executiva do Plano da Lavoura Cacaueira, 1970. 108 p. 
+		</p>
+		 
+		<p>
+			Silva, J.F. 1999. 
+			<italic>Influência de herbicidas no crescimento e anatomia da epiderme foliar de plantas de cupuaçu (Theobroma grandiflorum</italic>
+			 (Willdenow ex Spreng) Schumann)
+			<italic> e leguminosas em consorciação.</italic>
+			 Tese de Doutorado, Instituto Nacional de Pesquisa da Amazônia/Fundação Universidade do Amazonas. Manaus, Amazonas. 171p. 
+		</p>
+		 
+		<p>
+			Sorensen, T. 1948. A method of establishing groups of equal amplitude in plant society based on similarity of species content. 
+			<italic>In: </italic>
+			Odum, E.P. (Ed). 
+			<italic>Ecologia.</italic>
+			 3a ed., México, Interamericana. 1972. 640 p. 
+		</p>
+		 
+		<p>
+			Sousa, S.G.A. 1995. 
+			<italic>Dinâmica de plantas invasoras em sistemas agroflorestais implantados em pastagens degradadas da Amazônia Central. (Região de Manaus-AM).</italic>
+			 Dissertação de Mestrado, Escola Superior de Agricultura &quot;Luiz de Queiroz&quot; (ESALQ), Universidade de São Paulo. Piracicaba, São Paulo. 97p. 
+		</p>
+		 
+		<p>
+			Souza Filho, A.P.S. 1995
+			<italic>. Potencialidades alelopáticas envolvendo gramíneas e leguminosas forrageiras e plantas invasoras de pastagens.</italic>
+			 Dissertação de Mestrado, Faculdade de Ciências Agrárias e Veterinárias, Universidade Estadual Paulista, Campus de Jaboticabal. Jaboticabal. São Paulo. 137p. 
+		</p>
+		 
+		<p>
+			Souza Filho, A.P.S.; Rodrigues, L.R.A.; Rodrigues, T.J.D. 1997. Efeito do potencial alelopático de três leguminosas forrageiras sobre três invasoras de pastagens. 
+			<italic>Pesquisa Agropecuária Brasileira,</italic>
+			 32(2): 165-170. 
+		</p>
+		 
+		<p>
+			Souza, G.F.; Silva, J.F.; Figueiredo, A.F.. 1998. Levantamento de plantas daninhas em áreas com e sem cultivos, em Manaus-AM. 
+			<italic>Revista da Universidade do Amazonas</italic>
+			. Série: Ciências Agrárias, 7(1-2): 33-43. 
+		</p>
+		 
+		<p>
+			Stevensen, E.C.; Légère, A.; Simard, R.R.; Anger, D.A.; Pageau, D.; Lafond, J. 1997. Weed species diversity in spring barley varies with crop rotation and tillage, but not with nutrient source
+			<italic>. Weed Science</italic>
+			, 45: 798-806. 
+		</p>
+		 
+		<p>
+			SUDAM. 1984. 
+			<italic>Atlas Climatológico da Amazônia Brasileira.</italic>
+			 Projeto de Hidrologia e Climatologia da Amazônia. Superintendência de Desenvolvimento da Amazônia, (Public. n
+			<sup>0</sup>
+			 39), Belém, 125 p. 
+		</p>
+		 
+		<p>
+			Valenzuela, J.A.D. 1990. 
+			<italic>Leguminosas de cobertura em cacau (Theobroma cacao L.) y pejibaye (Bactris gasipaes H. B. K.).</italic>
+			 Tese de Mestrado em Fitoprotection, Centro Agronomico Tropical de Investigación y Enseñanza (CATIE). Turrialba, Costa Rica. 85p. 
+		</p>
+		 
+		<p>
+			Vangessel, M.J.; Schweizer, E.E.; Garrett, K.A.; Westra, P. 1995. Influence of weed density and distribution on corn (
+			<italic>Zea mays</italic>
+			) yield. 
+			<italic>Weed Science</italic>
+			, 43: 215-218. 
+		</p>
+		 
+		<p>
+			Yamoah, C.F.; Agboola, A.A.; Mulongoy, K. 1986. Decomposition, nitrogen release and weed control by prunings of selected alley cropping shrubs. 
+			<italic>Agroforestry Systems, </italic>
+			4: 239-246. 
+		</p>
+		 
+		<p>
+			Vinha, S.G.; Pereira, R.C.; Muller, M.W. 1982. Efeito do controle de plantas invasoras sobre uma vegetação na área do CEPEC. 
+			<italic>Revista Theobroma</italic>
+			, 12(3): 123-134. 
+		</p>
+		 
+		<p>Recebido: 06/07/2002 </p>
+		<p> Aceito: 10/03/2003 </p>
+		<p/>
+		 
+		<p>
+			<xref>1</xref>
+			 Parte da Tese de Doutorado submetida, pela autora, ao Instituto Nacional de Pesquisas da Amazônia - INPA.
+		</p>
+	</body>
+	
+ 
+	<back>
+		
+ 
+		<ref-list>
+			
+ 
+			<ref id="B1">
+				
+ 
+				<mixed-citation>
+					Akobundu, I.O. 1987. Weed science in integrated pest management. 
+					<italic>In</italic>
+					: Klingman, G.C.; Noordhoff, F.M. (Eds). 
+					<italic>Weed science in the tropics. Principles and practices.</italic>
+					 New York: John Willey. p.1-22.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Weed science in the tropics: Principles and practices</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1987</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>1</fpage>
+					
+ 
+					<lpage>22</lpage>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Akobundu</surname>
+							
+ 
+							<given-names>I.O.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Klingman</surname>
+							
+ 
+							<given-names>G.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Noordhoff</surname>
+							
+ 
+							<given-names>F.M.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B2">
+				
+ 
+				<mixed-citation>
+					Albuquerque, J.M. 1980. Identificação de plantas invasoras de cultura na região de Manaus. 
+					<italic>Acta Amazonica, </italic>
+					10(1): 47-95.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Identificação de plantas invasoras de cultura na região de Manaus</article-title>
+					
+ 
+					<source>Acta Amazonica,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1980</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>47</fpage>
+					
+ 
+					<lpage>95</lpage>
+					
+ 
+					<issue>1</issue>
+					
+ 
+					<volume>10</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Albuquerque</surname>
+							
+ 
+							<given-names>J.M.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B3">
+				
+ 
+				<mixed-citation>
+					Alcântara, E.N.; Carvalho, D.A. 1983. Plantas daninhas em mandiocais (
+					<italic>Manihot esculenta</italic>
+					 Crantz) na região mineradora de Diamantina (Alto Jequitinhonha), Minas Gerais. 
+					<italic>Planta Daninha,</italic>
+					 6(2): 138-143.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Plantas daninhas em mandiocais (Manihot esculenta Crantz) na região mineradora de Diamantina (Alto Jequitinhonha), Minas Gerais</article-title>
+					
+ 
+					<source>Planta Daninha,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1983</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>138</fpage>
+					
+ 
+					<lpage>143</lpage>
+					
+ 
+					<issue>2</issue>
+					
+ 
+					<volume>6</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Alcântara</surname>
+							
+ 
+							<given-names>E.N.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Carvalho</surname>
+							
+ 
+							<given-names>D.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B4">
+				
+ 
+				<mixed-citation>
+					Almeida, F.S. 1988. 
+					<italic>A alelopatia e as plantas</italic>
+					. IAPAR Circular, 53. Londrina, 60 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>A alelopatia e as plantas</article-title>
+					
+ 
+					<source>IAPAR Circular</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1988</year>
+						
+ 
+					</date>
+					
+ 
+					<volume>53</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Almeida</surname>
+							
+ 
+							<given-names>F.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B5">
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Projeto RADAMBRASIL. Folha SA. 20 Manaus: geologia, geomorfologia, pedologia, vegetação e uso potencial da terra</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1978</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B6">
+				
+ 
+				<mixed-citation>
+					Carsky, R.J; Tarawall, S.A.; Becker, M.; Chikoye, D.; Tian, G.; Sanginga, N. 1998. 
+					<italic>Mucuna- herbaceous cover legume with potential for multiple uses. </italic>
+					Ibadan: International Institute of Tropical Agriculture. Monograph 25. 52.p 
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Mucuna- herbaceous cover legume with potential for multiple uses</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1998</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Carsky</surname>
+							
+ 
+							<given-names>R.J</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Tarawall</surname>
+							
+ 
+							<given-names>S.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Becker</surname>
+							
+ 
+							<given-names>M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Chikoye</surname>
+							
+ 
+							<given-names>D.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Tian</surname>
+							
+ 
+							<given-names>G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Sanginga</surname>
+							
+ 
+							<given-names>N.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B7">
+				
+ 
+				<mixed-citation>
+					Carvalho, S.L.; Pitelli, R.A. 1992. Comportamento e análise fitossociológica das principais espécies de plantas daninhas de pastagens da região de Selvia (MS). 
+					<italic>Planta Daninha,</italic>
+					 10(1-2): 25-32.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Comportamento e análise fitossociológica das principais espécies de plantas daninhas de pastagens da região de Selvia (MS)</article-title>
+					
+ 
+					<source>Planta Daninha,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1992</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>25</fpage>
+					
+ 
+					<lpage>32</lpage>
+					
+ 
+					<issue>1-2</issue>
+					
+ 
+					<volume>10</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Carvalho</surname>
+							
+ 
+							<given-names>S.L.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pitelli</surname>
+							
+ 
+							<given-names>R.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B8">
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Potencial turístico do município de Presidente Figueiredo: Programa de Integração Mineral em municípios da Amazônia - Primaz de Presidente Figueiredo</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1998</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B9">
+				
+ 
+				<mixed-citation>
+					Dekker, J. 1997. Weed diversity and weed management. Symposium: Importance of weed biology to weed management. Weed Science Society of America, Norfolk, Virginia, 
+					<italic>Weed Science,</italic>
+					 45: 357-363.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Weed diversity and weed management</article-title>
+					
+ 
+					<source>Weed Science</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1997</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>357</fpage>
+					
+ 
+					<lpage>363</lpage>
+					
+ 
+					<volume>45</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Dekker</surname>
+							
+ 
+							<given-names>J.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B10">
+				
+ 
+				<mixed-citation>
+					Derksen, D.A.; Lafond, G.P.; Thomas, A.G.; Loeppky, H.A.; Swanton, C.J. 1993. Impact of agronomic practices on weed communities: Tillage systems. 
+					<italic>Weed Science,</italic>
+					 41(3): 409-17 
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Impact of agronomic practices on weed communities: Tillage systems</article-title>
+					
+ 
+					<source>Weed Science</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1993</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>409</fpage>
+					
+ 
+					<lpage>17</lpage>
+					
+ 
+					<issue>3</issue>
+					
+ 
+					<volume>41</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Derksen</surname>
+							
+ 
+							<given-names>D.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Lafond</surname>
+							
+ 
+							<given-names>G.P.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Thomas</surname>
+							
+ 
+							<given-names>A.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Loeppky</surname>
+							
+ 
+							<given-names>H.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Swanton</surname>
+							
+ 
+							<given-names>C.J.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B11">
+				
+ 
+				<mixed-citation>
+					Dias Filho, M.B. 1990. 
+					<italic>Plantas invasoras em pastagens cultivadas da Amazônia: estratégias de manejo e controle</italic>
+					. EMBRAPA-CPATU. Documentos, 52. 103 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Plantas invasoras em pastagens cultivadas da Amazônia: estratégias de manejo e controle</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1990</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Dias Filho</surname>
+							
+ 
+							<given-names>M.B.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B12">
+				
+ 
+				<mixed-citation>
+					Domingues, E.P.; Velline, R.A.; Pitelli, R.A.; Pacheco, P.A.C. 1982. Efeito do matocompetição sobre a produtividade da cultura do arroz de sequeiro 
+					<italic>(Oriza sativa L.)</italic>
+					; em diferentes condições de espaçamento e de fertilização nitrogenada em cobertura. 
+					<italic>In: Resumos do 6 Congresso Brasileira de Herbicida e Plantas Daninhas</italic>
+					. ALAM/SBHED, Campinas, 33 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Resumos do 6 Congresso Brasileira de Herbicida e Plantas Daninhas</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1982</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Domingues</surname>
+							
+ 
+							<given-names>E.P.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Velline</surname>
+							
+ 
+							<given-names>R.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pitelli</surname>
+							
+ 
+							<given-names>R.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pacheco</surname>
+							
+ 
+							<given-names>P.A.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B13">
+				
+ 
+				<mixed-citation>
+					EMBRAPA. 1997. 
+					<italic>Manual de métodos de análise de solo.</italic>
+					 Centro Nacional de Pesquisa de Solos. - 2. ed. rev. atual. - Rio de Janeiro, 1997. 212. (EMBRAP A-CNPS. Documentos; 1).
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Manual de métodos de análise de solo</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1997</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B14">
+				
+ 
+				<mixed-citation>
+					EMBRAPA, 1998a. 
+					<italic>Boletim Agrometeo-rológico</italic>
+					. EMBRAPA/CPAA, Manaus. 23 p
+					<italic>.</italic>
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Boletim Agrometeo-rológico</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1998</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B15">
+				
+ 
+				<mixed-citation>
+					EMBRAPA, 1998b. 
+					<italic>Boletim Agrometeo-rológico</italic>
+					. EMBRAPA/CPAA, Manaus. 19 p 
+					<italic>.</italic>
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Boletim Agrometeo-rológico</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1998</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B16">
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Informações básicas do município de Presidente Figueiredo</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1992</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B17">
+				
+ 
+				<mixed-citation>
+					IPEAAOC. 1971. Instituto de Pesquisa Agropecuária da Amazônia Ocidental. Convênio para levantamento da área do distrito Agropecuário da SUFRAMA, IPEAN e IPEAAOc
+					<italic>. Solos do Distrito Agropecuário da SUFRAMA</italic>
+					. IPEAAOc, Manaus, 99 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Solos do Distrito Agropecuário da SUFRAMA</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1971</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B18">
+				
+ 
+				<mixed-citation>
+					IPEAAOC. 1972. Instituto de Pesquisa Agropecuária da Amazônia Ocidental. Levantamento detalhado dos solos do IPEAAOc. 
+					<italic>Boletim Técnico,</italic>
+					 3. IPEAAOc, Manaus, 63 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Boletim Técnico</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1972</year>
+						
+ 
+					</date>
+					
+ 
+					<volume>3</volume>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B19">
+				
+ 
+				<mixed-citation>
+					Kellman, M. 1980. Geographic patterning. 
+					<italic>In: </italic>
+					Tropical weed communities and early secondary succession. 
+					<italic>Biotropica, </italic>
+					12: 34-39. (supl.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Geographic patterning</article-title>
+					
+ 
+					<source>Biotropica</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1980</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>34</fpage>
+					
+ 
+					<lpage>39</lpage>
+					
+ 
+					<volume>12</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Kellman</surname>
+							
+ 
+							<given-names>M.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B20">
+				
+ 
+				<mixed-citation>
+					Kissmann, K.G.; Groth, D. 1993.
+					<italic> Plantas infestantes e nocivas</italic>
+					. BASF, São Paulo, Tomo 4, 798 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Plantas infestantes e nocivas</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1993</year>
+						
+ 
+					</date>
+					
+ 
+					<volume>4</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Kissmann</surname>
+							
+ 
+							<given-names>K.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Groth</surname>
+							
+ 
+							<given-names>D.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B21">
+				
+ 
+				<mixed-citation>
+					Klinge, H.; Rodrigues, W.A.; Brunig, E.F.; Fittkau, E.J. 1975. Biomass and structure in a Central Amazonian rain forest.
+					<italic> In</italic>
+					: Golley, F.F.; Medina, E. (Eds). 
+					<italic>Tropical Ecological Systems 11. Trends in Terrestrial and Aquatic Ecology.</italic>
+					 New York, Springer-Verlag Berlin. p.115-122.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Tropical Ecological Systems 11: Trends in Terrestrial and Aquatic Ecology</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1975</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>115</fpage>
+					
+ 
+					<lpage>122</lpage>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Klinge</surname>
+							
+ 
+							<given-names>H.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Rodrigues</surname>
+							
+ 
+							<given-names>W.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Brunig</surname>
+							
+ 
+							<given-names>E.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Fittkau</surname>
+							
+ 
+							<given-names>E.J.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Golley</surname>
+							
+ 
+							<given-names>F.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Medina</surname>
+							
+ 
+							<given-names>E.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B22">
+				
+ 
+				<mixed-citation>
+					Le Bourgeois, T. Merlier, H. 1995. 
+					<italic>Adventrop. Les adventices d'Afrique soudane-sahélienne</italic>
+					. Montpellier, France, Cirad - CA (ed.), 640 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Adventrop: Les adventices d'Afrique soudane-sahélienne</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1995</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Le Bourgeois</surname>
+							
+ 
+							<given-names>T.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Merlier</surname>
+							
+ 
+							<given-names>H.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B23">
+				
+ 
+				<mixed-citation>
+					Leitão Filho, H.F.; Aranha, C.; Bacchi, O. 1972. 
+					<italic>Plantas invasoras de culturas</italic>
+					. Vol. 1.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Plantas invasoras de culturas</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1972</year>
+						
+ 
+					</date>
+					
+ 
+					<volume>1</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Leitão Filho</surname>
+							
+ 
+							<given-names>H.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Aranha</surname>
+							
+ 
+							<given-names>C.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Bacchi</surname>
+							
+ 
+							<given-names>O.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B24">
+				
+ 
+				<mixed-citation>
+					Lisboa, G. Vinha, S.G. 1982. Plantas indesejáveis em cacauais de idades diferentes na área do Centro de Pesquisas do Cacau (CEPEC), 
+					<italic>Revista Theobroma</italic>
+					, 12(3): 135-140.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Plantas indesejáveis em cacauais de idades diferentes na área do Centro de Pesquisas do Cacau (CEPEC)</article-title>
+					
+ 
+					<source>Revista Theobroma,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1982</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>135</fpage>
+					
+ 
+					<lpage>140</lpage>
+					
+ 
+					<issue>3</issue>
+					
+ 
+					<volume>12</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Lisboa</surname>
+							
+ 
+							<given-names>G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Vinha</surname>
+							
+ 
+							<given-names>S.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B25">
+				
+ 
+				<mixed-citation>
+					Lorenzi, H. 1980. Plantas daninhas na cultura do milho. 
+					<italic>Divulgação Agronômica Shell,</italic>
+					 São Paulo, 47: 1-9.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Plantas daninhas na cultura do milho</article-title>
+					
+ 
+					<source>Divulgação Agronômica Shell, São Paulo,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1980</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>1</fpage>
+					
+ 
+					<lpage>9</lpage>
+					
+ 
+					<volume>47</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Lorenzi</surname>
+							
+ 
+							<given-names>H.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B26">
+				
+ 
+				<mixed-citation>
+					Lorenzi, H. 1994. 
+					<italic>Manual de identificação e controle de plantas daninhas, plantio direto e convencional</italic>
+					 4.ed. Nova Odessa: Plantarum. 299 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Manual de identificação e controle de plantas daninhas, plantio direto e convencional</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1994</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Lorenzi</surname>
+							
+ 
+							<given-names>H.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B27">
+				
+ 
+				<mixed-citation>
+					Martins, D.; Pitelli, R.A. 1994. Influência das plantas daninhas na cultura do amendoim das águas: Efeitos de espaçamentos, variedades e períodos de convivência. 
+					<italic>Planta Daninha,</italic>
+					 12(2): 87-92.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Influência das plantas daninhas na cultura do amendoim das águas: Efeitos de espaçamentos, variedades e períodos de convivência</article-title>
+					
+ 
+					<source>Planta Daninha,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1994</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>87</fpage>
+					
+ 
+					<lpage>92</lpage>
+					
+ 
+					<issue>2</issue>
+					
+ 
+					<volume>12</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Martins</surname>
+							
+ 
+							<given-names>D.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pitelli</surname>
+							
+ 
+							<given-names>R.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B28">
+				
+ 
+				<mixed-citation>
+					McCloskey, M.; Firbank, L.G.; Watkinson, A.R.; Webb, D.J. 1996. The dynamics of experimental arable weed communities under different management practices. 
+					<italic>J. Veg. Sci., </italic>
+					7: 799-808.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>The dynamics of experimental arable weed communities under different management practices</article-title>
+					
+ 
+					<source>J. Veg. Sci.,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1996</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>799</fpage>
+					
+ 
+					<lpage>808</lpage>
+					
+ 
+					<volume>7</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>McCloskey</surname>
+							
+ 
+							<given-names>M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Firbank</surname>
+							
+ 
+							<given-names>L.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Watkinson</surname>
+							
+ 
+							<given-names>A.R.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Webb</surname>
+							
+ 
+							<given-names>D.J.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B29">
+				
+ 
+				<mixed-citation>
+					Mori, S.A.; Silva, A.A.M.; Lisboa, G.; Pereira, R.C.; Santos, T.S. 1980. Subsídios para estudos de plantas invasoras no sul da Bahia. I. Produtividade e Fenologia. 
+					<italic>Boletim Técnico 73</italic>
+					. Ilhéus, Comissão Executiva do Plano da Lavoura Cacaueira, 1980. 18 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Subsídios para estudos de plantas invasoras no sul da Bahia. I.: Produtividade e Fenologia</article-title>
+					
+ 
+					<source>Boletim Técnico</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1980</year>
+						
+ 
+					</date>
+					
+ 
+					<volume>73</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Mori</surname>
+							
+ 
+							<given-names>S.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Silva</surname>
+							
+ 
+							<given-names>A.A.M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Lisboa</surname>
+							
+ 
+							<given-names>G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pereira</surname>
+							
+ 
+							<given-names>R.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Santos</surname>
+							
+ 
+							<given-names>T.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B30">
+				
+ 
+				<mixed-citation>
+					Nee, M. 1995. 
+					<italic>Flora Preliminar do Projeto Dinâmica Biológica de Fragmentos Florestais (PDBFF). </italic>
+					New York Botanical Garden; INPA/Smithsonian, Manaus, 264 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Flora Preliminar do Projeto Dinâmica Biológica de Fragmentos Florestais (PDBFF)</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1995</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Nee</surname>
+							
+ 
+							<given-names>M.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B31">
+				
+ 
+				<mixed-citation>
+					Odum, E.P.; Park, T.Y.; Hutcheson, K. 1994. Comparison of the weedy vegetation in old-fields and crop fields on the same site reveals that fallowing crop fields does not result in seedbank buildup of agricultural weeds. 
+					<italic>Agriculture, Ecosystems and Environment,</italic>
+					 49: 247-252.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Comparison of the weedy vegetation in old-fields and crop fields on the same site reveals that fallowing crop fields does not result in seedbank buildup of agricultural weeds</article-title>
+					
+ 
+					<source>Agriculture, Ecosystems and Environment,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1994</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>247</fpage>
+					
+ 
+					<lpage>252</lpage>
+					
+ 
+					<volume>49</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Odum</surname>
+							
+ 
+							<given-names>E.P.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Park</surname>
+							
+ 
+							<given-names>T.Y.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Hutcheson</surname>
+							
+ 
+							<given-names>K.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B32">
+				
+ 
+				<mixed-citation>
+					Pimentel Gomes F. 1982. 
+					<italic>Curso de estatística experimental</italic>
+					. 10.ed. Piracicaba:ESAL Q. 430 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Curso de estatística experimental</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1982</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Pimentel Gomes</surname>
+							
+ 
+							<given-names>F.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B33">
+				
+ 
+				<mixed-citation>
+					Pleasant, J.Mt.; McCollum, R.E.; Coble, H.D. 1990. Weed population Dynamics and Weed Control in the Peruvian Amazon. 
+					<italic>Agronomy Journal,</italic>
+					 82:102-112.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Weed population Dynamics and Weed Control in the Peruvian Amazon</article-title>
+					
+ 
+					<source>Agronomy Journal,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1990</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>102</fpage>
+					
+ 
+					<lpage>112</lpage>
+					
+ 
+					<volume>82</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Pleasant</surname>
+							
+ 
+							<given-names>J.Mt.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>McCollum</surname>
+							
+ 
+							<given-names>R.E.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Coble</surname>
+							
+ 
+							<given-names>H.D.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B34">
+				
+ 
+				<mixed-citation>
+					Primavesi, A. 1992a. 
+					<italic>Agricultura sustentável</italic>
+					. São Paulo, Nobel, 141 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Agricultura sustentável</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1992</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Primavesi</surname>
+							
+ 
+							<given-names>A.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B35">
+				
+ 
+				<mixed-citation>
+					Primavesi, A. 1992b. 
+					<italic>Manejo ecológico de pastagens</italic>
+					. São Paulo, Nobel, 95 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Manejo ecológico de pastagens</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1992</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Primavesi</surname>
+							
+ 
+							<given-names>A.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B36">
+				
+ 
+				<mixed-citation>
+					Saavedra, M.S. 1994. Dinamica y manejo de poblaciones de malas hierbas. 
+					<italic>Planta Daninha</italic>
+					, 2(1): 29-38.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Dinamica y manejo de poblaciones de malas hierbas</article-title>
+					
+ 
+					<source>Planta Daninha,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1994</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>29</fpage>
+					
+ 
+					<lpage>38</lpage>
+					
+ 
+					<issue>1</issue>
+					
+ 
+					<volume>2</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Saavedra</surname>
+							
+ 
+							<given-names>M.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B37">
+				
+ 
+				<mixed-citation>
+					Schulz, B.; Becker, B.; Götsch, E. 1994. Indigenous knowledge in a ' modern' sustainable agroforestry system - a case study from eastern Brazil. 
+					<italic>Agroforestry Systems,</italic>
+					 25: 59-69.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Indigenous knowledge in a ' modern' sustainable agroforestry system - a case study from eastern Brazil</article-title>
+					
+ 
+					<source>Agroforestry Systems,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1994</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>59</fpage>
+					
+ 
+					<lpage>69</lpage>
+					
+ 
+					<volume>25</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Schulz</surname>
+							
+ 
+							<given-names>B.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Becker</surname>
+							
+ 
+							<given-names>B.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Götsch</surname>
+							
+ 
+							<given-names>E.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B38">
+				
+ 
+				<mixed-citation>
+					Silva, M.F.; Lisbôa, P.L.B.; Lisbôa, R.C.L.1977. 
+					<italic>Nome vulgares de plantas amazônicas</italic>
+					. Belém, INPA, 222 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Nome vulgares de plantas amazônicas</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1977</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Silva</surname>
+							
+ 
+							<given-names>M.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Lisbôa</surname>
+							
+ 
+							<given-names>P.L.B.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Lisbôa</surname>
+							
+ 
+							<given-names>R.C.L.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B39">
+				
+ 
+				<mixed-citation>
+					Silva, L.A.M.; Vinha, S.G.; Pereira, R.C. 1988. Gramíneas invasoras de cacauais. 
+					<italic>Boletim Técnico </italic>
+					159. Ilheus, Comissão Executiva do Plano da Lavoura Cacaueira, 1970. 108 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Gramíneas invasoras de cacauais</article-title>
+					
+ 
+					<source>Boletim Técnico</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1988</year>
+						
+ 
+					</date>
+					
+ 
+					<volume>159</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Silva</surname>
+							
+ 
+							<given-names>L.A.M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Vinha</surname>
+							
+ 
+							<given-names>S.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pereira</surname>
+							
+ 
+							<given-names>R.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B40">
+				
+ 
+				<mixed-citation>
+					Silva, J.F. 1999. 
+					<italic>Influência de herbicidas no crescimento e anatomia da epiderme foliar de plantas de cupuaçu (Theobroma grandiflorum</italic>
+					 (Willdenow ex Spreng) Schumann)
+					<italic> e leguminosas em consorciação.</italic>
+					 Tese de Doutorado, Instituto Nacional de Pesquisa da Amazônia/Fundação Universidade do Amazonas. Manaus, Amazonas. 171p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="thesis">
+					
+ 
+					<source>de herbicidas no crescimento e anatomia da epiderme foliar de plantas de cupuaçu (Theobroma grandiflorum (Willdenow ex Spreng) Schumann) e leguminosas em consorciação</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1999</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Silva</surname>
+							
+ 
+							<given-names>J.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B41">
+				
+ 
+				<mixed-citation>
+					Sorensen, T. 1948. A method of establishing groups of equal amplitude in plant society based on similarity of species content. 
+					<italic>In: </italic>
+					Odum, E.P. (Ed). 
+					<italic>Ecologia.</italic>
+					 3Ş ed., México, Interamericana. 1972. 640 p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Ecologia</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1948</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Sorensen</surname>
+							
+ 
+							<given-names>T.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Odum</surname>
+							
+ 
+							<given-names>E.P.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B42">
+				
+ 
+				<mixed-citation>
+					Sousa, S.G.A. 1995. 
+					<italic>Dinâmica de plantas invasoras em sistemas agroflorestais implantados em pastagens degradadas da Amazônia Central. (Região de Manaus-AM).</italic>
+					 Dissertação de Mestrado, Escola Superior de Agricultura &quot;Luiz de Queiroz&quot; (ESALQ), Universidade de São Paulo. Piracicaba, São Paulo. 97p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="thesis">
+					
+ 
+					<source>Dinâmica de plantas invasoras em sistemas agroflorestais implantados em pastagens degradadas da Amazônia Central. (Região de Manaus-AM)</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1995</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Sousa</surname>
+							
+ 
+							<given-names>S.G.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B43">
+				
+ 
+				<mixed-citation>
+					Souza Filho, A.P.S. 1995
+					<italic>. Potencialidades alelopáticas envolvendo gramíneas e leguminosas forrageiras e plantas invasoras de pastagens.</italic>
+					 Dissertação de Mestrado, Faculdade de Ciências Agrárias e Veterinárias, Universidade Estadual Paulista, Campus de Jaboticabal. Jaboticabal. São Paulo. 137p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="thesis">
+					
+ 
+					<source>Potencialidades alelopáticas envolvendo gramíneas e leguminosas forrageiras e plantas invasoras de pastagens</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1995</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Souza Filho</surname>
+							
+ 
+							<given-names>A.P.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B44">
+				
+ 
+				<mixed-citation>
+					Souza Filho, A.P.S.; Rodrigues, L.R.A.; Rodrigues, T.J.D. 1997. Efeito do potencial alelopático de três leguminosas forrageiras sobre três invasoras de pastagens. 
+					<italic>Pesquisa Agropecuária Brasileira,</italic>
+					 32(2): 165-170.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Efeito do potencial alelopático de três leguminosas forrageiras sobre três invasoras de pastagens</article-title>
+					
+ 
+					<source>Pesquisa Agropecuária Brasileira,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1997</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>165</fpage>
+					
+ 
+					<lpage>170</lpage>
+					
+ 
+					<issue>2</issue>
+					
+ 
+					<volume>32</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Souza Filho</surname>
+							
+ 
+							<given-names>A.P.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Rodrigues</surname>
+							
+ 
+							<given-names>L.R.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Rodrigues</surname>
+							
+ 
+							<given-names>T.J.D.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B45">
+				
+ 
+				<mixed-citation>
+					Souza, G.F.; Silva, J.F.; Figueiredo, A.F.. 1998. Levantamento de plantas daninhas em áreas com e sem cultivos, em Manaus-AM. 
+					<italic>Revista da Universidade do Amazonas</italic>
+					. Série: Ciências Agrárias, 7(1-2): 33-43.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Levantamento de plantas daninhas em áreas com e sem cultivos, em Manaus-AM</article-title>
+					
+ 
+					<source>Revista da Universidade do Amazonas</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1998</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>33</fpage>
+					
+ 
+					<lpage>43</lpage>
+					
+ 
+					<issue>1-2</issue>
+					
+ 
+					<volume>7</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Souza</surname>
+							
+ 
+							<given-names>G.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Silva</surname>
+							
+ 
+							<given-names>J.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Figueiredo</surname>
+							
+ 
+							<given-names>A.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B46">
+				
+ 
+				<mixed-citation>
+					Stevensen, E.C.; Légère, A.; Simard, R.R.; Anger, D.A.; Pageau, D.; Lafond, J. 1997. Weed species diversity in spring barley varies with crop rotation and tillage, but not with nutrient source
+					<italic>. Weed Science</italic>
+					, 45: 798-806.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Weed species diversity in spring barley varies with crop rotation and tillage, but not with nutrient source</article-title>
+					
+ 
+					<source>Weed Science,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1997</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>798</fpage>
+					
+ 
+					<lpage>806</lpage>
+					
+ 
+					<volume>45</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Stevensen</surname>
+							
+ 
+							<given-names>E.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Légère</surname>
+							
+ 
+							<given-names>A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Simard</surname>
+							
+ 
+							<given-names>R.R.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Anger</surname>
+							
+ 
+							<given-names>D.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pageau</surname>
+							
+ 
+							<given-names>D.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Lafond</surname>
+							
+ 
+							<given-names>J.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B47">
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Atlas Climatológico da Amazônia Brasileira: Projeto de Hidrologia e Climatologia da Amazônia</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1984</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B48">
+				
+ 
+				<mixed-citation>
+					Valenzuela, J.A.D. 1990. 
+					<italic>Leguminosas de cobertura em cacau (Theobroma cacao L.) y pejibaye (Bactris gasipaes H. B. K.).</italic>
+					 Tese de Mestrado em Fitoprotection, Centro Agronomico Tropical de Investigación y Enseñanza (CATIE). Turrialba, Costa Rica. 85p.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="thesis">
+					
+ 
+					<source>Leguminosas de cobertura em cacau (Theobroma cacao L.) y pejibaye (Bactris gasipaes H. B. K.)</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1990</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Valenzuela</surname>
+							
+ 
+							<given-names>J.A.D.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B49">
+				
+ 
+				<mixed-citation>
+					Vangessel, M.J.; Schweizer, E.E.; Garrett, K.A.; Westra, P. 1995. Influence of weed density and distribution on corn (
+					<italic>Zea mays</italic>
+					) yield. 
+					<italic>Weed Science</italic>
+					, 43: 215-218.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Influence of weed density and distribution on corn (Zea mays) yield</article-title>
+					
+ 
+					<source>Weed Science,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1995</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>215</fpage>
+					
+ 
+					<lpage>218</lpage>
+					
+ 
+					<volume>43</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Vangessel</surname>
+							
+ 
+							<given-names>M.J.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Schweizer</surname>
+							
+ 
+							<given-names>E.E.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Garrett</surname>
+							
+ 
+							<given-names>K.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Westra</surname>
+							
+ 
+							<given-names>P.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B50">
+				
+ 
+				<mixed-citation>
+					Yamoah, C.F.; Agboola, A.A.; Mulongoy, K. 1986. Decomposition, nitrogen release and weed control by prunings of selected alley cropping shrubs. 
+					<italic>Agroforestry Systems, </italic>
+					4: 239-246.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Decomposition, nitrogen release and weed control by prunings of selected alley cropping shrubs</article-title>
+					
+ 
+					<source>Agroforestry Systems,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1986</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>239</fpage>
+					
+ 
+					<lpage>246</lpage>
+					
+ 
+					<volume>4</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Yamoah</surname>
+							
+ 
+							<given-names>C.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Agboola</surname>
+							
+ 
+							<given-names>A.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Mulongoy</surname>
+							
+ 
+							<given-names>K.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B51">
+				
+ 
+				<mixed-citation>
+					Vinha, S.G.; Pereira, R.C.; Muller, M.W. 1982. Efeito do controle de plantas invasoras sobre uma vegetação na área do CEPEC. 
+					<italic>Revista Theobroma</italic>
+					, 12(3): 123-134.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Efeito do controle de plantas invasoras sobre uma vegetação na área do CEPEC</article-title>
+					
+ 
+					<source>Revista Theobroma,</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1982</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>123</fpage>
+					
+ 
+					<lpage>134</lpage>
+					
+ 
+					<issue>3</issue>
+					
+ 
+					<volume>12</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Vinha</surname>
+							
+ 
+							<given-names>S.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pereira</surname>
+							
+ 
+							<given-names>R.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Muller</surname>
+							
+ 
+							<given-names>M.W.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+		</ref-list>
+		
+ 
+	</back>
+	
+
+</article>

--- a/tests/samples/S0102-33062011000100002.pt.xml
+++ b/tests/samples/S0102-33062011000100002.pt.xml
@@ -1,0 +1,4173 @@
+<?xml version="1.0" ?>
+<!DOCTYPE article
+  PUBLIC '-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN'
+  'JATS-journalpublishing1.dtd'>
+<article article-type="research-article" dtd-version="1.1" specific-use="sps-1.8" xml:lang="pt" xmlns:xlink="http://www.w3.org/1999/xlink">
+	
+ 
+	<front>
+		
+ 
+		<journal-meta>
+			
+ 
+			<journal-id journal-id-type="publisher-id">abb</journal-id>
+			
+ 
+			<journal-title-group>
+				
+ 
+				<journal-title>Acta Botanica Brasilica</journal-title>
+				
+ 
+				<abbrev-journal-title abbrev-type="publisher">Acta Bot. Bras.</abbrev-journal-title>
+				
+ 
+			</journal-title-group>
+			
+ 
+			<issn pub-type="ppub">0102-3306</issn>
+			
+ 
+			<issn pub-type="epub">1677-941X</issn>
+			
+ 
+			<publisher>
+				
+ 
+				<publisher-name>Sociedade Botânica do Brasil</publisher-name>
+				
+ 
+				<publisher-loc>Belo Horizonte, BA, Brazil</publisher-loc>
+				
+ 
+			</publisher>
+			
+ 
+		</journal-meta>
+		
+ 
+		<article-meta>
+			
+ 
+			<article-id pub-id-type="publisher-id">S0102-33062011000100002</article-id>
+			
+ 
+			<article-id pub-id-type="doi">10.1590/S0102-33062011000100002</article-id>
+			
+ 
+			<article-categories>
+				
+ 
+				<subj-group subj-group-type="heading">
+					
+ 
+					<subject>Artigos</subject>
+					
+ 
+				</subj-group>
+				
+ 
+			</article-categories>
+			
+ 
+			<title-group>
+				
+ 
+				<article-title>Variações na morfoanatomia foliar de Aechmea lindenii (E. Morren) Baker var. lindenii (Bromeliaceae) sob distintas condições ambientais</article-title>
+				
+ 
+				<trans-title-group xml:lang="en">
+					
+ 
+					<trans-title>Leaf morphoanatomy variation in Aechmea lindenii (E. Morren) Baker var. lindenii (Bromeliaceae) under distinct environmental conditions</trans-title>
+					
+ 
+				</trans-title-group>
+				
+ 
+			</title-group>
+			
+ 
+			<contrib-group>
+				
+ 
+				<contrib contrib-type="author">
+					
+ 
+					<name>
+						
+ 
+						<surname>Voltolini</surname>
+						
+ 
+						<given-names>Caroline Heinig</given-names>
+						
+ 
+					</name>
+					
+ 
+					<role>ND</role>
+					
+ 
+					<xref ref-type="aff" rid="aff01"/>
+					
+ 
+				</contrib>
+				
+ 
+				<contrib contrib-type="author">
+					
+ 
+					<name>
+						
+ 
+						<surname>Santos</surname>
+						
+ 
+						<given-names>Marisa</given-names>
+						
+ 
+					</name>
+					
+ 
+					<role>ND</role>
+					
+ 
+					<xref ref-type="aff" rid="aff01"/>
+					
+ 
+				</contrib>
+				
+ 
+			</contrib-group>
+			
+ 
+			<aff id="aff01">
+				
+ 
+				<addr-line>
+					
+ 
+					<named-content content-type="city">Florianópolis</named-content>
+					
+ 
+					<named-content content-type="state">Santa Catarina</named-content>
+					
+ 
+				</addr-line>
+				
+ 
+				<institution content-type="orgname">Universidade Federal de Santa Catarina</institution>
+				
+ 
+				<institution content-type="orgdiv1">Departamento de Botânica </institution>
+				
+ 
+				<country country="BR">Brazil</country>
+				
+ 
+			</aff>
+			
+ 
+			<pub-date pub-type="epub-ppub">
+				
+ 
+				<month>03</month>
+				
+ 
+				<year>2011</year>
+				
+ 
+			</pub-date>
+			
+ 
+			<volume>25</volume>
+			
+ 
+			<issue>1</issue>
+			
+ 
+			<fpage>2</fpage>
+			
+ 
+			<lpage>10</lpage>
+			
+ 
+			<history>
+				
+ 
+				<date date-type="received">
+					
+ 
+					<day>14</day>
+					
+ 
+					<month>05</month>
+					
+ 
+					<year>2009</year>
+					
+ 
+				</date>
+				
+ 
+				<date date-type="accepted">
+					
+ 
+					<day>22</day>
+					
+ 
+					<month>09</month>
+					
+ 
+					<year>2010</year>
+					
+ 
+				</date>
+				
+ 
+			</history>
+			
+ 
+			<permissions>
+				
+ 
+				<license license-type="open-access" xlink:href="http://creativecommons.org/licenses/by-nc/4.0/" xml:lang="en">
+					
+ 
+					<license-p>This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License.</license-p>
+					
+ 
+				</license>
+				
+ 
+			</permissions>
+			
+ 
+			<abstract>
+				
+ 
+				<p>Aechmea lindenii (E. Morren) Baker var. lindenii (Bromeliaceae-Bromelioideae) ocorre em restingas e Floresta Pluvial de Encosta Atlântica em Santa Catarina e Nordeste do Rio Grande do Sul, BR. Pode ser encontrada total ou parcialmente exposta à irradiação solar e em distintas formas de vida - terrícola, rupícola e epifítica. O objetivo deste trabalho foi comparar morfoanatomicamente às características de folhas de A. lindenii var. lindenii em distintas condições ambientais. Foram coletadas, na Ilha de Santa Catarina (Florianópolis, SC), folhas de plantas terrícolas em restinga herbácea (alta irradiação solar), rupícolas de costões rochosos (alta irradiação solar), terrícolas e epifíticas de sub-bosques (baixa irradiação solar) de restinga arbórea e rupícolas de sub-bosque (baixa irradiação solar) de Floresta Pluvial de Encosta Atlântica. Foram mensurados comprimento, largura, área da lâmina e bainha foliar, densidade estomática, comprimento e largura das células-guarda, espessura total e das estruturas constituintes na lâmina foliar. As características anatômicas qualitativas são semelhantes nas distintas condições analisadas. A baixa irradiação solar determina maior expansão da área foliar, decorrente do alongamento da lâmina. Lâmina e bainha foliares têm maior largura sob alta irradiação. A densidade estomática foi maior em folhas de plantas sob alta irradiação solar. A espessura total da lâmina foliar foi menor em plantas terrícolas sob alta irradiação, porém não mostrou diferenças estatísticas significativas entre as outras condições.</p>
+				
+ 
+			</abstract>
+			
+ 
+			<trans-abstract xml:lang="en">
+				
+ 
+				<p>Aechmea lindenii (E. Morren) Baker var. lindenii (Bromeliaceae-Bromelioideae) occurs in restingas and hillside Atlantic rain forest in Santa Catarina and northeastern Rio Grande do Sul, Brazil. It is found totally or partially exposed to solar radiation and in different life forms - terricolous, rupicolous and epiphytes. The aim of this work was to compare morphoanatomical leaf characteristics of A. lindenii var. lindenii in distinct environmental conditions. On Santa Catarina Island (Florianópolis, SC), the following were collected: leaves of terricolous plants in the herbaceous restinga (high solar radiation), rupicolous from rocky coast (high solar radiation), terricolous and understory epiphytes (low solar radiation) in the arboreal restinga and understory rupicolous (low solar radiation) from hillside Atlantic rain forest. We measured length, breadth and area of leaf blade and sheath, stomatal density, length and breadth of guard-cells; width of leaf blade and structural components. Qualitative anatomical characteristics are similar in the distinct conditions analyzed. Low solar radiation determined greater expansion of the leaf area, due to stretching of the blade. Leaf blade and sheath have greater breadth under high solar radiation. Stomatal density was greater in leaves of plants in high solar radiation. Total blade leaf width was smaller in leaves of terricolous plants under high solar radiation, nevertheless, statistically significant differences were not found among other conditions.</p>
+				
+ 
+			</trans-abstract>
+			
+ 
+			<kwd-group kwd-group-type="author-generated" xml:lang="en">
+				
+ 
+				<kwd>Responses to solar radiation, restinga</kwd>
+				
+ 
+				<kwd>Atlantic rain forest</kwd>
+				
+ 
+				<kwd>life forms</kwd>
+				
+ 
+			</kwd-group>
+			
+ 
+			<kwd-group kwd-group-type="author-generated" xml:lang="pt">
+				
+ 
+				<kwd>Respostas à irradiação solar, restinga</kwd>
+				
+ 
+				<kwd>Floresta Pluvial Atlântica</kwd>
+				
+ 
+				<kwd>formas de vida</kwd>
+				
+ 
+			</kwd-group>
+			
+ 
+			<counts>
+				
+ 
+				<fig-count count="0"/>
+				
+ 
+				<table-count count="0"/>
+				
+ 
+				<equation-count count="0"/>
+				
+ 
+				<ref-count count="41"/>
+				
+ 
+				<page-count count="9"/>
+				
+ 
+			</counts>
+			
+ 
+		</article-meta>
+		
+ 
+	</front>
+	
+ 
+	<body>
+		<p>
+			<bold>ARTIGOS</bold>
+			 ARTICLES
+		</p>
+		 
+		<p>
+			<bold>
+				Variações na morfoanatomia foliar de 
+				<italic>Aechmea lindenii</italic>
+				 (E. Morren) Baker var. 
+				<italic>lindenii</italic>
+				 (Bromeliaceae) sob distintas condições ambientais
+				<xref>
+					<sup>1</sup>
+				</xref>
+			</bold>
+		</p>
+		 
+		<p>
+			<bold>
+				Leaf morphoanatomy variation in 
+				<italic>Aechmea lindenii</italic>
+				 (E. Morren) Baker var. 
+				<italic>lindenii</italic>
+				 (Bromeliaceae) under distinct environmental conditions
+			</bold>
+		</p>
+		 
+		<p>
+			<bold>
+				Caroline Heinig Voltolini
+				<xref>
+					<sup>2</sup>
+				</xref>
+				; Marisa Santos
+			</bold>
+		</p>
+		 
+		<p>Universidade Federal de Santa Catarina, Departamento de Botânica, Florianópolis, SC, Brasil</p>
+		 
+		<p>
+			<bold>RESUMO</bold>
+		</p>
+		 
+		<p>
+			<italic>Aechmea lindenii</italic>
+			 (E. Morren) Baker var. 
+			<italic>lindenii</italic>
+			 (Bromeliaceae-Bromelioideae) ocorre em restingas e Floresta Pluvial de Encosta Atlântica em Santa Catarina e Nordeste do Rio Grande do Sul, BR. Pode ser encontrada total ou parcialmente exposta à irradiação solar e em distintas formas de vida - terrícola, rupícola e epifítica. O objetivo deste trabalho foi comparar morfoanatomicamente às características de folhas de 
+			<italic>A. lindenii</italic>
+			 var. 
+			<italic>lindenii</italic>
+			 em distintas condições ambientais. Foram coletadas, na Ilha de Santa Catarina (Florianópolis, SC), folhas de plantas terrícolas em restinga herbácea (alta irradiação solar), rupícolas de costões rochosos (alta irradiação solar), terrícolas e epifíticas de sub-bosques (baixa irradiação solar) de restinga arbórea e rupícolas de sub-bosque (baixa irradiação solar) de Floresta Pluvial de Encosta Atlântica. Foram mensurados comprimento, largura, área da lâmina e bainha foliar, densidade estomática, comprimento e largura das células-guarda, espessura total e das estruturas constituintes na lâmina foliar. As características anatômicas qualitativas são semelhantes nas distintas condições analisadas. A baixa irradiação solar determina maior expansão da área foliar, decorrente do alongamento da lâmina. Lâmina e bainha foliares têm maior largura sob alta irradiação. A densidade estomática foi maior em folhas de plantas sob alta irradiação solar. A espessura total da lâmina foliar foi menor em plantas terrícolas sob alta irradiação, porém não mostrou diferenças estatísticas significativas entre as outras condições.
+		</p>
+		 
+		<p>
+			<bold>Palavras-chave:</bold>
+			 Respostas à irradiação solar, restinga, Floresta Pluvial Atlântica, formas de vida
+		</p>
+		 
+		<p>
+			<bold>ABSTRACT</bold>
+		</p>
+		 
+		<p>
+			<italic>Aechmea lindenii</italic>
+			 (E. Morren) Baker var. 
+			<italic>lindenii</italic>
+			 (Bromeliaceae-Bromelioideae) occurs in restingas and hillside Atlantic rain forest in Santa Catarina and northeastern Rio Grande do Sul, Brazil. It is found totally or partially exposed to solar radiation and in different life forms - terricolous, rupicolous and epiphytes. The aim of this work was to compare morphoanatomical leaf characteristics of 
+			<italic>A. lindenii</italic>
+			 var. 
+			<italic>lindenii</italic>
+			 in distinct environmental conditions. On Santa Catarina Island (Florianópolis, SC), the following were collected: leaves of terricolous plants in the herbaceous restinga (high solar radiation), rupicolous from rocky coast (high solar radiation), terricolous and understory epiphytes (low solar radiation) in the arboreal restinga and understory rupicolous (low solar radiation) from hillside Atlantic rain forest. We measured length, breadth and area of leaf blade and sheath, stomatal density, length and breadth of guard-cells; width of leaf blade and structural components. Qualitative anatomical characteristics are similar in the distinct conditions analyzed. Low solar radiation determined greater expansion of the leaf area, due to stretching of the blade. Leaf blade and sheath have greater breadth under high solar radiation. Stomatal density was greater in leaves of plants in high solar radiation. Total blade leaf width was smaller in leaves of terricolous plants under high solar radiation, nevertheless, statistically significant differences were not found among other conditions.
+		</p>
+		 
+		<p>
+			<bold>Key words:</bold>
+			 Responses to solar radiation, restinga, Atlantic rain forest, life forms
+		</p>
+		 
+		<p>
+			<bold>Introdução</bold>
+		</p>
+		 
+		<p>
+			A família Bromeliaceae está amplamente distribuída nas Américas, especialmente nas regiões tropicais e subtropicais (Judd 
+			<italic>et al</italic>
+			. 1999, Benzing 2000). Tradicionalmente Bromeliaceae possui três subfamílias - Pitcairnioideae, Tillandsioideae e Bromelioideae (Reitz 1983), contudo estudos filogenéticos recentes indicam Pitcairnioideae como parafilética, sugerindo a inclusão de novas subfamílias (Givnish 
+			<italic>et al.</italic>
+			 2009). Em Bromelioideae, conforme referem Smith &amp; Downs (1979) e Reitz (1983), as plantas são geralmente epífitas, apresentando sistema radicular reduzido, o qual serve para fixação no substrato, porém a absorção de água e nutrientes é realizada por tricomas peltados irregulares, os quais recobrem a lâmina foliar; a margem foliar é inteira ou serrilhada; as folhas formam tanques basais onde há armazenamento de água. O gênero 
+			<italic>Aechmea</italic>
+			 Ruiz &amp; Pavon pertence à Bromelioideae, sendo constituído por cerca de 172 espécies (Smith &amp; Downs 1979, Reitz 1983). No Estado de Santa Catarina ocorrem 17 espécies de 
+			<italic>Aechmea</italic>
+			, entre elas 
+			<italic>A. lindenii</italic>
+			 (E. Morren) Baker, que possui duas variedades: 
+			<italic>makoyana</italic>
+			 e 
+			<italic>lindenii</italic>
+			 (Reitz 1983). O autor refere que 
+			<italic>A. lindenii</italic>
+			 var. 
+			<italic>lindenii</italic>
+			, é endêmica do litoral de Santa Catarina e do Nordeste do Rio Grande do Sul (Torres), ocorrendo desde restingas até florestas de encostas. O autor ainda menciona que esta variedade pode ocorrer como epifítica, rupícola e terrícola (Reitz 1983). Lenzi 
+			<italic>et al</italic>
+			. (2006) constataram variações morfológicas e reprodutivas entre 
+			<italic>A. lindenii</italic>
+			 var. 
+			<italic>lindenii</italic>
+			 presente em ambientes de restinga herbácea (alta irradiação solar), sub-bosque de restinga arbórea (baixa irradiação solar).
+		</p>
+		 
+		<p>
+			Diversos fatores limitantes para o estabelecimento e desenvolvimento de espécies vegetais são observados na restinga, em ambientes de dunas costeiras ocorrem fatores de estresse como borrifos marinhos, soterramento por areia, inundações, seca, alta irradiação solar, altas temperaturas, exposição ao vento, salinidade e deficiência nutricional (Hesp 1991). Respostas adaptativas, expressas em estratégias morfoanatômicas e fisiológicas, permitem a sobrevivência das plantas sob distintas condições ambientais (Lambers 
+			<italic>et al.</italic>
+			 1998). Podem ocorrer aclimatações na estrutura de folhas maduras afetadas pelo nível de irradiação solar (quantidade e qualidade), ao qual estão expostas durante o desenvolvimento (Dickison 2000).
+		</p>
+		 
+		<p>
+			Atuais pesquisas envolvendo anatomia de outras espécies de 
+			<italic>Aechmea,</italic>
+			 em sua maioria abordam aspectos taxonômicos e alguns filogenéticos e ecológicos (Scarano 
+			<italic>et al.</italic>
+			 2002, Aoyama &amp; Sajo 2003, Proença &amp; Sajo 2004, Sousa 
+			<italic>et al</italic>
+			. 2005, Horres 
+			<italic>et al.</italic>
+			 2007).
+		</p>
+		 
+		<p>
+			Este estudo abordará a anatomia de folhas de 
+			<italic>Aechmea lindenii</italic>
+			 (E. Morren) Baker var. 
+			<italic>lindenii</italic>
+			, sob diferentes exposições à irradiação solar (alta, em restinga herbácea e baixa em restinga arbórea) e com distintas formas de vida - terrícola, rupícola e epifítica. A investigação pretende contribuir para o melhor entendimento da biologia e adaptações desta espécie relacionadas às diferentes condições de sobrevivência.
+		</p>
+		 
+		<p>
+			<bold>Material e métodos</bold>
+		</p>
+		 
+		<p>
+			Para o estudo foram utilizadas folhas totalmente expandidas de 
+			<italic>Aechmea lindenni</italic>
+			 (E. Morren) Baker var. 
+			<italic>lindenni</italic>
+			 de no mínimo 5 plantas adultas por condição analisada. Exemplares do táxon estudado nos diferentes pontos de coleta, após identificação, foram depositados no Herbário FLOR (UFSC, Florianópolis, SC) sob números: 36.272, 36.275, 36.276, 36.277 e 36.871.
+		</p>
+		 
+		<p>
+			As coletas do material foram realizadas na Ilha de Santa Catarina (Florianópolis, SC, Brasil), que está situada entre as latitudes 27°22&amp;#x27;45&amp;#x27;&amp;#x27; e 27°50&amp;#x27;10&amp;#x27;&amp;#x27; e longitude 48°21&amp;#x27;37&amp;#x27;&amp;#x27; e 48°34&amp;#x27;49&amp;#x27;&amp;#x27;(
+			<xref>Fig. 1-2</xref>
+			), possui um clima do tipo Cfa, de acordo com Köeppen, subtropical úmido, com temperatura média anual de 20°C (Atlas de Santa Catarina 1986). A precipitação total anual é de 1400 mm, sem déficit hídrico (há excedente anual de 400-600 mm) e a umidade relativa anual é de 80-85% (Atlas de Santa Catarina 1986).
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/abb/v25n1/02f01a03.jpg"/>
+		</p>
+		<p>
+			<inline-graphic xlink:href="/img/revistas/abb/v25n1/02f04a06.jpg"/>
+		</p>
+		 
+		<p>
+			Para cada condição analisada (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02t01.jpg">Tab. 1</ext-link>
+			), foi mensurada a irradiância com quantômetro LI-COR Model LI-250 
+			<italic>light meter</italic>
+			 utilizando-se a metodologia conforme Scarano 
+			<italic>et al.</italic>
+			 (2002). A análise do teor de matéria orgânica foi realizado, em triplicata, no Laboratório Físico Químico e Biológico da Companhia Integrada de Desenvolvimento Agrícola de Santa Catarina- CIDASC. Solos com teor de matéria orgânica até 1,5% são classificados como nível baixo; de 1,6 a 3,0%, nível médio; e acima de 3,0%, nível alto (Guimarães 
+			<italic>et al.</italic>
+			 1980).
+		</p>
+		 
+		<p>
+			Para avaliar a área foliar média, de cada folha, foram delineados os contornos das lâminas foliares, em papel 75g/m
+			<sup>2</sup>
+			, com densidade constante (tamanho ofício padrão). Os moldes foram recortados e medidos em balança digital. A massa destes moldes foi relacionada à massa de área conhecida em cm
+			<sup>2</sup>
+			 do mesmo papel, para a determinação da área foliar em cm
+			<sup>2</sup>
+			. Foram medidas as dimensões da lâmina e bainha foliar: comprimento (C = eixo longitudinal, desde a base até o ápice) e largura (L = eixo transversal, de bordo a bordo, na região média).
+		</p>
+		 
+		<p>Os terços médios da lâmina e da bainha foliar, foram seccionados paradérmica, transversal e longitudinalmente, na porção central entre bordos. As amostras foram analisadas em microscópio Leica MPS 30 DMLS e as imagens foram capturadas com câmara digital Sony P92.</p>
+		 
+		<p>
+			Foram feitas secções à mão-livre, nas amostras, com auxílio de lâmina de barbear, para confecção de lâminas temporárias, com água, e semipermanentes, com gelatina-glicerinada (Kaiser 1880, 
+			<italic>apud</italic>
+			 Kraus &amp; Arduin 1997), estas foram utilizadas para a determinação da densidade estomática e dimensões das células-guarda. A contagem do número de estômatos por área, em regiões sulcadas da lâmina foliar, foi obtida projetando as imagens, com câmara clara acoplada ao microscópio óptico CarlZeiss Jena, sobre área delimitada conhecida. Imagens das células-guarda projetadas foram medidas para determinar as dimensões. Pequenas amostras foram fixadas em glutaraldeído 2,5%, em tampão fosfato de sódio 0,1M, em pH 7,2, por três horas. Após o material foi lavado, por três vezes em tampão fosfato de sódio e mantido, por três dias, em etilenodiamina 10% (Carlquist 1982). Após este período, o material foi lavado em água destilada e desidratado em série etílica gradual e conservado em etanol 70 oGL. Estas amostras fixadas e desidratadas foram infiltradas em historresina (hidroxietilmetacrilato, 
+			<italic>Jung&amp;#x27;s Historesin</italic>
+			 - marca Leica). Blocos de historresina, contendo o material, foram seccionados com 5 μm de espessura, em micrótomo de rotação Leica - RM 2125 RT. As secções foram distendidas sobre lâminas de vidro contendo água, em chapa aquecedora (40 oC). Após a secagem das lâminas, o material foi corado com azul de toluidina 0,25% aquoso (Ruzin 1999). Estas foram utilizadas para a determinação da espessura da lâmina foliar e estruturas constituintes através de imagens capturadas em microscópio óptico e as medidas realizadas com auxílio do programa computacional ANATI-QUANTI (Aguiar 
+			<italic>et al.</italic>
+			 2007).
+		</p>
+		 
+		<p>
+			Para todos os estudos quantitativos foram determinados o número mínimo amostral pela equação n=(t
+			<sup>2</sup>
+			.s
+			<sup>2</sup>
+			).d
+			<sup>-2</sup>
+			, onde &quot;t&quot; é dado pela tabela de Student (considerando n-1, para significância de 0,05), &quot;s&quot; é o desvio padrão e &quot;s&quot; é igual a E/100.média, onde E=10 para 10% de probabilidade, valor considerado satisfatório (Sokal &amp; Rohlf 1969). Foram avaliadas a normalidade dos dados com o teste Shapiro-wilk e a homogeneidade das variâncias com o teste Levene através dos programas computacionais BioEstat 5.0 (Ayres 
+			<italic>et al.</italic>
+			 2007) e Statistica 7.0 (Statistica 2004), respectivamente. Após foram aplicadas transformações, quando necessário, e os dados obtidos para os cinco tratamentos foram comparados por análise de variância ANOVA (one-way), seguido por teste Tukey (ao nível de significância de 5%), quando paramétricos ou por análise Kruskal-Wallis seguido de teste DUM, quando não-paramétricos, através dos programas computacionais Statistica 7.0. e BioEstat 5.0, respectivamente.
+		</p>
+		 
+		<p>
+			<bold>Resultados e discussão</bold>
+		</p>
+		 
+		<p>
+			<italic>Aechmea lindenii</italic>
+			 var. 
+			<italic>lindenii</italic>
+			 possui aspecto rosetado decorrente da filotaxia espiralada e tem bainhas foliares imbricadas (
+			<xref>Fig. 1-6</xref>
+			), o que favorece o acúmulo de água. As folhas são perenes, têm forma lanceolada, sendo constituídas por lâmina, com espinhos marginais, e bainha. Os espinhos marginais são rígidos e recurvados sendo raros ou ausentes na bainha. Morfologicamente, a delimitação entre lâmina e bainha é caracterizada por tênue saliência. A face adaxial da bainha é levemente arroxeada. A filotaxia espiralada é característica da família Bromeliaceae (Benzing 1980). Algumas adaptações foliares em bromélias garantem suprimento de água e nutrientes em ambientes nos quais as raízes são prioritariamente fixadoras (epifíticas e rupícolas), em algumas espécies há presença de folhas estreitas e densamente cobertas por tricomas, os quais absorvem água e nutrientes quando a superfície está úmida enquanto que em outras espécies, bainhas amplas e imbricadas, formando um tanque onde acumulam água e detritos além dos tricomas absorventes (Benzing 
+			<italic>et al.</italic>
+			 1976; Benzing 2000).
+		</p>
+		 
+		<p>
+			As lâminas foliares de 
+			<italic>A. lindenii</italic>
+			 var. 
+			<italic>lindenii</italic>
+			 mostram-se mais alongadas sob baixa irradiação solar, em relação àquelas sob alta irradiação, determinando aumento na área, embora com menor largura (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02t02.jpg">Tab. 2</ext-link>
+			). Maior expansão da superfície de folhas de sombra, em relação às de sol, é amplamente referido na literatura (Parkhurst &amp; Loucks 1972, Lambers 
+			<italic>et al.</italic>
+			1998, Cao 2000, Rôças 
+			<italic>et al.</italic>
+			 2001), o que favorece a captação de fótons (Lee 
+			<italic>et al.</italic>
+			 1996). A bainha foliar apresenta maior largura e maior área sob alta irradiação (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02t02.jpg">Tab. 2</ext-link>
+			). Plantas sob alta irradiação solar possuem folhas mais imbricadas (
+			<xref>Fig.1-2</xref>
+			), em decorrência da maior largura da bainha, fator este que favorece a melhor formação do tanque de reserva de água. Lenzi 
+			<italic>et al</italic>
+			. (2006) relatam que folhas de 
+			<italic>A. lindenii</italic>
+			 var. 
+			<italic>lindenii</italic>
+			 em ambientes de restinga herbácea (totalmente expostas à irradiação solar) são mais curtas, largas e coriáceas em relação as de restinga arbórea (sombreadas), estas mais longas, estreitas e membranáceas.
+		</p>
+		 
+		<p>
+			As folhas de 
+			<italic>A. lindenii</italic>
+			 var. 
+			<italic>lindenii</italic>
+			 independente do grau de exposição à irradiação solar e da forma de vida apresentam característica anatômicas qualitativas semelhantes. Na lâmina foliar ocorrem tricomas peltados em ambas as faces (
+			<xref>Fig.7-8</xref>
+			) e estômatos restritos à face abaxial em regiões sulcadas (
+			<xref>Fig. 8-9</xref>
+			). A epiderme é uniestratificada e apresenta corpos silicosos (
+			<xref>Fig. 10</xref>
+			), paredes anticlinais sinuosas e membrana cuticular espessa. Em posição subepidermica, ocorre esclerênquima, hidrênquima, clorênquima, feixes vasculares e cordões de fibras extra-vasculares (
+			<xref>Fig. 11-15</xref>
+			). A disposição dos tecidos na bainha foliar de 
+			<italic>A. lindenii</italic>
+			 var. 
+			<italic>lindenii</italic>
+			 é semelhante à lâmina, com exceção da presença de aerênquima entre os feixes vasculares (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02f16a18.jpg">Fig. 16-18</ext-link>
+			), menor alongamento das células do hidrênquima e ocorrência rara de clorênquima. Diversos autores observaram em Bromeliaceae células epidérmicas com paredes sinuosas em vista frontal, epiderme uniestratificada, presença de corpos silicosos e membrana cuticular delgada (Krauss 1949, Tomlinson 1969, Aoyama &amp; Sajo 2003, Proença &amp; Sajo 2004, Sousa 
+			<italic>et al</italic>
+			. 2005, Proença &amp; Sajo 2007). Corpos silicosos têm sido relacionados à proteção da planta contra herbivoria por serem indigestos e a economia hídrica por otimizar a refração de luz reduzindo desta forma a transpiração (Krauss 1949, Yoshida 
+			<italic>et al.</italic>
+			 1962). A presença de clorênquima, hidrênquima e cordões de fibras extra-vasculares é referida para a lâmina foliar em outras espécies de 
+			<italic>Aechmea</italic>
+			 estudadas (Aoyama &amp; Sajo 2003, Proença &amp; Sajo 2004, Sousa 
+			<italic>et al.</italic>
+			 2005).
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/abb/v25n1/02f07a8.jpg"/>
+		</p>
+		<p>
+			<inline-graphic xlink:href="/img/revistas/abb/v25n1/02f09a10.jpg"/>
+		</p>
+		 
+		<p/>
+		 
+		<p>
+			<inline-graphic xlink:href="/img/revistas/abb/v25n1/02f11a12.jpg"/>
+		</p>
+		<p>
+			<inline-graphic xlink:href="/img/revistas/abb/v25n1/02f13a14.jpg"/>
+		</p>
+		<p>
+			<inline-graphic xlink:href="/img/revistas/abb/v25n1/02f15.jpg"/>
+		</p>
+		 
+		<p>
+			As espessuras das estruturas e tecidos constituintes da lâmina foliar de 
+			<italic>A. lindenii</italic>
+			 var. 
+			<italic>lindenii</italic>
+			 (membrana cuticular, célula epidérmica, esclerênquima, hidrênquima e clorênquima) mostram variações peculiares, que somadas resultam em diferenças ou semelhanças na espessura total da lâmina. Lâminas foliares menos espessas foram observadas em plantas terrícolas sob alta irradiação solar (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02t03.jpg">Tab. 3</ext-link>
+			). Entre as demais condições analisadas neste estudo, inclusive para plantas rupícolas sob alta irradiação solar comparadas àquelas sob baixa irradiação, não foram verificadas diferenças estatisticamente significativas (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02t03.jpg">Tab. 3</ext-link>
+			). A espessura do hidrênquima, tecido de reserva hídrica, atinge maior dimensão nas folhas sob baixa irradiação solar (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02t03.jpg">Tab. 3</ext-link>
+			). Resultados que contrariam o que usualmente é referido na literatura. Folhas de sol são mais espessas que folhas de sombra, destacando-se o maior espessamento cuticular e do parênquima paliçádico, bem como dos tecidos de reserva hídrica (Lamber 
+			<italic>et al</italic>
+			. 1998, Dickison 2000, Taiz &amp; Zeiger 2004, Mantuano 
+			<italic>et al.</italic>
+			 2006, Terashima 
+			<italic>et al</italic>
+			. 2006). Contudo em folhas de 
+			<italic>A. bromeliifolia</italic>
+			 (Rudge) Baker (Bromeliaceae), quando em ambientes secos, o hidrênquima é mais espesso em plantas sombreadas do que naquelas totalmente expostas à irradiação solar (Scarano 
+			<italic>et al.</italic>
+			 2002).
+		</p>
+		 
+		<p>
+			Com relação ao clorênquima, comparando a mesma forma de vida, plantas rupícolas apresentam maior espessura quando sob alta irradiação, correspondendo ao usualmente referido na literatura, entretanto nas terrícolas ocorre o contrário (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02t03.jpg">Tab. 3</ext-link>
+			). Lee 
+			<italic>et al.</italic>
+			 (1989) ressaltam que folhas mais expostas à irradiação tendem a ampliar os tecidos clorofilados. Scarano 
+			<italic>et al</italic>
+			. (2002) comparando plantas de 
+			<italic>A. bromeliifolia</italic>
+			 desenvolvidas em ambiente seco e sujeito ao alagamento observaram que a espessura do clorênquima nas folhas reflete interações que não estão diretamente relacionadas com distintos níveis de exposição solar. Em ambiente seco, as folhas de plantas sombreadas apresentavam maior espessura do clorênquima em relação àquelas sob alta irradiação solar, enquanto que em ambientes sujeitos ao alagamento foi observado o oposto, folhas sob alta irradiação mostraram maior espessura deste tecido em relação às sombreadas (Scarano 
+			<italic>et al</italic>
+			. 2002)
+		</p>
+		 
+		<p>
+			A maior espessura da membrana cuticular e das células epidérmicas ocorre sob alta irradiação, em ambas as faces da folha, nas terrícolas (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02t03.jpg">Tab. 3</ext-link>
+			). Em rupícolas, na face adaxial, apenas as células epidérmicas mostram-se mais espessas e, na face abaxial, apenas a membrana cuticular (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02t03.jpg">Tab. 3</ext-link>
+			). Comparando as espessuras destas estruturas das epífitas em relação às demais condições (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02t03.jpg">Tab. 3</ext-link>
+			), constata-se maior similaridade às plantas sob baixa irradiação, embora, na face adaxial, a espessura da membrana cuticular não é distinta das rupícolas sob alta irradiação e a espessura das células epidérmicas distingue-se também das rupícolas sob baixa irradiação. Tais fatos apontam para alguma interação entre a forma de vida, epifítica ou rupícola, e a intensidade de irradiação. Diversos autores, entre eles Napp-Zinn (1984) e Fahn &amp; Cutler (1992), mencionam que folhas de sol mostram maior espessura de membrana cuticular. Mantuano 
+			<italic>et al.</italic>
+			 (2006) verificou células epidérmicas adaxiais mais espessas em folhas de plantas de 
+			<italic>Erythroxylum ovalifolium</italic>
+			 Peyr (dicotiledônea-Erythroxilaceae) mais expostas à irradiação solar quando comparadas às daquelas sombreadas. Tanto a espessura da membrana cuticular da face abaxial, devido à posição mais ereta da folha, quanto das células epidérmicas adaxiais, podem ter uma função de proteção em condições de alta irradiação solar. Em ambientes de alta irradiação solar estratégias estruturais como diminuição dos ângulos foliares e o auto-sombreamento auxiliam na fotoproteção minimizando os danos potenciais por fotoinibição (Pearcy 
+			<italic>et al.</italic>
+			 2005).
+		</p>
+		 
+		<p>
+			Com relação à espessura do esclerênquima em folhas de 
+			<italic>A. lindenii</italic>
+			 var. 
+			<italic>lindenii</italic>
+			, há diferenças entre os tratamentos, em ambas faces, entretanto, é mais marcante a maior espessura deste tecido subepidérmico na face abaxial das rupícolas sob alta irradiação (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02t03.jpg">Tab. 3</ext-link>
+			). Os tecidos subepidérmicos esclerenquimáticos, além do importante papel na sustentação das folhas (Krauss 1949), também podem contribuir para o bloqueio do excesso de irradiação, amenizando o excesso de luz e calor. Plantas rupícolas sob alta irradiação solar recebem ventos fortes diretos provenientes do mar, enquanto que as terrícolas sob alta irradiação são protegidas pelas dunas frontais, que servem como barreiras aos ventos. Nas plantas sob baixa irradiação, a força do vento é amenizada pela proteção da vegetação no entorno.
+		</p>
+		 
+		<p>
+			A densidade estomática é maior nas folhas mais expostas à irradiação (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02t03.jpg">Tab. 3</ext-link>
+			). A densidade de tricomas reduz com a irradiação (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02t03.jpg">Tab. 3</ext-link>
+			), auxiliando na formação do microclima na região dos estômatos. As células-guarda expandem-se mais longitudinalmente nas folhas sob baixa irradiação, em relação àquelas sob alta irradiação, se considerada a mesma forma de vida (
+			<ext-link ext-link-type="uri" xlink:href="/img/revistas/abb/v25n1/02t03.jpg">Tab. 3</ext-link>
+			). O comprimento das células-guarda em lâminas foliares de plantas epifíticas, sob baixa irradiação, só diferiu das rupícolas sob alta irradiação. As plantas epifíticas em muitas das características analisadas mostram um padrão intermediário entre características de plantas sob alta e baixa irradiação solar. De acordo com Abrans 
+			<italic>et al.</italic>
+			 (1992), a menor expansão das células-guarda pode minimizar a perda de água em situações de maior irradiação solar no ambiente. Em 
+			<italic>A. lindenii</italic>
+			 var. 
+			<italic>lindenii,</italic>
+			 o comprimento da célula-guarda deve estar relacionado com as características intrínsecas das folhas de monocotiledôneas, uma vez que os estômatos orientam-se longitudinalmente e há tendência a maior desenvolvimento sentido base-ápiceDe modo geral a influência das distintas formas de vida não se mostrou tão evidente nas características morfoanatômicas de 
+			<italic>A. lindenii</italic>
+			 var. 
+			<italic>lindenii</italic>
+			 quanto o nível de irradiação solar.
+		</p>
+		 
+		<p>
+			<bold>Agradecimentos</bold>
+		</p>
+		 
+		<p>À Coordenação de Auxílio à Pesquisa de Ensino Superior (CAPES) pela bolsa de mestrado concedida à primeira autora. Ao Conselho Nacional de Desenvolvimento Científico e Tecnológico (CNPq) pela bolsa de produtividade em pesquisa à segunda autora (proc. 481623/2007-8) e auxílio financeiro (proc. 303351/2008-0).</p>
+		 
+		<p>
+			<bold>Referências Bibliográficas</bold>
+		</p>
+		 
+		<p>
+			Abrans, M.C.; Kloeppel, B.D. &amp;amp; Kubiske, M.E. 1992. Ecophysiological and morphological responses to shade and drought in two contrasting ecotypes of 
+			<italic>Prunus setorina</italic>
+			. 
+			<bold>Tree Physiology 10</bold>
+			: 343-355. 
+		</p>
+		 
+		<p>
+			Aguiar, T.V.; Sant&amp;#x27;anna-Santos, B.F.; Azevedo, A.A. &amp;amp; Ferreira, R.S. 2007. ANATI QUANTI: Software de análises quantitativas para estudos em anatomia vegetal. 
+			<bold>Planta Daninha 25</bold>
+			: 649-659. 
+		</p>
+		 
+		<p>
+			Aoyama, E.M &amp;amp; Sajo, M.G. 2003. Estrutura foliar de 
+			<italic>Aechmea</italic>
+			 Ruiz &amp; Pav. subgênero 
+			<italic>Lamprococcus</italic>
+			 (Beer) Baker e espécies relacionadas (Bromeliaceae). 
+			<bold>Revista Brasileira de Botânica 26</bold>
+			: 461-473. 
+		</p>
+		 
+		<p>
+			<bold>Atlas de Santa Catarina</bold>
+			. 1986. Gabinete de Planejamento e Coordenação Geral. Subchefia de Estatística, Geografia e Informática. Rio de Janeiro, Aerofoto Cruzeiro. 
+		</p>
+		 
+		<p>
+			Ayres, M.; Ayres, Júnior M.; Ayres D.L. &amp;amp; Santos, A.S. 2007. 
+			<bold>BioEstat 5.0: Aplicações estatísticas nas áreas das ciências biológicas e médicas.</bold>
+			 Belém, Sociedade Civil Mamiraúa/CNPq. 
+		</p>
+		 
+		<p>
+			Benzing, D.H. 1980. 
+			<bold>The Biology of the Bromeliads</bold>
+			. Califórnia, Mad River Press. 
+		</p>
+		 
+		<p>
+			Benzing, D.H. 2000. 
+			<bold>Bromeliaceae: Profile of an Adaptative Radiation.</bold>
+			 USA, Cambridge University Press. 
+		</p>
+		 
+		<p>
+			Benzing, D.H.; Henderson, K.; Kessel, B. &amp;amp; Sulak, J. 1976. The absortive capacities of bromeliad trichomes. 
+			<bold>American Journal of Botany 63</bold>
+			: 1009-1014. 
+		</p>
+		 
+		<p>
+			Cao, K.F. 2000. Leaf anatomy and chlorophyll content of 12 woody species in contrasting light conditions in a Bornean heath forest. 
+			<bold>Canadian Journal of Botany 78</bold>
+			: 1245-1253. 
+		</p>
+		 
+		<p>
+			Carlquist, S. 1982. The use of ethylenediamine in softening hard plant structures for paraffin sectioning. 
+			<bold>Stain Technology 57</bold>
+			: 311-317. 
+		</p>
+		 
+		<p>
+			Dickison, W.C. 2000. 
+			<bold>Integrative Plant Anatomy.</bold>
+			 Califórnia, Academic Press. 
+		</p>
+		 
+		<p>
+			Fahn, A. &amp;amp; Cutler, D.F. 1992. 
+			<bold>Xerophytes.</bold>
+			 Berlin, Gebrüder Borntraeger. 
+		</p>
+		 
+		<p>
+			Givnish, T.J.; Millan K.C.; Berry, P.E. &amp;amp; Sytsma, K.J. 2007. Phylogeny, adaptive radiation, and historical biogeography of Bromeliaceae inferred from 
+			<italic>ndh</italic>
+			F sequence data. 
+			<bold>Aliso 23</bold>
+			: 3-26. 
+		</p>
+		 
+		<p>
+			Guimarães, P.T.G.; Ferreira, J.G.; Carvalho, J.G &amp;amp; Lopes, A.S. 1980. Adubação de pastagens. 
+			<bold>Informe Agropecuário 70</bold>
+			: 34-52. 
+		</p>
+		 
+		<p>
+			Hesp, A.P. 1991. Ecological processes and plant adaptions on coastal dunes. 
+			<bold>Journal of Arid Enviromments 21</bold>
+			: 165-191. 
+		</p>
+		 
+		<p>
+			Horres, R.; Schulte, K.; Weising, K. &amp;amp; Zizka, G. 2007. Systematics of Bromelioideae (Bromeliaceae) evidence from molecular and anatomical studies. 
+			<bold>Aliso 23</bold>
+			: 27-43. 
+		</p>
+		 
+		<p>
+			Judd, W.S.; Campbell, C.S.; Kellogg, E.A. &amp;amp; Stevens, P.F. 1999. 
+			<bold>Plant Systematics: a phylogenetic approach.</bold>
+			 USA, Sinauer Associates. 
+		</p>
+		 
+		<p>
+			Kraus, J.E &amp;amp; Arduin, M. 1997. 
+			<bold>Manual Básico de Métodos em Morfologia Vegetal.</bold>
+			 Seropédica, Editora Universidade Rural. 
+		</p>
+		 
+		<p>
+			Krauss, B.H. 1949. Anatomy of the vegetative organs of the pineapple, 
+			<italic>Ananas comosus</italic>
+			 (L) Merr. (continued) II. The leaf. 
+			<bold>Botanical Gazette 110</bold>
+			: 303-404. 
+		</p>
+		 
+		<p>
+			Lambers, H.; Stuart, F. &amp;amp; Pons, T.L. 1998. 
+			<bold>Plant Physiological Ecology</bold>
+			. New York, Springers-Verlag. 
+		</p>
+		 
+		<p>
+			Lee, D.W.; Baskaran, K. Mansor, M.; Mohamad, H. &amp;amp; Yap, S. K. 1996. Irradiance and spectral quality effect Asian tropical rain forest tree seedling development. 
+			<bold>Ecology 77</bold>
+			: 568-580. 
+		</p>
+		 
+		<p>
+			Lee, H.S.J.; Lüttge, U.; Medina, E.; Smith, J.A.C.; Cram, W.J.; Diaz, M.; Grifûths, H.; Popp, M.; Schäfer, C.; Stimmel, K-H. &amp;amp;, Thonke, B. 1989. Ecophysiology of xerophytic and halophytic vegetation of a coastal alluvial plain in northern Venezuela III - 
+			<italic>Bromelia humilis</italic>
+			 Jacq. a terrestrial CAM bromeliad. 
+			<bold>New Phytologist 111</bold>
+			: 253-271. 
+		</p>
+		 
+		<p>
+			Lenzi, M.; Matos J.M. &amp;amp; Orth, A.I. 2006. Variação morfológica e reprodutiva de 
+			<italic>Aechmea lindenii</italic>
+			 (E. Morren) Baker var. 
+			<italic>lindenii</italic>
+			 (Bromeliaceae). 
+			<bold>Acta Botanica Brasilica 20</bold>
+			: 487-500. 
+		</p>
+		 
+		<p>
+			Mantuano, D.G.; Barros, C.F. &amp;amp; Scarano, F.R. 2006. Leaf anatomy variation within and between three &amp;quot;restinga&amp;quot; populations of 
+			<italic>Erythroxylum ovalifolium</italic>
+			 Peyr. (Erythroxylaceae) in Southeast Brazil. 
+			<bold>Revista Brasileira de Botânica 29</bold>
+			: 209-215. 
+		</p>
+		 
+		<p>
+			Napp-Zinn, K. 1984. 
+			<bold>Handbuch der Pflanzenanatomie. VIII Anatomie des Blattes,</bold>
+			 2. Blattanatomie der Angiospermen, B. Experimentelle und ökologishe Anatomie des Angiospermenblattes. Berlin, Gbdr. Borntraeger. 
+		</p>
+		 
+		<p>
+			Parkhurst, D.F. &amp;amp; Loucks, O.L. 1972. Optimal leaf size in relation to environment. 
+			<bold>Journal of Ecology 60</bold>
+			: 505-537. 
+		</p>
+		 
+		<p>
+			Pearcy, R.W.; Muraoka, H. &amp;amp; Valladares, F. 2005. Crown architecture in sun and shade environments: assessing function and trade-offs with a three-dimensional simulation mode. 
+			<bold>New Phytologist 166</bold>
+			: 791-800. 
+		</p>
+		 
+		<p>
+			Proença, S.L. &amp;amp; Sajo, M.G. 2004. Estrutura foliar de espécies de 
+			<italic>Aechmea</italic>
+			 Ruiz &amp; Pav. (Bromeliaceae) do Estado de São Paulo, Brasil. 
+			<bold>Acta Botanica Brasilica 18</bold>
+			: 319-331. 
+		</p>
+		 
+		<p>
+			Proença, S.L. &amp;amp; Sajo, M.G. 2007. Anatomia foliar de bromélias ocorrentes em áreas de cerrado do Estado de São Paulo, SP. 
+			<bold>Acta Botanica Brasilica 21</bold>
+			: 657-673. 
+		</p>
+		 
+		<p>
+			Reitz, R. 1983. Bromeliáceas e a Malária-Bromélia Endêmica. In: 
+			<bold>Flora Ilustrada Catarinense</bold>
+			. Parte I. Fascículo Bromélia. 
+		</p>
+		 
+		<p>
+			Rôças, G.; Scarano, F.R. &amp;amp; Barros, C.F. 2001. Leaf anatomical variation in 
+			<italic>Alchornea triplinervia</italic>
+			 (Spreng) Müll. Arg. (Euphorbiaceae) under distinct light and soil water regimes. 
+			<bold>Botanical Journal of the Linnean Society 136</bold>
+			: 231-238. 
+		</p>
+		 
+		<p>
+			Ruzin, S.E. 1999. 
+			<bold>Plant Microtechnique and Microscopy</bold>
+			. New York, Oxford University Press. 
+		</p>
+		 
+		<p>
+			Scarano, F.R.; Duarte, H.M.; Rôças, G.; Barreto, S.M.B.; Amado, E.F.; Reinert, F.; Wendt, T.; Mantovani, A.; Lima H.R.P. &amp;amp; Barros, C.F. 2002. Acclimation or stress symptom? An integrated study of intraspecific variation in the clonal plant 
+			<italic>Aechmea bromeliifolia</italic>
+			, a widespread CAM tank-bromeliad. 
+			<bold>Botanical Journal of the Linnean Society 140</bold>
+			: 391-401. 
+		</p>
+		 
+		<p>
+			Smith, L.B. &amp;amp; Downs, R.J. 1979. Bromelioideae (Bromeliaceae). 
+			<bold>Flora Neotropica Monograph 14</bold>
+			: 1493-2142. 
+		</p>
+		 
+		<p>
+			Sokal, R.R. &amp;amp; Rohlf, F.J. 1969. 
+			<bold>Biometry</bold>
+			. San Francisco, Freeman and Company. 
+		</p>
+		 
+		<p>
+			Sousa, G.M.; Estelita, M.E.M. &amp;amp; Wanderley, M.G.L. 2005. Anatomia foliar de espécies brasileiras de 
+			<italic>Aechmea</italic>
+			 subg. 
+			<italic>Chevaliera</italic>
+			 (Gaudich. 
+			<italic>ex</italic>
+			 Beer) Baker, Bromelioideae-Bromelioideae. 
+			<bold>Revista Brasileira Botânica 28</bold>
+			: 603-613. 
+		</p>
+		 
+		<p>
+			<bold>Statistica</bold>
+			. 2004. StatSoft, Inc. (data analysis software system), version 7. 
+		</p>
+		 
+		<p>
+			Taiz, L. &amp;amp; Zeiger, E. 2004. 
+			<bold>Fisiologia Vegetal</bold>
+			. 3a ed. Porto Alegre, Artmed Editora. 
+		</p>
+		 
+		<p>
+			Terashima, I; Miyazawa, S-I &amp;amp; Handa, Y.T. 2006. Why are sun leaves thicker than shade leaves? Consideration based on analyses of CO
+			<sub>2</sub>
+			 diffusion in the leaf. 
+			<bold>Journal of Plant Research 114</bold>
+			: 93-105. 
+		</p>
+		 
+		<p>
+			Tomlinson, P.B. 1969. 
+			<bold>Anatomy of the monocotyledons: III Commmelinales-Zingiberales</bold>
+			. Oxford, Oxford University Press. 
+		</p>
+		 
+		<p>
+			Yoshida, S.; Ohnishi, Y. &amp;amp; Kitagishi, K. 1962. Histochemistry of silicon in rice plant. III. The presence of cuticle-silica double layer in the epidermal tissue. 
+			<bold>Soil Science And Plant Nutricion 8</bold>
+			: 1-5. 
+		</p>
+		 
+		<p>Recebido em 14/05/2009. </p>
+		<p> Aceito em 22/09/2010</p>
+		 
+		<p>
+			<xref>1</xref>
+			 Parte da dissertação de Mestrado da primeira Autora 
+		</p>
+		<p>
+			<xref>2</xref>
+			 Autora para correspondência: 
+			<ext-link ext-link-type="email" xlink:href="mailto:carolinevoltolini@gmail.com">carolinevoltolini@gmail.com</ext-link>
+		</p>
+	</body>
+	
+ 
+	<back>
+		
+ 
+		<ref-list>
+			
+ 
+			<ref id="B1">
+				
+ 
+				<mixed-citation>
+					Abrans, M.C.; Kloeppel, B.D. &amp; Kubiske, M.E. 1992. Ecophysiological and morphological responses to shade and drought in two contrasting ecotypes of 
+					<italic>Prunus setorina</italic>
+					. 
+					<bold>Tree Physiology 10</bold>
+					: 343-355.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Ecophysiological and morphological responses to shade and drought in two contrasting ecotypes of Prunus setorina</article-title>
+					
+ 
+					<source>Tree Physiology</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1992</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>343</fpage>
+					
+ 
+					<lpage>355</lpage>
+					
+ 
+					<volume>10</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Abrans</surname>
+							
+ 
+							<given-names>M.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Kloeppel</surname>
+							
+ 
+							<given-names>B.D.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Kubiske</surname>
+							
+ 
+							<given-names>M.E.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B2">
+				
+ 
+				<mixed-citation>
+					Aguiar, T.V.; Sant'anna-Santos, B.F.; Azevedo, A.A. &amp; Ferreira, R.S. 2007. ANATI QUANTI: Software de análises quantitativas para estudos em anatomia vegetal. 
+					<bold>Planta Daninha 25</bold>
+					: 649-659.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>ANATI QUANTI: Software de análises quantitativas para estudos em anatomia vegetal</article-title>
+					
+ 
+					<source>Planta Daninha</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2007</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>649</fpage>
+					
+ 
+					<lpage>659</lpage>
+					
+ 
+					<volume>25</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Aguiar</surname>
+							
+ 
+							<given-names>T.V.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Sant'anna-Santos</surname>
+							
+ 
+							<given-names>B.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Azevedo</surname>
+							
+ 
+							<given-names>A.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Ferreira</surname>
+							
+ 
+							<given-names>R.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B3">
+				
+ 
+				<mixed-citation>
+					Aoyama, E.M &amp; Sajo, M.G. 2003. Estrutura foliar de 
+					<italic>Aechmea</italic>
+					 Ruiz &amp; Pav. subgênero 
+					<italic>Lamprococcus</italic>
+					 (Beer) Baker e espécies relacionadas (Bromeliaceae). 
+					<bold>Revista Brasileira de Botânica 26</bold>
+					: 461-473.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Estrutura foliar de Aechmea Ruiz &amp; Pav. subgênero Lamprococcus (Beer) Baker e espécies relacionadas (Bromeliaceae)</article-title>
+					
+ 
+					<source>Revista Brasileira de Botânica</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2003</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>461</fpage>
+					
+ 
+					<lpage>473</lpage>
+					
+ 
+					<volume>26</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Aoyama</surname>
+							
+ 
+							<given-names>E.M</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Sajo</surname>
+							
+ 
+							<given-names>M.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B4">
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Gabinete de Planejamento e Coordenação Geral: Subchefia de Estatística, Geografia e Informática</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1986</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B5">
+				
+ 
+				<mixed-citation>
+					Ayres, M.; Ayres, Júnior M.; Ayres D.L. &amp; Santos, A.S. 2007. 
+					<bold>BioEstat 5.0: Aplicações estatísticas nas áreas das ciências biológicas e médicas.</bold>
+					 Belém, Sociedade Civil Mamiraúa/CNPq.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>BioEstat 5.0: Aplicações estatísticas nas áreas das ciências biológicas e médicas</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2007</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Ayres</surname>
+							
+ 
+							<given-names>M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Ayres</surname>
+							
+ 
+							<given-names>Júnior M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Ayres</surname>
+							
+ 
+							<given-names>D.L.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Santos</surname>
+							
+ 
+							<given-names>A.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B6">
+				
+ 
+				<mixed-citation>
+					Benzing, D.H. 1980. 
+					<bold>The Biology of the Bromeliads</bold>
+					. Califórnia, Mad River Press.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>The Biology of the Bromeliads</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1980</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Benzing</surname>
+							
+ 
+							<given-names>D.H.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B7">
+				
+ 
+				<mixed-citation>
+					Benzing, D.H. 2000. 
+					<bold>Bromeliaceae: Profile of an Adaptative Radiation.</bold>
+					 USA, Cambridge University Press.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Bromeliaceae: Profile of an Adaptative Radiation</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2000</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Benzing</surname>
+							
+ 
+							<given-names>D.H.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B8">
+				
+ 
+				<mixed-citation>
+					Benzing, D.H.; Henderson, K.; Kessel, B. &amp; Sulak, J. 1976. The absortive capacities of bromeliad trichomes. 
+					<bold>American Journal of Botany 63</bold>
+					: 1009-1014.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>The absortive capacities of bromeliad trichomes</article-title>
+					
+ 
+					<source>American Journal of Botany</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1976</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>1009</fpage>
+					
+ 
+					<lpage>1014</lpage>
+					
+ 
+					<volume>63</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Benzing</surname>
+							
+ 
+							<given-names>D.H.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Henderson</surname>
+							
+ 
+							<given-names>K.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Kessel</surname>
+							
+ 
+							<given-names>B.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Sulak</surname>
+							
+ 
+							<given-names>J.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B9">
+				
+ 
+				<mixed-citation>
+					Cao, K.F. 2000. Leaf anatomy and chlorophyll content of 12 woody species in contrasting light conditions in a Bornean heath forest. 
+					<bold>Canadian Journal of Botany 78</bold>
+					: 1245-1253.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Leaf anatomy and chlorophyll content of 12 woody species in contrasting light conditions in a Bornean heath forest</article-title>
+					
+ 
+					<source>Canadian Journal of Botany</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2000</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>1245</fpage>
+					
+ 
+					<lpage>1253</lpage>
+					
+ 
+					<volume>78</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Cao</surname>
+							
+ 
+							<given-names>K.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B10">
+				
+ 
+				<mixed-citation>
+					Carlquist, S. 1982. The use of ethylenediamine in softening hard plant structures for paraffin sectioning. 
+					<bold>Stain Technology 57</bold>
+					: 311-317.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>The use of ethylenediamine in softening hard plant structures for paraffin sectioning</article-title>
+					
+ 
+					<source>Stain Technology</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1982</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>311</fpage>
+					
+ 
+					<lpage>317</lpage>
+					
+ 
+					<volume>57</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Carlquist</surname>
+							
+ 
+							<given-names>S.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B11">
+				
+ 
+				<mixed-citation>
+					Dickison, W.C. 2000. 
+					<bold>Integrative Plant Anatomy.</bold>
+					 Califórnia, Academic Press.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Integrative Plant Anatomy</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2000</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Dickison</surname>
+							
+ 
+							<given-names>W.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B12">
+				
+ 
+				<mixed-citation>
+					Fahn, A. &amp; Cutler, D.F. 1992. 
+					<bold>Xerophytes.</bold>
+					 Berlin, Gebrüder Borntraeger.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Xerophytes</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1992</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Fahn</surname>
+							
+ 
+							<given-names>A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Cutler</surname>
+							
+ 
+							<given-names>D.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B13">
+				
+ 
+				<mixed-citation>
+					Givnish, T.J.; Millan K.C.; Berry, P.E. &amp; Sytsma, K.J. 2007. Phylogeny, adaptive radiation, and historical biogeography of Bromeliaceae inferred from 
+					<italic>ndh</italic>
+					F sequence data. 
+					<bold>Aliso 23</bold>
+					: 3-26.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Phylogeny, adaptive radiation, and historical biogeography of Bromeliaceae inferred from ndhF sequence data</article-title>
+					
+ 
+					<source>Aliso</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2007</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>3</fpage>
+					
+ 
+					<lpage>26</lpage>
+					
+ 
+					<volume>23</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Givnish</surname>
+							
+ 
+							<given-names>T.J.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Millan</surname>
+							
+ 
+							<given-names>K.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Berry</surname>
+							
+ 
+							<given-names>P.E.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Sytsma</surname>
+							
+ 
+							<given-names>K.J.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B14">
+				
+ 
+				<mixed-citation>
+					Guimarães, P.T.G.; Ferreira, J.G.; Carvalho, J.G &amp; Lopes, A.S. 1980. Adubação de pastagens. 
+					<bold>Informe Agropecuário 70</bold>
+					: 34-52.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Adubação de pastagens</article-title>
+					
+ 
+					<source>Informe Agropecuário</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1980</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>34</fpage>
+					
+ 
+					<lpage>52</lpage>
+					
+ 
+					<volume>70</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Guimarães</surname>
+							
+ 
+							<given-names>P.T.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Ferreira</surname>
+							
+ 
+							<given-names>J.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Carvalho</surname>
+							
+ 
+							<given-names>J.G</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Lopes</surname>
+							
+ 
+							<given-names>A.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B15">
+				
+ 
+				<mixed-citation>
+					Hesp, A.P. 1991. Ecological processes and plant adaptions on coastal dunes. 
+					<bold>Journal of Arid Enviromments 21</bold>
+					: 165-191.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Ecological processes and plant adaptions on coastal dunes</article-title>
+					
+ 
+					<source>Journal of Arid Enviromments</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1991</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>165</fpage>
+					
+ 
+					<lpage>191</lpage>
+					
+ 
+					<volume>21</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Hesp</surname>
+							
+ 
+							<given-names>A.P.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B16">
+				
+ 
+				<mixed-citation>
+					Horres, R.; Schulte, K.; Weising, K. &amp; Zizka, G. 2007. Systematics of Bromelioideae (Bromeliaceae) evidence from molecular and anatomical studies. 
+					<bold>Aliso 23</bold>
+					: 27-43.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Systematics of Bromelioideae (Bromeliaceae) evidence from molecular and anatomical studies</article-title>
+					
+ 
+					<source>Aliso</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2007</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>27</fpage>
+					
+ 
+					<lpage>43</lpage>
+					
+ 
+					<volume>23</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Horres</surname>
+							
+ 
+							<given-names>R.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Schulte</surname>
+							
+ 
+							<given-names>K.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Weising</surname>
+							
+ 
+							<given-names>K.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Zizka</surname>
+							
+ 
+							<given-names>G.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B17">
+				
+ 
+				<mixed-citation>
+					Judd, W.S.; Campbell, C.S.; Kellogg, E.A. &amp; Stevens, P.F. 1999. 
+					<bold>Plant Systematics: a phylogenetic approach.</bold>
+					 USA, Sinauer Associates.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Plant Systematics: a phylogenetic approach</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1999</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Judd</surname>
+							
+ 
+							<given-names>W.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Campbell</surname>
+							
+ 
+							<given-names>C.S.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Kellogg</surname>
+							
+ 
+							<given-names>E.A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Stevens</surname>
+							
+ 
+							<given-names>P.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B18">
+				
+ 
+				<mixed-citation>
+					Kraus, J.E &amp; Arduin, M. 1997. 
+					<bold>Manual Básico de Métodos em Morfologia Vegetal.</bold>
+					 Seropédica, Editora Universidade Rural.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Manual Básico de Métodos em Morfologia Vegetal</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1997</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Kraus</surname>
+							
+ 
+							<given-names>J.E</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Arduin</surname>
+							
+ 
+							<given-names>M.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B19">
+				
+ 
+				<mixed-citation>
+					Krauss, B.H. 1949. Anatomy of the vegetative organs of the pineapple, 
+					<italic>Ananas comosus</italic>
+					 (L) Merr. (continued) II. The leaf. 
+					<bold>Botanical Gazette 110</bold>
+					: 303-404.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Anatomy of the vegetative organs of the pineapple, Ananas comosus (L) Merr. (continued) II: The leaf</article-title>
+					
+ 
+					<source>Botanical Gazette</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1949</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>303</fpage>
+					
+ 
+					<lpage>404</lpage>
+					
+ 
+					<volume>110</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Krauss</surname>
+							
+ 
+							<given-names>B.H.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B20">
+				
+ 
+				<mixed-citation>
+					Lambers, H.; Stuart, F. &amp; Pons, T.L. 1998. 
+					<bold>Plant Physiological Ecology</bold>
+					. New York, Springers-Verlag.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Plant Physiological Ecology</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1998</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Lambers</surname>
+							
+ 
+							<given-names>H.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Stuart</surname>
+							
+ 
+							<given-names>F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Pons</surname>
+							
+ 
+							<given-names>T.L.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B21">
+				
+ 
+				<mixed-citation>
+					Lee, D.W.; Baskaran, K. Mansor, M.; Mohamad, H. &amp; Yap, S. K. 1996. Irradiance and spectral quality effect Asian tropical rain forest tree seedling development. 
+					<bold>Ecology 77</bold>
+					: 568-580.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Irradiance and spectral quality effect Asian tropical rain forest tree seedling development</article-title>
+					
+ 
+					<source>Ecology</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1996</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>568</fpage>
+					
+ 
+					<lpage>580</lpage>
+					
+ 
+					<volume>77</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Lee</surname>
+							
+ 
+							<given-names>D.W.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Baskaran</surname>
+							
+ 
+							<given-names>K.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Mansor</surname>
+							
+ 
+							<given-names>M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Mohamad</surname>
+							
+ 
+							<given-names>H.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Yap</surname>
+							
+ 
+							<given-names>S. K.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B22">
+				
+ 
+				<mixed-citation>
+					Lee, H.S.J.; Lüttge, U.; Medina, E.; Smith, J.A.C.; Cram, W.J.; Diaz, M.; Grifûths, H.; Popp, M.; Schäfer, C.; Stimmel, K-H. &amp;, Thonke, B. 1989. Ecophysiology of xerophytic and halophytic vegetation of a coastal alluvial plain in northern Venezuela III - 
+					<italic>Bromelia humilis</italic>
+					 Jacq. a terrestrial CAM bromeliad. 
+					<bold>New Phytologist 111</bold>
+					: 253-271.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Ecophysiology of xerophytic and halophytic vegetation of a coastal alluvial plain in northern Venezuela III: Bromelia humilis Jacq. a terrestrial CAM bromeliad</article-title>
+					
+ 
+					<source>New Phytologist</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1989</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>253</fpage>
+					
+ 
+					<lpage>271</lpage>
+					
+ 
+					<volume>111</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Lee</surname>
+							
+ 
+							<given-names>H.S.J.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Lüttge</surname>
+							
+ 
+							<given-names>U.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Medina</surname>
+							
+ 
+							<given-names>E.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Smith</surname>
+							
+ 
+							<given-names>J.A.C.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Cram</surname>
+							
+ 
+							<given-names>W.J.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Diaz</surname>
+							
+ 
+							<given-names>M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Grifûths</surname>
+							
+ 
+							<given-names>H.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Popp</surname>
+							
+ 
+							<given-names>M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Schäfer</surname>
+							
+ 
+							<given-names>C.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Stimmel</surname>
+							
+ 
+							<given-names>K-H.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Thonke</surname>
+							
+ 
+							<given-names>B.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B23">
+				
+ 
+				<mixed-citation>
+					Lenzi, M.; Matos J.M. &amp; Orth, A.I. 2006. Variação morfológica e reprodutiva de 
+					<italic>Aechmea lindenii</italic>
+					 (E. Morren) Baker var. 
+					<italic>lindenii</italic>
+					 (Bromeliaceae). 
+					<bold>Acta Botanica Brasilica 20</bold>
+					: 487-500.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Variação morfológica e reprodutiva de Aechmea lindenii (E. Morren) Baker var. lindenii (Bromeliaceae)</article-title>
+					
+ 
+					<source>Acta Botanica Brasilica</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2006</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>487</fpage>
+					
+ 
+					<lpage>500</lpage>
+					
+ 
+					<volume>20</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Lenzi</surname>
+							
+ 
+							<given-names>M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Matos</surname>
+							
+ 
+							<given-names>J.M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Orth</surname>
+							
+ 
+							<given-names>A.I.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B24">
+				
+ 
+				<mixed-citation>
+					Mantuano, D.G.; Barros, C.F. &amp; Scarano, F.R. 2006. Leaf anatomy variation within and between three &quot;restinga&quot; populations of 
+					<italic>Erythroxylum ovalifolium</italic>
+					 Peyr. (Erythroxylaceae) in Southeast Brazil. 
+					<bold>Revista Brasileira de Botânica 29</bold>
+					: 209-215.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Leaf anatomy variation within and between three &quot;restinga&quot; populations of Erythroxylum ovalifolium Peyr. (Erythroxylaceae) in Southeast Brazil</article-title>
+					
+ 
+					<source>Revista Brasileira de Botânica</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2006</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>209</fpage>
+					
+ 
+					<lpage>215</lpage>
+					
+ 
+					<volume>29</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Mantuano</surname>
+							
+ 
+							<given-names>D.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Barros</surname>
+							
+ 
+							<given-names>C.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Scarano</surname>
+							
+ 
+							<given-names>F.R.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B25">
+				
+ 
+				<mixed-citation>
+					Napp-Zinn, K. 1984. 
+					<bold>Handbuch der Pflanzenanatomie. VIII Anatomie des Blattes,</bold>
+					 2. Blattanatomie der Angiospermen, B. Experimentelle und ökologishe Anatomie des Angiospermenblattes. Berlin, Gbdr. Borntraeger.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Handbuch der Pflanzenanatomie: VIII Anatomie des Blattes, 2. Blattanatomie der Angiospermen, B. Experimentelle und ökologishe Anatomie des Angiospermenblattes</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1984</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Napp-Zinn</surname>
+							
+ 
+							<given-names>K.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B26">
+				
+ 
+				<mixed-citation>
+					Parkhurst, D.F. &amp; Loucks, O.L. 1972. Optimal leaf size in relation to environment. 
+					<bold>Journal of Ecology 60</bold>
+					: 505-537.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Optimal leaf size in relation to environment</article-title>
+					
+ 
+					<source>Journal of Ecology</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1972</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>505</fpage>
+					
+ 
+					<lpage>537</lpage>
+					
+ 
+					<volume>60</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Parkhurst</surname>
+							
+ 
+							<given-names>D.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Loucks</surname>
+							
+ 
+							<given-names>O.L.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B27">
+				
+ 
+				<mixed-citation>
+					Pearcy, R.W.; Muraoka, H. &amp; Valladares, F. 2005. Crown architecture in sun and shade environments: assessing function and trade-offs with a three-dimensional simulation mode. 
+					<bold>New Phytologist 166</bold>
+					: 791-800.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Crown architecture in sun and shade environments: assessing function and trade-offs with a three-dimensional simulation mode</article-title>
+					
+ 
+					<source>New Phytologist</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2005</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>791</fpage>
+					
+ 
+					<lpage>800</lpage>
+					
+ 
+					<volume>166</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Pearcy</surname>
+							
+ 
+							<given-names>R.W.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Muraoka</surname>
+							
+ 
+							<given-names>H.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Valladares</surname>
+							
+ 
+							<given-names>F.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B28">
+				
+ 
+				<mixed-citation>
+					Proença, S.L. &amp; Sajo, M.G. 2004. Estrutura foliar de espécies de 
+					<italic>Aechmea</italic>
+					 Ruiz &amp; Pav. (Bromeliaceae) do Estado de São Paulo, Brasil. 
+					<bold>Acta Botanica Brasilica 18</bold>
+					: 319-331.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Estrutura foliar de espécies de Aechmea Ruiz &amp; Pav. (Bromeliaceae) do Estado de São Paulo, Brasil</article-title>
+					
+ 
+					<source>Acta Botanica Brasilica</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2004</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>319</fpage>
+					
+ 
+					<lpage>331</lpage>
+					
+ 
+					<volume>18</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Proença</surname>
+							
+ 
+							<given-names>S.L.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Sajo</surname>
+							
+ 
+							<given-names>M.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B29">
+				
+ 
+				<mixed-citation>
+					Proença, S.L. &amp; Sajo, M.G. 2007. Anatomia foliar de bromélias ocorrentes em áreas de cerrado do Estado de São Paulo, SP. 
+					<bold>Acta Botanica Brasilica 21</bold>
+					: 657-673.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Anatomia foliar de bromélias ocorrentes em áreas de cerrado do Estado de São Paulo, SP</article-title>
+					
+ 
+					<source>Acta Botanica Brasilica</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2007</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>657</fpage>
+					
+ 
+					<lpage>673</lpage>
+					
+ 
+					<volume>21</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Proença</surname>
+							
+ 
+							<given-names>S.L.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Sajo</surname>
+							
+ 
+							<given-names>M.G.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B30">
+				
+ 
+				<mixed-citation>
+					Reitz, R. 1983. Bromeliáceas e a Malária-Bromélia Endêmica. In: 
+					<bold>Flora Ilustrada Catarinense</bold>
+					. Parte I. Fascículo Bromélia.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Flora Ilustrada Catarinense: Parte I. Fascículo Bromélia</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1983</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Reitz</surname>
+							
+ 
+							<given-names>R.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B31">
+				
+ 
+				<mixed-citation>
+					Rôças, G.; Scarano, F.R. &amp; Barros, C.F. 2001. Leaf anatomical variation in 
+					<italic>Alchornea triplinervia</italic>
+					 (Spreng) Müll. Arg. (Euphorbiaceae) under distinct light and soil water regimes. 
+					<bold>Botanical Journal of the Linnean Society 136</bold>
+					: 231-238.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Leaf anatomical variation in Alchornea triplinervia (Spreng) Müll. Arg. (Euphorbiaceae) under distinct light and soil water regimes</article-title>
+					
+ 
+					<source>Botanical Journal of the Linnean Society</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2001</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>231</fpage>
+					
+ 
+					<lpage>238</lpage>
+					
+ 
+					<volume>136</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Rôças</surname>
+							
+ 
+							<given-names>G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Scarano</surname>
+							
+ 
+							<given-names>F.R.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Barros</surname>
+							
+ 
+							<given-names>C.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B32">
+				
+ 
+				<mixed-citation>
+					Ruzin, S.E. 1999. 
+					<bold>Plant Microtechnique and Microscopy</bold>
+					. New York, Oxford University Press.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Plant Microtechnique and Microscopy</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1999</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Ruzin</surname>
+							
+ 
+							<given-names>S.E.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B33">
+				
+ 
+				<mixed-citation>
+					Scarano, F.R.; Duarte, H.M.; Rôças, G.; Barreto, S.M.B.; Amado, E.F.; Reinert, F.; Wendt, T.; Mantovani, A.; Lima H.R.P. &amp; Barros, C.F. 2002. Acclimation or stress symptom? An integrated study of intraspecific variation in the clonal plant 
+					<italic>Aechmea bromeliifolia</italic>
+					, a widespread CAM tank-bromeliad. 
+					<bold>Botanical Journal of the Linnean Society 140</bold>
+					: 391-401.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Acclimation or stress symptom?: An integrated study of intraspecific variation in the clonal plant Aechmea bromeliifolia, a widespread CAM tank-bromeliad</article-title>
+					
+ 
+					<source>Botanical Journal of the Linnean Society</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2002</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>391</fpage>
+					
+ 
+					<lpage>401</lpage>
+					
+ 
+					<volume>140</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Scarano</surname>
+							
+ 
+							<given-names>F.R.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Duarte</surname>
+							
+ 
+							<given-names>H.M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Rôças</surname>
+							
+ 
+							<given-names>G.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Barreto</surname>
+							
+ 
+							<given-names>S.M.B.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Amado</surname>
+							
+ 
+							<given-names>E.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Reinert</surname>
+							
+ 
+							<given-names>F.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Wendt</surname>
+							
+ 
+							<given-names>T.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Mantovani</surname>
+							
+ 
+							<given-names>A.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Lima</surname>
+							
+ 
+							<given-names>H.R.P.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Barros</surname>
+							
+ 
+							<given-names>C.F.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B34">
+				
+ 
+				<mixed-citation>
+					Smith, L.B. &amp; Downs, R.J. 1979. Bromelioideae (Bromeliaceae). 
+					<bold>Flora Neotropica Monograph 14</bold>
+					: 1493-2142.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Bromelioideae (Bromeliaceae)</article-title>
+					
+ 
+					<source>Flora Neotropica Monograph</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1979</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>1493</fpage>
+					
+ 
+					<lpage>2142</lpage>
+					
+ 
+					<volume>14</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Smith</surname>
+							
+ 
+							<given-names>L.B.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Downs</surname>
+							
+ 
+							<given-names>R.J.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B35">
+				
+ 
+				<mixed-citation>
+					Sokal, R.R. &amp; Rohlf, F.J. 1969. 
+					<bold>Biometry</bold>
+					. San Francisco, Freeman and Company.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Biometry</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1969</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Sokal</surname>
+							
+ 
+							<given-names>R.R.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Rohlf</surname>
+							
+ 
+							<given-names>F.J.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B36">
+				
+ 
+				<mixed-citation>
+					Sousa, G.M.; Estelita, M.E.M. &amp; Wanderley, M.G.L. 2005. Anatomia foliar de espécies brasileiras de 
+					<italic>Aechmea</italic>
+					 subg. 
+					<italic>Chevaliera</italic>
+					 (Gaudich. 
+					<italic>ex</italic>
+					 Beer) Baker, Bromelioideae-Bromelioideae. 
+					<bold>Revista Brasileira Botânica 28</bold>
+					: 603-613.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Anatomia foliar de espécies brasileiras de Aechmea subg. Chevaliera (Gaudich. ex Beer) Baker, Bromelioideae-Bromelioideae</article-title>
+					
+ 
+					<source>Revista Brasileira Botânica</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2005</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>603</fpage>
+					
+ 
+					<lpage>613</lpage>
+					
+ 
+					<volume>28</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Sousa</surname>
+							
+ 
+							<given-names>G.M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Estelita</surname>
+							
+ 
+							<given-names>M.E.M.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Wanderley</surname>
+							
+ 
+							<given-names>M.G.L.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B37">
+				
+ 
+				<mixed-citation>
+					<bold>Statistica</bold>
+					. 2004. StatSoft, Inc. (data analysis software system), version 7.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Statistica</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2004</year>
+						
+ 
+					</date>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B38">
+				
+ 
+				<mixed-citation>
+					Taiz, L. &amp; Zeiger, E. 2004. 
+					<bold>Fisiologia Vegetal</bold>
+					. 3ª ed. Porto Alegre, Artmed Editora.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Fisiologia Vegetal</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2004</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Taiz</surname>
+							
+ 
+							<given-names>L.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Zeiger</surname>
+							
+ 
+							<given-names>E.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B39">
+				
+ 
+				<mixed-citation>
+					Terashima, I; Miyazawa, S-I &amp; Handa, Y.T. 2006. Why are sun leaves thicker than shade leaves? Consideration based on analyses of CO
+					<sub>2</sub>
+					 diffusion in the leaf. 
+					<bold>Journal of Plant Research 114</bold>
+					: 93-105.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Why are sun leaves thicker than shade leaves?: Consideration based on analyses of CO2 diffusion in the leaf</article-title>
+					
+ 
+					<source>Journal of Plant Research</source>
+					
+ 
+					<date>
+						
+ 
+						<year>2006</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>93</fpage>
+					
+ 
+					<lpage>105</lpage>
+					
+ 
+					<volume>114</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Terashima</surname>
+							
+ 
+							<given-names>I</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Miyazawa</surname>
+							
+ 
+							<given-names>S-I</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Handa</surname>
+							
+ 
+							<given-names>Y.T.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B40">
+				
+ 
+				<mixed-citation>
+					Tomlinson, P.B. 1969. 
+					<bold>Anatomy of the monocotyledons: III Commmelinales-Zingiberales</bold>
+					. Oxford, Oxford University Press.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="book">
+					
+ 
+					<source>Anatomy of the monocotyledons: III Commmelinales-Zingiberales</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1969</year>
+						
+ 
+					</date>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Tomlinson</surname>
+							
+ 
+							<given-names>P.B.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+			<ref id="B41">
+				
+ 
+				<mixed-citation>
+					Yoshida, S.; Ohnishi, Y. &amp; Kitagishi, K. 1962. Histochemistry of silicon in rice plant. III. The presence of cuticle-silica double layer in the epidermal tissue. 
+					<bold>Soil Science And Plant Nutricion 8</bold>
+					: 1-5.
+				</mixed-citation>
+				
+ 
+				<element-citation publication-type="journal">
+					
+ 
+					<article-title>Histochemistry of silicon in rice plant: III. The presence of cuticle-silica double layer in the epidermal tissue</article-title>
+					
+ 
+					<source>Soil Science And Plant Nutricion</source>
+					
+ 
+					<date>
+						
+ 
+						<year>1962</year>
+						
+ 
+					</date>
+					
+ 
+					<fpage>1</fpage>
+					
+ 
+					<lpage>5</lpage>
+					
+ 
+					<volume>8</volume>
+					
+ 
+					<person-group person-group-type="author">
+						
+ 
+						<name>
+							
+ 
+							<surname>Yoshida</surname>
+							
+ 
+							<given-names>S.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Ohnishi</surname>
+							
+ 
+							<given-names>Y.</given-names>
+							
+ 
+						</name>
+						
+ 
+						<name>
+							
+ 
+							<surname>Kitagishi</surname>
+							
+ 
+							<given-names>K.</given-names>
+							
+ 
+						</name>
+						
+ 
+					</person-group>
+					
+ 
+				</element-citation>
+				
+ 
+			</ref>
+			
+ 
+		</ref-list>
+		
+ 
+	</back>
+	
+
+</article>

--- a/tests/samples/any.xml
+++ b/tests/samples/any.xml
@@ -1,0 +1,1 @@
+<root><a><b>bar</b></a></root>

--- a/tests/test_processing_packing.py
+++ b/tests/test_processing_packing.py
@@ -1,0 +1,265 @@
+import os
+import shutil
+import unittest
+from unittest.mock import patch, ANY, Mock
+
+from lxml import etree
+from requests import HTTPError
+
+from documentstore_migracao.processing import (
+    packing,
+)
+from . import (
+    utils,
+    SAMPLES_PATH,
+    TEMP_TEST_PATH,
+    COUNT_SAMPLES_FILES,
+)
+
+
+class TestProcessingPacking(unittest.TestCase):
+
+    def test_packing_article_xml_missing_media(self):
+        with utils.environ(
+            VALID_XML_PATH=SAMPLES_PATH,
+            SPS_PKG_PATH=SAMPLES_PATH,
+            INCOMPLETE_SPS_PKG_PATH=SAMPLES_PATH,
+        ):
+            packing.packing_article_xml(
+                os.path.join(
+                    SAMPLES_PATH, "S0044-59672003000300002_sps_incompleto.xml")
+            )
+            files = set(os.listdir(
+                        os.path.join(
+                            SAMPLES_PATH,
+                            'S0044-59672003000300002_sps_incompleto_INCOMPLETE')))
+            self.assertEqual({
+                '1809-4392-aa-33-03-353-370-ga02fig01.gif',
+                '1809-4392-aa-33-03-353-370-ga02tab03.gif',
+                '1809-4392-aa-33-03-353-370-ga02fig02.jpg',
+                '1809-4392-aa-33-03-353-370-ga02tab04.gif',
+                '1809-4392-aa-33-03-353-370.err',
+                '1809-4392-aa-33-03-353-370-ga02fr01.gif',
+                '1809-4392-aa-33-03-353-370-ga02tab05.gif',
+                '1809-4392-aa-33-03-353-370.xml',
+                '1809-4392-aa-33-03-353-370-ga02tab02.gif'},
+                files)
+            self.assertEqual(9, len(files))
+
+    def test_packing_article_xml_has_media(self):
+        with utils.environ(
+            VALID_XML_PATH=SAMPLES_PATH,
+            SPS_PKG_PATH=SAMPLES_PATH,
+            INCOMPLETE_SPS_PKG_PATH=SAMPLES_PATH,
+        ):
+            packing.packing_article_xml(
+                os.path.join(
+                    SAMPLES_PATH, "S0044-59672003000300002_sps_completo.xml")
+            )
+            files = set(os.listdir(
+                        os.path.join(
+                            SAMPLES_PATH,
+                            'S0044-59672003000300002_sps_completo')))
+            self.assertEqual(
+                {
+                    '1809-4392-aa-33-03-353-370-ga02tab04.gif',
+                    '1809-4392-aa-33-03-353-370-ga02tab05.gif',
+                    '1809-4392-aa-33-03-353-370-ga02fig02.jpg',
+                    '1809-4392-aa-33-03-353-370-ga02tab02.gif',
+                    '1809-4392-aa-33-03-353-370-ga02tab03.gif',
+                    '1809-4392-aa-33-03-353-370-ga02fr01.gif',
+                    '1809-4392-aa-33-03-353-370.xml',
+                    '1809-4392-aa-33-03-353-370-ga02fig01.gif',
+                    '1809-4392-aa-33-03-353-370-ga02tab01a.gif',
+                    '1809-4392-aa-33-03-353-370-ga02tab01b.gif'},
+                files)
+            self.assertEqual(10, len(files))
+
+    def test_packing_article_xml_has_no_media(self):
+        with utils.environ(
+            VALID_XML_PATH=SAMPLES_PATH,
+            SPS_PKG_PATH=SAMPLES_PATH,
+            INCOMPLETE_SPS_PKG_PATH=SAMPLES_PATH,
+        ):
+            packing.packing_article_xml(
+                os.path.join(
+                    SAMPLES_PATH, "any.xml")
+            )
+            files = set(os.listdir(
+                        os.path.join(
+                            SAMPLES_PATH,
+                            'any')))
+            self.assertEqual({'any.xml'}, files)
+            self.assertEqual(1, len(files))
+
+    @patch("documentstore_migracao.processing.packing.packing_article_xml")
+    def test_packing_article_ALLxml(self, mk_packing_article_xml):
+
+        with utils.environ(VALID_XML_PATH=SAMPLES_PATH):
+            packing.packing_article_ALLxml()
+            mk_packing_article_xml.assert_called_with(ANY)
+            self.assertEqual(
+                len(mk_packing_article_xml.mock_calls), COUNT_SAMPLES_FILES
+            )
+
+    @patch("documentstore_migracao.processing.packing.packing_article_xml")
+    def test_packing_article_ALLxml_with_errors(self, mk_packing_article_xml):
+
+        mk_packing_article_xml.side_effect = [
+            PermissionError("Permission error message"),
+            OSError('OSError message'),
+            etree.Error(ANY),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            OSError('OSError message'),
+            None,
+            None,
+            ]
+
+        with utils.environ(VALID_XML_PATH=SAMPLES_PATH):
+            with self.assertLogs("documentstore_migracao.processing.packing") as log:
+                packing.packing_article_ALLxml()
+
+            msg = []
+            for log_message in log.output:
+                if "Falha no empacotamento" in log_message:
+                    msg.append(log_message)
+            self.assertEqual(len(msg), 4)
+
+
+class TestProcessingPackingDownloadAsset(unittest.TestCase):
+    def setUp(self):
+        if os.path.isdir(TEMP_TEST_PATH):
+            shutil.rmtree(TEMP_TEST_PATH)
+        os.makedirs(TEMP_TEST_PATH)
+
+        new_fname = 'novo'
+        dest_path = TEMP_TEST_PATH
+        self.dest_filename = os.path.join(dest_path, new_fname+'.gif')
+        if os.path.isfile(self.dest_filename):
+            os.unlink(self.dest_filename)
+
+    def tearDown(self):
+        shutil.rmtree(TEMP_TEST_PATH)
+
+    @patch("documentstore_migracao.utils.request.get")
+    def test_download_asset(self, request_get):
+        request_get.return_value.ok = True
+        request_get.return_value.content = b'conteudo'
+        old_path = '/img/en/scielobre.gif'
+        new_fname = 'novo'
+        dest_path = TEMP_TEST_PATH
+
+        self.assertFalse(os.path.isfile(self.dest_filename))
+        error = packing.download_asset(old_path, new_fname, dest_path)
+        self.assertIsNone(error)
+        with open(self.dest_filename) as fp:
+            self.assertTrue(fp.read(), b'conteudo')
+
+    @patch("documentstore_migracao.utils.request.get")
+    def test_download_asset_raise_HTTPError_exception(self, mk_request_get):
+        mk_request_get.side_effect = HTTPError
+        old_path = '/img/en/scielobre.gif'
+        new_fname = 'novo'
+        dest_path = TEMP_TEST_PATH
+
+        error = packing.download_asset(old_path, new_fname, dest_path)
+        self.assertIsNotNone(error)
+
+
+class TestProcessingPacking_PackingAssets(unittest.TestCase):
+    def setUp(self):
+        if os.path.isdir(TEMP_TEST_PATH):
+            shutil.rmtree(TEMP_TEST_PATH)
+        os.makedirs(TEMP_TEST_PATH)
+        self.good_pkg_path = os.path.join(TEMP_TEST_PATH, 'good')
+        self.bad_pkg_path = os.path.join(TEMP_TEST_PATH, 'bad')
+
+    def tearDown(self):
+        shutil.rmtree(TEMP_TEST_PATH)
+
+    @patch("documentstore_migracao.utils.request.get")
+    def test__packing_incomplete_package(self, mk_request_get):
+        asset_replacements = [
+            ('/img/revistas/a01.gif', 'f01'),
+            ('/img/revistas/a02.gif', 'f02'),
+        ]
+        m = Mock()
+        m.content = b'conteudo'
+        pkg_path = self.good_pkg_path
+        bad_pkg_path = self.bad_pkg_path
+        pkg_name = 'pacote_sps'
+
+        mk_request_get.side_effect = [
+            HTTPError('Error'),
+            m,
+        ]
+        result_path = packing.packing_assets(
+            asset_replacements, pkg_path, bad_pkg_path, pkg_name)
+        self.assertEqual(result_path, bad_pkg_path)
+        self.assertFalse(os.path.isdir(pkg_path))
+        self.assertEqual(
+            ['f02.gif', pkg_name+'.err'], os.listdir(bad_pkg_path))
+        with open(os.path.join(bad_pkg_path, pkg_name+'.err')) as fp:
+            self.assertEqual(
+                fp.read(),
+                '/img/revistas/a01.gif f01 Error')
+
+    @patch("documentstore_migracao.utils.request.get")
+    def test__packing_incomplete_package_same_dir(self, mk_request_get):
+        asset_replacements = [
+            ('/img/revistas/a01.gif', 'f01'),
+            ('/img/revistas/a02.gif', 'f02'),
+        ]
+        m = Mock()
+        m.content = b'conteudo'
+        pkg_path = self.good_pkg_path
+        bad_pkg_path = self.good_pkg_path
+        renamed_path = pkg_path + '_INCOMPLETE'
+        pkg_name = 'pacote_sps'
+        mk_request_get.side_effect = [
+            HTTPError('Error'),
+            m,
+        ]
+        result_path = packing.packing_assets(
+            asset_replacements, pkg_path, bad_pkg_path, pkg_name)
+        self.assertEqual(result_path, renamed_path)
+        self.assertFalse(os.path.isdir(pkg_path))
+        self.assertEqual(
+            ['f02.gif', pkg_name+'.err'], os.listdir(renamed_path))
+        with open(os.path.join(renamed_path, pkg_name+'.err')) as fp:
+            self.assertEqual(
+                fp.read(),
+                '/img/revistas/a01.gif f01 Error')
+
+    @patch("documentstore_migracao.utils.request.get")
+    def test__packing_complete_package(self, mk_request_get):
+        asset_replacements = [
+            ('/img/revistas/a01.gif', 'f01'),
+            ('/img/revistas/a02.gif', 'f02'),
+        ]
+        mk_request_get_result1 = Mock()
+        mk_request_get_result1.content = b'conteudo'
+        mk_request_get_result2 = Mock()
+        mk_request_get_result2.content = b'conteudo'
+
+        pkg_path = self.good_pkg_path
+        bad_pkg_path = self.bad_pkg_path
+        pkg_name = 'pacote_sps'
+        mk_request_get.side_effect = [
+            mk_request_get_result1,
+            mk_request_get_result2,
+        ]
+        result_path = packing.packing_assets(
+            asset_replacements, pkg_path, bad_pkg_path, pkg_name)
+        self.assertEqual(result_path, pkg_path)
+        self.assertFalse(os.path.isdir(bad_pkg_path))
+        self.assertEqual(
+            {'f01.gif', 'f02.gif'},
+            set(os.listdir(pkg_path)))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,14 +2,24 @@ import os
 import unittest
 from unittest.mock import patch
 from lxml import etree
-from documentstore_migracao.utils import files, xml, request, dicts, string
+from documentstore_migracao.utils import files, xml, request, dicts
 
 from . import SAMPLES_PATH, COUNT_SAMPLES_FILES
 
 
 class TestUtilsFiles(unittest.TestCase):
+    def test_extract_filename_ext_by_path(self):
+
+        filename, extension = files.extract_filename_ext_by_path(
+            "xml/conversion/S0044-59672014000400003/S0044-59672014000400003.pt.xml"
+        )
+        self.assertEqual(filename, "S0044-59672014000400003")
+        self.assertEqual(extension, ".xml")
+
     def test_xml_files_list(self):
-        self.assertEqual(len(files.xml_files_list(SAMPLES_PATH)), COUNT_SAMPLES_FILES)
+        self.assertEqual(
+            len(files.xml_files_list(SAMPLES_PATH)),
+            COUNT_SAMPLES_FILES)
 
     def test_read_file(self):
         data = files.read_file(
@@ -31,12 +41,12 @@ class TestUtilsFiles(unittest.TestCase):
 
         self.assertEqual(expected_text, text)
 
-    def test_write_file(self):
+    def test_write_binary_file(self):
         expected_text = b"<a><b>bar</b></a>"
         filename = "foo_test_binary.txt"
 
         try:
-            files.write_file_bynary(filename, expected_text)
+            files.write_file_binary(filename, expected_text)
 
             with open(filename, "rb") as f:
                 text = f.read()
@@ -121,6 +131,22 @@ class TestUtilsXML(unittest.TestCase):
                 expected = html.findall(".//%s" % tag)
                 self.assertFalse(expected)
 
+    def test_file2objXML(self):
+        file_path = os.path.join(SAMPLES_PATH, 'any.xml')
+        expected_text = "<root><a><b>bar</b></a></root>"
+        obj = xml.file2objXML(file_path)
+        self.assertIn(expected_text, str(etree.tostring(obj)))
+
+    def test_file2objXML_raise_OSError_for_filenotfound(self):
+        file_path = os.path.join(SAMPLES_PATH, 'none.xml')
+        with self.assertRaises(OSError):
+            xml.file2objXML(file_path)
+
+    def test_file2objXML_raise_XMLSyntaxError_for_filenotfound(self):
+        file_path = os.path.join(SAMPLES_PATH, 'file.txt')
+        with self.assertRaises(etree.XMLSyntaxError):
+            xml.file2objXML(file_path)
+
 
 class TestUtilsRequest(unittest.TestCase):
     @patch("documentstore_migracao.utils.request.requests")
@@ -146,13 +172,3 @@ class TestUtilsDicts(unittest.TestCase):
     def test_grouper(self):
         result = dicts.grouper(3, "abcdefg", "x")
         self.assertEqual(list(result)[0], ("a", "b", "c"))
-
-
-class TestUtilsStrings(unittest.TestCase):
-    def test_extract_filename_ext_by_path(self):
-
-        filename, extension = string.extract_filename_ext_by_path(
-            "xml/conversion/S0044-59672014000400003/S0044-59672014000400003.pt.xml"
-        )
-        self.assertEqual(filename, "S0044-59672014000400003")
-        self.assertEqual(extension, ".xml")


### PR DESCRIPTION
#### O que esse PR faz?
Disponibiliza um comando para produzir os pacotes SciELO PS a partir dos XML validados, renomeando-os de acordo com as recomendações SPS. Também trocando os nomes dos ativos digitais e suas respectivas referências (xlink:href) dentro do XML. 

Os pacotes gerados por completo são gerados dentro da pasta `SPS_PKG_PATH`, dentro do subdiretório dado pelo PID. Exemplo:
```sps_packages/S0102-33062011000100002```

Os pacotes que faltam ativos digitais são movidos para dentro da pasta `INCOMPLETE_SPS_PKG_PATH`

#### Onde a revisão poderia começar?
documentstore_migracao/main.py

#### Como este poderia ser testado manualmente?
- ```python setup.py test -s tests/test_processing_packing.py```
- ```documentstore_migracao -p tests/samples/S0102-33062011000100002.pt.xml```
- ```documentstore_migracao -P``` (gera os pacotes de todos os XML que estiverem na pasta ```VALID_XML_PATH```)

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
<img width="368" alt="Captura de Tela 2019-04-18 às 11 54 09" src="https://user-images.githubusercontent.com/505143/56369961-bb00e280-61d0-11e9-9210-9346535efb86.png">

#### Quais são tickets relevantes?
#18 

### Referências
N/A
