### PR TITLE
Trata exceções decorrentes da comunicação com o Article Meta

### DIFF
--- a/documentstore_migracao/export/article.py
+++ b/documentstore_migracao/export/article.py
@@ -12,8 +12,9 @@ def ext_identifiers(issn_journal):
     articles_id = request.get(
         "%s/article/identifiers/" % config.get("AM_URL_API"),
         params={"collection": config.get("SCIELO_COLLECTION"), "issn": issn_journal},
-    ).json()
-    return articles_id
+    )
+    if articles_id:
+        return articles_id.json()
 
 
 def get_articles(issn_journal):
@@ -25,20 +26,27 @@ def get_articles(issn_journal):
 def ext_article(code, **ext_params):
     params = ext_params
     params.update({"collection": config.get("SCIELO_COLLECTION"), "code": code})
-
-    article = request.get("%s/article" % config.get("AM_URL_API"), params=params)
-    return article
+    try:
+        article = request.get("%s/article" % config.get("AM_URL_API"), params=params)
+    except request.HTTPGetError:
+        logger.error(
+            "Erro coletando dados do artigo PID %s" % code
+        )
+    else:
+        return article
 
 
 def ext_article_json(code, **ext_params):
-    article = ext_article(code, **ext_params).json()
-    return article
+    article = ext_article(code, **ext_params)
+    if article:
+        return article.json()
 
 
 def ext_article_txt(code, **ext_params):
     logger.info("\t Arquivo XML '%s' extraido", code)
-    article = ext_article(code, body="true", format="xmlrsps", **ext_params).text
-    return article
+    article = ext_article(code, body="true", format="xmlrsps", **ext_params)
+    if article:
+        return article.text
 
 
 def get_all_articles_notXML(issn):

--- a/documentstore_migracao/export/journal.py
+++ b/documentstore_migracao/export/journal.py
@@ -19,17 +19,17 @@ def ext_identifiers():
 
 
 def ext_journal(issn):
-
-    journal = request.get(
-        "%s/journal" % config.get("AM_URL_API"),
-        params={"collection": config.get("SCIELO_COLLECTION"), "issn": issn},
-    ).json()
-    if journal:
-        return Journal(journal[0])
-    else:
-        raise ValueError(
+    try:
+        journal = request.get(
+            "%s/journal" % config.get("AM_URL_API"),
+            params={"collection": config.get("SCIELO_COLLECTION"), "issn": issn},
+        )
+    except request.HTTPGetError:
+        logger.error(
             "Journal nao encontrado: %s: %s" % (config.get("SCIELO_COLLECTION"), issn)
         )
+    else:
+        return Journal(journal.json()[0])
 
 
 def get_all_journal():

--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -3,7 +3,6 @@ import shutil
 import logging
 
 from requests.compat import urljoin
-from requests.exceptions import HTTPError
 from lxml import etree
 from documentstore_migracao.utils import (
     files,
@@ -69,7 +68,7 @@ def download_asset(old_path, new_fname, dest_path):
     try:
         request_file = request.get(
             location, timeout=int(config.get("TIMEOUT") or 10))
-    except HTTPError as e:
+    except request.HTTPGetError as e:
         try:
             msg = str(e)
         except TypeError:

--- a/documentstore_migracao/utils/request.py
+++ b/documentstore_migracao/utils/request.py
@@ -1,8 +1,17 @@
 import requests
+from requests.exceptions import HTTPError
+
+
+class HTTPGetError(Exception):
+    pass
 
 
 def get(uri, **kwargs):
 
     r = requests.get(uri, **kwargs)
-    r.raise_for_status()
-    return r
+    try:
+        r.raise_for_status()
+    except HTTPError as exc:
+        raise HTTPGetError(str(exc))
+    else:
+        return r

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,9 +1,11 @@
 import os
 import unittest
+import requests
 from copy import deepcopy
 from unittest.mock import patch, ANY
 from xylose.scielodocument import Journal, Article
 from documentstore_migracao.export import journal, article
+from documentstore_migracao.utils import request
 from documentstore_migracao import exceptions, config
 from . import SAMPLES_JOURNAL, SAMPLES_ARTICLE, SAMPLES_PATH, utils
 
@@ -20,6 +22,19 @@ class TestExportJournal(unittest.TestCase):
         )
 
         self.assertEqual(result.title, SAMPLES_JOURNAL["v100"][0]["_"])
+
+    @patch("documentstore_migracao.export.journal.logger.error")
+    def test_ext_journal_catch_request_get_exception(
+        self,
+        mk_logger_error,
+        mk_request_get,
+    ):
+        mk_request_get.side_effect = request.HTTPGetError
+        result = journal.ext_journal("1234-5678")
+        mk_logger_error.assert_called_once_with(
+            "Journal nao encontrado: spa: 1234-5678"
+        )
+        self.assertIsNone(result)
 
     def test_ext_identifiers(self, mk_request_get):
 
@@ -63,11 +78,32 @@ class TestExportArticle(unittest.TestCase):
             ANY, params={"collection": ANY, "code": "S0036-36341997000100001"}
         )
 
+    @patch("documentstore_migracao.export.article.logger.error")
+    @patch("documentstore_migracao.export.article.request.get")
+    def test_ext_article_log_error_if_request_raises_exception(
+        self,
+        mk_request_get,
+        mk_logger_error
+    ):
+        article_pid = "S0036-36341997000100001"
+        mk_request_get.side_effect = request.HTTPGetError
+        result = article.ext_article(article_pid)
+        self.assertIsNone(result)
+        mk_logger_error.assert_called_once_with(
+            "Erro coletando dados do artigo PID %s" % article_pid
+        )
+
     @patch("documentstore_migracao.export.article.ext_article")
     def test_ext_article_json(self, mk_ext_article):
 
         result = article.ext_article_json("S0036-36341997000100001")
         mk_ext_article.assert_called_once_with("S0036-36341997000100001")
+
+    @patch("documentstore_migracao.export.article.ext_article")
+    def test_ext_article_json_returns_none_if_no_ext_article(self, mk_ext_article):
+        mk_ext_article.return_value = None
+        result = article.ext_article_json("S0036-36341997000100001")
+        self.assertIsNone(result)
 
     @patch("documentstore_migracao.export.article.ext_article")
     def test_ext_article_txt(self, mk_ext_article):
@@ -76,6 +112,12 @@ class TestExportArticle(unittest.TestCase):
         mk_ext_article.assert_called_once_with(
             "S0036-36341997000100001", body="true", format="xmlrsps"
         )
+
+    @patch("documentstore_migracao.export.article.ext_article")
+    def test_ext_article_txt_returns_none_if_no_ext_article(self, mk_ext_article):
+        mk_ext_article.return_value = None
+        result = article.ext_article_txt("S0036-36341997000100001")
+        self.assertIsNone(result)
 
     @patch("documentstore_migracao.export.article.get_articles")
     def test_get_all_articles_notXML(self, mk_get_articles):

--- a/tests/test_processing_packing.py
+++ b/tests/test_processing_packing.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch, ANY, Mock
 
 from lxml import etree
-from requests import HTTPError
+from documentstore_migracao.utils.request import HTTPGetError
 
 from documentstore_migracao.processing import (
     packing,
@@ -163,8 +163,8 @@ class TestProcessingPackingDownloadAsset(unittest.TestCase):
             self.assertTrue(fp.read(), b'conteudo')
 
     @patch("documentstore_migracao.utils.request.get")
-    def test_download_asset_raise_HTTPError_exception(self, mk_request_get):
-        mk_request_get.side_effect = HTTPError
+    def test_download_asset_raise_HTTPGetError_exception(self, mk_request_get):
+        mk_request_get.side_effect = HTTPGetError
         old_path = '/img/en/scielobre.gif'
         new_fname = 'novo'
         dest_path = TEMP_TEST_PATH
@@ -197,7 +197,7 @@ class TestProcessingPacking_PackingAssets(unittest.TestCase):
         pkg_name = 'pacote_sps'
 
         mk_request_get.side_effect = [
-            HTTPError('Error'),
+            HTTPGetError('Error'),
             m,
         ]
         result_path = packing.packing_assets(
@@ -224,7 +224,7 @@ class TestProcessingPacking_PackingAssets(unittest.TestCase):
         renamed_path = pkg_path + '_INCOMPLETE'
         pkg_name = 'pacote_sps'
         mk_request_get.side_effect = [
-            HTTPError('Error'),
+            HTTPGetError('Error'),
             m,
         ]
         result_path = packing.packing_assets(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
 import unittest
-from unittest.mock import patch
+from requests.exceptions import HTTPError
+from unittest.mock import patch, MagicMock
 from lxml import etree
 from uuid import UUID
 from documentstore_migracao.utils import files, xml, request, dicts, string
@@ -154,6 +155,18 @@ class TestUtilsRequest(unittest.TestCase):
         expected = {"params": {"collection": "spa"}}
         request.get("http://api.test.com", **expected)
         mk_requests.get.assert_called_once_with("http://api.test.com", **expected)
+
+    @patch("documentstore_migracao.utils.request.requests")
+    def test_get_raises_exception_if_requests_exception(self, mk_requests):
+        mk_response = MagicMock()
+        mk_response.raise_for_status.side_effect = HTTPError
+        mk_requests.get.return_value = mk_response
+        self.assertRaises(
+            request.HTTPGetError,
+            request.get,
+            "http://api.test.com",
+            **{}
+        )
 
 
 class TestUtilsDicts(unittest.TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Trata exceções decorrentes da comunicação com o Article Meta. O comportamento do `utils.request.get()` foi alterado, além dos pontos da aplicação que o utilizam. A exceção lançada pela função, `HTTPGetError`, deve ser tratada por quem a utiliza.

#### Onde a revisão poderia começar?
Em `documentstore_migracao/utils/request.py`.

#### Como este poderia ser testado manualmente?
Executando o comando `SCIELO_COLLECTION=scl documentstore_migracao --issn-journal 0066-782X`, apesar dos erros que ocorrem, o processo de extração não deve ser interrompido.

#### Algum cenário de contexto que queira dar?
Detalhes no ticket #51.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#51.

### Referências
Nenhuma.
