### PR TITLE
Adiciona função para realizar link entre documents bundles e documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ xml/*
 json/*
 
 
+tests/samples/S0044-59672003000300002_sps_*
+tests/samples/any

--- a/tests/test_inserting.py
+++ b/tests/test_inserting.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest import mock
+from documentstore_migracao.processing import inserting
+from .apptesting import Session
+from . import SAMPLE_ISSUES_KERNEL
+
+
+class TestLinkDocumentsBundleWithDocuments(unittest.TestCase):
+    def setUp(self):
+        self.session = Session()
+        manifest = inserting.ManifestDomainAdapter(SAMPLE_ISSUES_KERNEL[0])
+        self.session.documents_bundles.add(manifest)
+        self.documents_bundle = self.session.documents_bundles.fetch(manifest.id())
+
+    def test_should_link_documents_bundle_with_documents(self):
+        inserting.link_documents_bundles_with_documents(
+            self.documents_bundle, ["doc-1", "doc-2"], self.session
+        )
+
+        self.assertEqual(["doc-1", "doc-2"], self.documents_bundle.documents)
+
+    def test_should_not_insert_duplicated_documents(self):
+        inserting.link_documents_bundles_with_documents(
+            self.documents_bundle, ["doc-1", "doc-1"], self.session
+        )
+
+        self.assertEqual(["doc-1"], self.documents_bundle.documents)
+
+    def test_should_register_changes(self):
+        inserting.link_documents_bundles_with_documents(
+            self.documents_bundle, ["doc-1", "doc-2"], self.session
+        )
+
+        _changes = self.session.changes.filter()
+
+        self.assertEqual(1, len(_changes))
+        self.assertEqual(self.documents_bundle.id(), _changes[0]["id"])
+        self.assertEqual("DocumentsBundle", _changes[0]["entity"])


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona uma função para realizar o relacionamento entre `documents bundles` e `documents`.

#### Onde a revisão poderia começar?
- `documentstore_migracao/processing/inserting.py` linha `105`

#### Como este poderia ser testado manualmente?

Para realizar os testes manuais deve-se:
- invocar `link_documents_bundles_with_documents` com um objeto do tipo `domain.DocumentsBundle`, uma lista contendo os `ids` de `documents` e um objeto de conexão com o banco de dados.
- Verificar se o objeto `DocumentsBundle` sofreu alterações na sua lista de `documents`

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#48 

### Referências
N/A

