### PR TITLE
Atualizacao da tag do scielo-id

### DIFF
--- a/documentstore_migracao/utils/constructor_xml.py
+++ b/documentstore_migracao/utils/constructor_xml.py
@@ -36,10 +36,11 @@ class ConstructorXMLPipeline(object):
             iterators = [xml.iterfind(path) for path in self.PATHS]
             for article in itertools.chain(*iterators):
 
-                node = article.findall(".//article-id[@pub-id-type='scielo-id']")
+                node = article.findall(".//article-id[@specific-use='scielo']")
                 if not node:
                     articleId = etree.Element("article-id")
-                    articleId.set("pub-id-type", "scielo-id")
+                    articleId.set("pub-id-type", "publisher-id")
+                    articleId.set("specific-use", "scielo")
                     articleId.text = string.generate_scielo_pid()
                     self._append_node(article, articleId)
 

--- a/documentstore_migracao/utils/manifest.py
+++ b/documentstore_migracao/utils/manifest.py
@@ -11,7 +11,7 @@ def get_document_bundle_manifest(
     documento xml"""
 
     try:
-        _id = document.find(".//article-id[@pub-id-type='scielo-id']").text
+        _id = document.find(".//article-id[@specific-use='scielo']").text
     except AttributeError:
         raise ValueError("Document requires an scielo-id") from None
 

--- a/documentstore_migracao/utils/xml.py
+++ b/documentstore_migracao/utils/xml.py
@@ -112,7 +112,6 @@ def get_languages(obj_xml):
 
 
 def get_document_publication_date_for_migration(obj_xml):
-
     def format(item):
         if item:
             return item.zfill(2)
@@ -120,19 +119,21 @@ def get_document_publication_date_for_migration(obj_xml):
     pubdate_xpaths = (
         'pub-date[@pub-type="epub"]',
         'pub-date[@date-type="pub"]',
-        'pub-date',
+        "pub-date",
     )
 
-    article_meta = obj_xml.find('.//article-meta')
+    article_meta = obj_xml.find(".//article-meta")
     if article_meta is None:
-        raise ValueError('XML não possui article-meta')
+        raise ValueError("XML não possui article-meta")
 
     for xpath in pubdate_xpaths:
         pubdate = article_meta.find(xpath)
         if pubdate is not None:
-            items = [format(pubdate.findtext(elem_name))
-                     for elem_name in ['year', 'month', 'day']]
-            return '-'.join([item for item in items if item])
+            items = [
+                format(pubdate.findtext(elem_name))
+                for elem_name in ["year", "month", "day"]
+            ]
+            return "-".join([item for item in items if item])
 
 
 def loadToXML(file):
@@ -149,7 +150,7 @@ def loadToXML(file):
 def get_scielo_id(obj_xml):
     """The scielo id of the main document.
     """
-    return obj_xml.findtext('//article-id[@pub-id-type="scielo-id"]')
+    return obj_xml.findtext(".//article-id[@specific-use='scielo']")
 
 
 def get_journal_id(obj_xml):


### PR DESCRIPTION
#### O que esse PR faz?
Altera a tag para o cielo-id, antes ela erra assim 
```
 <article-id pub-id-type="scielo-id">zTp3PyKhQYvgVQdv8zkVY9h</article-id>
```
e agora é assim 
```
 <article-id pub-id-type="publisher-id" specific-use="scielo">FC4vDyPznvr3yH5dsYkKm5G</article-id>
```

Devido a problemas na validação  do xml com as normas da Jats, foi necessario essa mudança

#### Onde a revisão poderia começar?
Pelo arquivo:
* `documentstore_migracao/utils/constructor_xml.py`

#### Como este poderia ser testado manualmente?
Apos atualizar o codigo, rodar novamente a construção dos XML para que seja adiciona a nova tag nos XMLs 

#### Quais são tickets relevantes?
#60
