### PR TITLE
Corrige get_document_bundle_manifest() na definição da data de criação

### DIFF
--- a/documentstore_migracao/utils/manifest.py
+++ b/documentstore_migracao/utils/manifest.py
@@ -11,7 +11,6 @@ def get_document_bundle_manifest(
     documento xml"""
 
     obj_sps = SPS_Package(document)
-
     _id = obj_sps.scielo_id
     date = obj_sps.document_pubdate
 
@@ -21,7 +20,9 @@ def get_document_bundle_manifest(
     if not date:
         raise ValueError("A creation date is required") from None
 
-    _creation_date = parse_date(date)
+    _creation_date = parse_date(
+        "-".join([date_part for date_part in date if date_part])
+    )
 
     _version = {"data": document_url, "assets": {}, "timestamp": _creation_date}
     _document = {"id": _id, "versions": [_version]}


### PR DESCRIPTION
#### O que esse PR faz?
Corrige função `manifest.get_document_bundle_manifest()` na definição da data de criação, que utiliza `xylose_converter.parse_date`. Como a data de publicação do documento de `SPS_Package` retornar uma tupla com os dados da data, este monta a data em formato string para o parser.
Esta correção é importante pois o erro impede a importação dos documentos para o Kernel.

#### Onde a revisão poderia começar?
Em `documentstore_migracao/utils/manifest.py`, L23.

#### Como este poderia ser testado manualmente?
Executando o comando `ds_migracao import` com pacotes válidos, a importação dos documentos no kernel deve ocorrer sem problemas. 

#### Algum cenário de contexto que queira dar?
Foram feitas alterações na data de publicação do documento de `SPS_Package` e faltou alterar esta parte do fluxo da migração.

### Screenshots
N/A.

#### Quais são tickets relevantes?
Nenhum.

### Referências
Nenhuma.

