### PR TITLE
Adiciona o Jython.jar como biblioteca versionada no projeto

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Esta ferramenta possui a capacidade de migrar dados de bases ISIS (title e issue
 Antes de executar a ferramenta de migração observe se as seguintes dependências estão presentes:
 
 - Java `>= 1.8`
-- [Jython](http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.5.3/jython-installer-2.5.3.jar) `== 2.5.x`
 - Python `== 3.6.x`
 
 #### Configuração
@@ -22,9 +21,8 @@ Antes de executar a ferramenta de migração observe se as seguintes dependênci
 Para o devido funcionamento desta ferramenta é necessário que algumas configurações sejam feitas, siga as seguintes instruções:
 
 1. Instale o Java.
-2. Instale o Jython.
-3. Instale o Python.
-4. Instale os utilitários de migração
+2. Instale o Python.
+3. Instale os utilitários de migração
 
 ```shell
 python setup.py install

--- a/documentstore_migracao/config.py
+++ b/documentstore_migracao/config.py
@@ -60,12 +60,12 @@ DOC_TYPE_XML = """<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Pu
 
 os.environ["XML_CATALOG_FILES"] = XML_CATALOG
 
-os.environ["CLASSPATH"] = "".join(
-    [
-        os.path.join(BASE_PATH, "documentstore_migracao/utils/isis2json/lib/Bruma.jar"),
-        ":",
-        os.path.join(
-            BASE_PATH, "documentstore_migracao/utils/isis2json/lib/jyson-1.0.1.jar"
-        ),
-    ]
-)
+JAVA_LIB_DIR = os.path.join(BASE_PATH, "documentstore_migracao/utils/isis2json/lib/")
+
+JAVA_LIBS_PATH = [
+    os.path.join(JAVA_LIB_DIR, file)
+    for file in os.listdir(JAVA_LIB_DIR)
+    if file.endswith(".jar")
+]
+
+os.environ["CLASSPATH"] = ":".join(JAVA_LIBS_PATH)

--- a/documentstore_migracao/utils/extract_isis.py
+++ b/documentstore_migracao/utils/extract_isis.py
@@ -27,7 +27,12 @@ def run(path: str, output_file: str):
     parâmetro output_file.
     """
 
-    command = "jython %s -t 3 -p 'v' -o %s %s" % (ISIS2JSON_PATH, output_file, path)
+    command = "java -cp %s org.python.util.jython %s -t 3 -p 'v' -o %s %s" % (
+        config.get("CLASSPATH"),
+        ISIS2JSON_PATH,
+        output_file,
+        path,
+    )
 
     try:
         logger.debug("Extracting database file: %s" % path)


### PR DESCRIPTION
#### O que esse PR faz?
Este PR versiona o binário do`jython` e altera a execução da extração de bases MST. A extração passa a utilizar a classe do `jython` que agora é automaticamente injetada no `CLASSPATH`.

#### Onde a revisão poderia começar?
- `documentstore_migracao/config.py` linha `63`;
- `documentstore_migracao/utils/extract_isis.py` linha `30`.

#### Como este poderia ser testado manualmente?
Para testar este PR deve-se:
- Verificar a não existência do `jython` no classpath antes de executar a migração:
  - `echo $CLASSPATH`
- Extrair uma base MST;
- Observar se a extração ocorreu com **sucesso**

#### Algum cenário de contexto que queira dar?
Esta modificação facilita a utilização do utilitário de migração uma vez que não é mais necessário baixar e configurar o `jython` na máquina de destino do utilitário.

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
[Jython bug tracker](https://bugs.jython.org/issue1422)

