### PR TITLE
Cria uma função que extrai do XML a data de publicação

### DIFF
--- a/documentstore_migracao/utils/string.py
+++ b/documentstore_migracao/utils/string.py
@@ -1,9 +1,7 @@
 """ module to methods to string format """
 import re
 import unicodedata
-import string
-import os
-from datetime import datetime
+
 from math import log2, ceil
 from uuid import UUID, uuid4
 
@@ -12,22 +10,14 @@ DIGIT_CHARS = "bcdfghjkmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ3456789"
 chars_map = {dig: idx for idx, dig in enumerate(DIGIT_CHARS)}
 
 
-def normalize(string):
+def normalize(_string):
 
-    return unicodedata.normalize("NFKD", " ".join(string.split()))
-
-
-def remove_spaces(string):
-
-    return re.sub(" +", " ", string).strip()
+    return unicodedata.normalize("NFKD", " ".join(_string.split()))
 
 
-def extract_filename_ext_by_path(inputFilepath):
+def remove_spaces(_string):
 
-    filename_w_ext = os.path.basename(inputFilepath)
-    c_filename, file_extension = os.path.splitext(filename_w_ext)
-    filename, _ = os.path.splitext(c_filename)
-    return filename, file_extension
+    return re.sub(" +", " ", _string).strip()
 
 
 def uuid2str(value):

--- a/documentstore_migracao/utils/xml.py
+++ b/documentstore_migracao/utils/xml.py
@@ -109,3 +109,27 @@ def get_languages(obj_xml):
     return obj_xml.xpath(
         '/article/@xml:lang | //sub-article[@article-type="translation"]/@xml:lang'
     )
+
+
+def get_document_publication_date_for_migration(obj_xml):
+    
+    def format(item):
+        if item:
+            return item.zfill(2)
+
+    pubdate_xpaths = (
+        'pub-date[@pub-type="epub"]',
+        'pub-date[@date-type="pub"]',
+        'pub-date',
+    )
+
+    article_meta = obj_xml.find('.//article-meta')
+    if article_meta is None:
+        raise ValueError('XML não possui article-meta')
+
+    for xpath in pubdate_xpaths:
+        pubdate = article_meta.find(xpath)
+        if pubdate is not None:
+            items = [format(pubdate.findtext(elem_name))
+                     for elem_name in ['year', 'month', 'day']]
+            return '-'.join([item for item in items if item])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -174,13 +174,6 @@ class TestUtilsDicts(unittest.TestCase):
 
 
 class TestUtilsStrings(unittest.TestCase):
-    def test_extract_filename_ext_by_path(self):
-
-        filename, extension = string.extract_filename_ext_by_path(
-            "xml/conversion/S0044-59672014000400003/S0044-59672014000400003.pt.xml"
-        )
-        self.assertEqual(filename, "S0044-59672014000400003")
-        self.assertEqual(extension, ".xml")
 
     def test_uuid2str(self):
         uuid = "585b0b68-aa1d-41ab-8f19-aaa37c516337"
@@ -197,3 +190,179 @@ class TestUtilsStrings(unittest.TestCase):
         mk_uuid4.return_value = UUID("585b0b68-aa1d-41ab-8f19-aaa37c516337")
 
         self.assertEqual(string.generate_scielo_pid(), "FX6F3cbyYmmwvtGmMB7WCgr")
+
+
+class TestGetPublicationDate(unittest.TestCase):
+
+    def test_pubdate_pubtype_epub(self):
+        _xml = """<root>
+            <article-meta>
+                <pub-date pub-type="collection">
+                    <year>2011</year>
+                </pub-date>
+                <pub-date pub-type="epub">
+                    <year>2010</year>
+                    <month>1</month>
+                    <day>9</day>
+                </pub-date>
+            </article-meta>
+        </root>
+        """
+        article_xml = etree.fromstring(_xml)
+        self.assertEqual(
+            xml.get_document_publication_date_for_migration(article_xml),
+            '2010-01-09')
+
+    def test_pubdate_datetype_pub(self):
+        _xml = """<root>
+            <article-meta>
+                <pub-date date-type="collection">
+                    <year>2013</year>
+                </pub-date>
+                <pub-date date-type="pub">
+                    <year>2012</year>
+                    <month>9</month>
+                    <day>3</day>
+                </pub-date>
+            </article-meta>
+        </root>
+        """
+        article_xml = etree.fromstring(_xml)
+        self.assertEqual(
+            xml.get_document_publication_date_for_migration(article_xml),
+            '2012-09-03')
+
+    def test_pubdate_pubtype_collection_year_month(self):
+        _xml = """<root>
+            <article-meta>
+                <pub-date pub-type="collection">
+                    <year>2013</year>
+                    <month>2</month>
+                </pub-date>
+            </article-meta>
+        </root>
+        """
+        article_xml = etree.fromstring(_xml)
+        self.assertEqual(
+            xml.get_document_publication_date_for_migration(article_xml),
+            '2013-02')
+
+    def test_pubdate_pubtype_collection_year(self):
+        _xml = """<root>
+            <article-meta>
+                <pub-date pub-type="collection">
+                    <year>2013</year>
+                </pub-date>
+            </article-meta>
+        </root>
+        """
+        article_xml = etree.fromstring(_xml)
+        self.assertEqual(
+            xml.get_document_publication_date_for_migration(article_xml),
+            '2013')
+
+    def test_pubdate_pubtype_collection_year_month_day(self):
+        _xml = """<root>
+            <article-meta>
+                <pub-date pub-type="collection">
+                    <year>2013</year>
+                    <month>2</month>
+                    <day>4</day>
+                </pub-date>
+            </article-meta>
+        </root>
+        """
+        article_xml = etree.fromstring(_xml)
+        self.assertEqual(
+            xml.get_document_publication_date_for_migration(article_xml),
+            '2013-02-04')
+
+    def test_pubdate_datetype_collection_year_month(self):
+        _xml = """<root>
+            <article-meta>
+                <pub-date date-type="collection">
+                    <year>2013</year>
+                    <month>2</month>
+                </pub-date>
+            </article-meta>
+        </root>
+        """
+        article_xml = etree.fromstring(_xml)
+        self.assertEqual(
+            xml.get_document_publication_date_for_migration(article_xml),
+            '2013-02')
+
+    def test_pubdate_datetype_collection_year(self):
+        _xml = """<root>
+            <article-meta>
+                <pub-date date-type="collection">
+                    <year>2013</year>
+                </pub-date>
+            </article-meta>
+        </root>
+        """
+        article_xml = etree.fromstring(_xml)
+        self.assertEqual(
+            xml.get_document_publication_date_for_migration(article_xml),
+            '2013')
+
+    def test_pubdate_datetype_collection_year_month_day(self):
+        _xml = """<root>
+            <article-meta>
+                <pub-date date-type="collection">
+                    <year>2013</year>
+                    <month>2</month>
+                    <day>4</day>
+                </pub-date>
+            </article-meta>
+        </root>
+        """
+        article_xml = etree.fromstring(_xml)
+        self.assertEqual(
+            xml.get_document_publication_date_for_migration(article_xml),
+            '2013-02-04')
+
+    def test_pubdate_pubtype_epubppub_year_month(self):
+        _xml = """<root>
+            <article-meta>
+                <pub-date pub-type="epub-pub">
+                    <year>2013</year>
+                    <month>2</month>
+                </pub-date>
+            </article-meta>
+        </root>
+        """
+        article_xml = etree.fromstring(_xml)
+        self.assertEqual(
+            xml.get_document_publication_date_for_migration(article_xml),
+            '2013-02')
+
+    def test_pubdate_pubtype_epubppub_year(self):
+        _xml = """<root>
+            <article-meta>
+                <pub-date pub-type="epub-pub">
+                    <year>2013</year>
+                </pub-date>
+            </article-meta>
+        </root>
+        """
+        article_xml = etree.fromstring(_xml)
+        self.assertEqual(
+            xml.get_document_publication_date_for_migration(article_xml),
+            '2013')
+
+    def test_pubdate_pubtype_epubppub_year_month_day(self):
+        _xml = """<root>
+            <article-meta>
+                <pub-date pub-type="epub-pub">
+                    <year>2013</year>
+                    <month>2</month>
+                    <day>4</day>
+                </pub-date>
+            </article-meta>
+        </root>
+        """
+        article_xml = etree.fromstring(_xml)
+        self.assertEqual(
+            xml.get_document_publication_date_for_migration(article_xml),
+            '2013-02-04')


### PR DESCRIPTION
#### O que esse PR faz?
Disponibiliza uma função para obter do XML a data de publicação do artigo mais precisa, considerando as várias possibilidade de combinações de datas, dando prioridade na seguinte ordem datas epub, pub, outras.

#### Onde a revisão poderia começar?
- `documentstore_migracao/utils/xml.py`

#### Como este poderia ser testado manualmente?
`python setup.py test -s tests/test_utils.py
`
#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
relacionado #19 

### Referências

- http://docs.scielo.org/projects/scielo-publishing-schema/pt_BR/1.9-branch/tagset/elemento-pub-date.html
- http://docs.scielo.org/projects/scielo-publishing-schema/pt_BR/1.8-branch/tagset/elemento-pub-date.html
