### PR TITLE
Trata erros do LXML durante a validação de artigos

### DIFF
--- a/documentstore_migracao/processing/validation.py
+++ b/documentstore_migracao/processing/validation.py
@@ -6,6 +6,7 @@ from packtools import XMLValidator, exceptions
 
 from documentstore_migracao.utils import files, dicts
 from documentstore_migracao import config
+from lxml import etree
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +18,7 @@ def validate_article_xml(file_xml_path, print_error=True):
     try:
         xmlvalidator = XMLValidator.parse(file_xml_path)
         is_valid, errors = xmlvalidator.validate()
-    except exceptions.XMLSPSVersionError as e:
+    except (exceptions.XMLSPSVersionError, etree.LxmlError) as e:
         result[str(e)] = {
             "count": 1,
             "lineno": [1],


### PR DESCRIPTION
#### O que esse PR faz?
Durante a validação de artigos com `nós` contendo identificadores duplicados o parser do LXML lança uma `Exception` do tipo `etree.XMLSyntaxError`, o `packtools` não trata este tipo de erro consequentemente a execução da migração era encerrada abruptamente.

#### Onde a revisão poderia começar?
- `documentstore_migracao/processing/validation.py` linha `21`

#### Como este poderia ser testado manualmente?
Para testar manualmente este PR, deve-se:
- Baixar o arquivo [1];
- Executar o comando `ds_migracao validate --file path/para/o/arquivo.txt`;
- Observar que a execução quebra e o programa finaliza a sua execução do modo esperado.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
closes #50 

### Anexos
[already_id.txt](https://github.com/scieloorg/document-store-migracao/files/3158776/already_id.txt)

### Referências
[lmlx execeptions](https://lxml.de/api/lxml.etree.XMLSyntaxError-class.html)
