### PR TITLE
Correção dos primeiros casos da conversão do XML  #73

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -380,7 +380,7 @@ class SPS_Package:
             logger.info("Processando body numero: %s" % index)
 
             txt_body = body.findtext("./p") or ""
-            convert = HTML2SPSPipeline(pid=self.publisher_id)
+            convert = HTML2SPSPipeline(pid=self.publisher_id, index_body=index)
             _, obj_html_body = convert.deploy(txt_body)
 
             # sobrecreve o html escapado anterior pelo novo xml tratado

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -94,6 +94,10 @@ class SPS_Package:
         return self.xmltree.findtext('.//journal-id[@journal-id-type="publisher-id"]')
 
     @property
+    def publisher_id(self):
+        return self.xmltree.findtext('.//article-id[@pub-id-type="publisher-id"]')
+
+    @property
     def journal_meta(self):
         data = []
         issns = [
@@ -376,7 +380,7 @@ class SPS_Package:
             logger.info("Processando body numero: %s" % index)
 
             txt_body = body.findtext("./p") or ""
-            convert = HTML2SPSPipeline()
+            convert = HTML2SPSPipeline(pid=self.publisher_id)
             _, obj_html_body = convert.deploy(txt_body)
 
             # sobrecreve o html escapado anterior pelo novo xml tratado

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -380,7 +380,7 @@ class SPS_Package:
             _, obj_html_body = convert.deploy(txt_body)
 
             # sobrecreve o html escapado anterior pelo novo xml tratado
-            body.getparent().replace(body, obj_html_body)
+            body.getparent().replace(body, obj_html_body.find("body"))
 
         return self.xmltree
 

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -53,14 +53,28 @@ def _process(xml, tag, func):
 
 
 def wrap_node(node, elem_wrap="p"):
-    tag = node.tag
 
-    p = etree.Element(elem_wrap)
     _node = deepcopy(node)
+    p = etree.Element(elem_wrap)
     p.append(_node)
-    etree.strip_tags(p, tag)
+    node.getparent().replace(node, p)
 
     return p
+
+
+def wrap_content_node(node, elem_wrap="p"):
+
+    _node = deepcopy(node)
+    p = etree.Element(elem_wrap)
+    if _node.text:
+        p.text = _node.text
+    if _node.tail:
+        p.tail = _node.tail
+
+    _node.text = None
+    _node.tail = None
+    _node.append(p)
+    node.getparent().replace(node, _node)
 
 
 def gera_id(_string):
@@ -332,7 +346,6 @@ class HTML2SPSPipeline(object):
             return data
 
     class ANamePipe(CustomPipe):
-
         def find_a_href(self, root, _id_name):
             return root.find('.//a[@href="#{}"]'.format(_id_name))
 
@@ -346,10 +359,12 @@ class HTML2SPSPipeline(object):
             root = node.getroottree()
             if _id_name.startswith("tx"):
                 _remove_element_or_comment(node)
-                _remove_element_or_comment(self.find_a_href(root, _id_name))
+                _a_ref_node = self.find_a_href(root, _id_name)
+                if _a_ref_node is not None:
+                    _remove_element_or_comment(_a_ref_node)
             elif _id_name.startswith("t"):
                 a_href = self.find_a_href(root, _id_name)
-                if a_href and a_href.text and 'tab' in a_href.text.lower():
+                if a_href is not None and a_href.text and "tab" in a_href.text.lower():
                     node.tag = "table-wrap"
                 else:
                     node.tag = "fn"
@@ -358,13 +373,19 @@ class HTML2SPSPipeline(object):
             elif _id_name.startswith("n"):
                 node.tag = "fn"
 
+            if node.tag == "fn":
+                p = etree.Element("p")
+                p.text = (node.text or "") + (node.tail or "")
+                node.tail = None
+                node.text = None
+                node.append(p)
+
             node.attrib.clear()
             ref_id = "%s-%s" % (
                 gera_id(_id_name) or _id_name,
                 self.super_obj.index_body,
             )
-            if ref_id:
-                node.set("ref-id", ref_id)
+            node.set("ref-id", ref_id)
             node.set("id", ref_id)
 
         def transform(self, data):
@@ -443,7 +464,7 @@ class HTML2SPSPipeline(object):
                 if c_node.tag not in self.ALLOWED_CHILDREN
             ]
             for c_node in c_not_allowed:
-                node.replace(c_node, wrap_node(c_node, "p"))
+                wrap_node(c_node, "p")
 
             if node.text:
                 p = etree.Element("p")
@@ -574,14 +595,13 @@ class HTML2SPSPipeline(object):
                     node.remove(list_c_node[0])
                 _remove_element_or_comment(node)
 
-
             node.attrib.clear()
             root = node.getroottree()
 
             xref_name = href.replace("#", "")
             if xref_name == "ref":
 
-                rid = node.text
+                rid = node.text or ""
                 if not rid.isdigit():
                     rid = (
                         rid.replace("(", "")
@@ -590,6 +610,7 @@ class HTML2SPSPipeline(object):
                         .split(",")
                     )
                     rid = rid[0]
+
                 node.set("rid", "B%s" % rid)
                 node.set("ref-type", "bibr")
 
@@ -959,9 +980,9 @@ class DataSanitizationPipeline(object):
         self._ppl = plumber.Pipeline(
             self.SetupPipe(),
             self.GraphicInExtLink(),
-            self.HRTagPape(),
             self.TableinBody(),
             self.TableinP(),
+            self.AddPinFN(),
         )
 
     def deploy(self, raw):
@@ -975,17 +996,11 @@ class DataSanitizationPipeline(object):
             return data, new_obj
 
     class GraphicInExtLink(plumber.Pipe):
-        NEW_TAG = "p"
-
         def parser_node(self, node):
 
             graphic = node.find("graphic")
-            _graphic = deepcopy(graphic)
-            _graphic.tag = "inline-graphic"
-            p = etree.Element(self.NEW_TAG)
-            p.append(_graphic)
-            node.append(p)
-            node.remove(graphic)
+            graphic.tag = "inline-graphic"
+            wrap_node(graphic, "p")
 
         def transform(self, data):
             raw, xml = data
@@ -993,29 +1008,11 @@ class DataSanitizationPipeline(object):
             _process(xml, "ext-link[graphic]", self.parser_node)
             return data
 
-    class HRTagPape(plumber.Pipe):
-        def parser_node(self, node):
-
-            element = etree.fromstring(
-                "<table-wrap><table><tr><td><hr/></td></tr></table></table-wrap>"
-            )
-            node.getparent().replace(node, element)
-
-        def transform(self, data):
-            raw, xml = data
-
-            _process(xml, "hr", self.parser_node)
-            return data
-
     class TableinBody(plumber.Pipe):
         def parser_node(self, node):
 
             table = node.find("table")
-            _table = deepcopy(table)
-            w_wrap = etree.Element("table-wrap")
-            w_wrap.append(_table)
-            node.append(w_wrap)
-            node.remove(table)
+            wrap_node(table, "table-wrap")
 
         def transform(self, data):
             raw, xml = data
@@ -1028,4 +1025,15 @@ class DataSanitizationPipeline(object):
             raw, xml = data
 
             _process(xml, "p[table]", self.parser_node)
+            return data
+
+    class AddPinFN(plumber.Pipe):
+        def parser_node(self, node):
+            if node.text:
+                wrap_content_node(node, "p")
+
+        def transform(self, data):
+            raw, xml = data
+
+            _process(xml, "fn", self.parser_node)
             return data

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -787,6 +787,8 @@ class HTML2SPSPipeline(object):
     class HrPipe(plumber.Pipe):
         def parser_node(self, node):
             node.attrib.clear()
+            node.tag = "p"
+            node.set("content-type", "hr")
 
         def transform(self, data):
             raw, xml = data

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -105,7 +105,7 @@ class HTML2SPSPipeline(object):
             self.EmPipe(),
             self.UPipe(),
             self.BPipe(),
-            # self.APipe(),
+            self.APipe(),
             self.StrongPipe(),
             self.TdCleanPipe(),
             self.TableCleanPipe(),
@@ -332,6 +332,10 @@ class HTML2SPSPipeline(object):
             return data
 
     class ANamePipe(CustomPipe):
+
+        def find_a_href(self, root, _id_name):
+            return root.find('.//a[@href="#{}"]'.format(_id_name))
+
         def parser_node(self, node):
             attrib = node.attrib
 
@@ -339,8 +343,16 @@ class HTML2SPSPipeline(object):
             if _id_name.startswith("top") or _id_name.startswith("back"):
                 return
 
-            if _id_name.startswith("t"):
-                node.tag = "table-wrap"
+            root = node.getroottree()
+            if _id_name.startswith("tx"):
+                _remove_element_or_comment(node)
+                _remove_element_or_comment(self.find_a_href(root, _id_name))
+            elif _id_name.startswith("t"):
+                a_href = self.find_a_href(root, _id_name)
+                if a_href and a_href.text and 'tab' in a_href.text.lower():
+                    node.tag = "table-wrap"
+                else:
+                    node.tag = "fn"
             elif _id_name[0] in "fcq":
                 node.tag = "fig"
             elif _id_name.startswith("n"):
@@ -561,6 +573,7 @@ class HTML2SPSPipeline(object):
                 ):
                     node.remove(list_c_node[0])
                 _remove_element_or_comment(node)
+
 
             node.attrib.clear()
             root = node.getroottree()

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -97,7 +97,7 @@ class HTML2SPSPipeline(object):
             self.EmPipe(),
             self.UPipe(),
             self.BPipe(),
-            self.APipe(),
+            # self.APipe(),
             self.StrongPipe(),
             self.TdCleanPipe(),
             self.TableCleanPipe(),
@@ -617,7 +617,61 @@ class HTML2SPSPipeline(object):
             return data
 
     class TdCleanPipe(plumber.Pipe):
-        UNEXPECTED_INNER_TAGS = ["p", "span", "small", "dir"]
+        EXPECTED_INNER_TAGS = [
+            "email",
+            "ext-link",
+            "uri",
+            "hr",
+            "inline-supplementary-material",
+            "related-article",
+            "related-object",
+            "disp-formula",
+            "disp-formula-group",
+            "break",
+            "citation-alternatives",
+            "element-citation",
+            "mixed-citation",
+            "nlm-citation",
+            "bold",
+            "fixed-case",
+            "italic",
+            "monospace",
+            "overline",
+            "roman",
+            "sans-serif",
+            "sc",
+            "strike",
+            "underline",
+            "ruby",
+            "chem-struct",
+            "inline-formula",
+            "def-list",
+            "list",
+            "tex-math",
+            "mml:math",
+            "p",
+            "abbrev",
+            "index-term",
+            "index-term-range-end",
+            "milestone-end",
+            "milestone-start",
+            "named-content",
+            "styled-content",
+            "alternatives",
+            "array",
+            "code",
+            "graphic",
+            "media",
+            "preformat",
+            "inline-graphic",
+            "inline-media",
+            "private-char",
+            "fn",
+            "target",
+            "xref",
+            "sub",
+            "sup",
+        ]
         EXPECTED_ATTRIBUTES = [
             "abbr",
             "align",
@@ -636,8 +690,10 @@ class HTML2SPSPipeline(object):
         ]
 
         def parser_node(self, node):
-            for tag in self.UNEXPECTED_INNER_TAGS:
-                etree.strip_tags(node, tag)
+            for c_node in node.getchildren():
+                if c_node.tag not in self.EXPECTED_INNER_TAGS:
+                    _remove_element_or_comment(c_node)
+
             _attrib = {}
             for key in node.attrib.keys():
                 if key in self.EXPECTED_ATTRIBUTES:
@@ -652,6 +708,8 @@ class HTML2SPSPipeline(object):
             return data
 
     class TableCleanPipe(TdCleanPipe):
+        EXPECTED_INNER_TAGS = ["col", "colgroup", "thead", "tfoot", "tbody", "tr"]
+
         EXPECTED_ATTRIBUTES = [
             "border",
             "cellpadding",

--- a/documentstore_migracao/utils/xml.py
+++ b/documentstore_migracao/utils/xml.py
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 def str2objXML(_string):
     _string = string.normalize(_string)
     try:
-        return etree.fromstring("<body>%s</body>" % (_string))
+        parser = etree.HTMLParser(remove_blank_text=True, recover=True)
+        return etree.fromstring("<body>%s</body>" % (_string), parser=parser)
     except etree.XMLSyntaxError as e:
         logger.exception(e)
         return etree.fromstring("<body></body>")

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -105,7 +105,7 @@ class TestHTML2SPSPipeline(unittest.TestCase):
     def test_pipe_hr(self):
         text = '<root><hr style="x" /></root>'
         raw, transformed = self._transform(text, self.pipeline.HrPipe())
-        self.assertEqual(etree.tostring(transformed), b"<root><hr/></root>")
+        self.assertEqual(etree.tostring(transformed), b'<root><p content-type="hr"/></root>')
 
     def test_pipe_br(self):
         text = '<root><p align="x">bla<br/> continua outra linha</p><p baljlba="1"/><td><br/></td><sec><br/></sec></root>'

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -454,6 +454,23 @@ class TestHTML2SPSPipeline(unittest.TestCase):
 
     #     self.assertEqual(new_xml.find("xref").attrib["rid"], "home")
 
+    def test_pipe_aname__removes_navigation_to_note_go_and_back(self):
+        text = """<root><a href="#tx01">
+            <graphic xmlns:ns2="http://www.w3.org/1999/xlink" ns2:href="/img/revistas/gs/v29n2/seta.gif"/>
+        </a><a name="tx01" id="tx01"/></root>"""
+
+        raw, transformed = self._transform(
+            text, self.pipeline.ANamePipe(self.pipeline))
+
+        node = transformed.find(".//xref")
+        self.assertIsNone(node)
+
+        node = transformed.find(".//a")
+        self.assertIsNone(node)
+
+        node = transformed.find(".//graphic")
+        self.assertIsNotNone(node)
+
     def test_pipe_a_anchor__remove_xref_with_graphic(self):
         text = """<root><a href="#top">
             <graphic xmlns:ns2="http://www.w3.org/1999/xlink" ns2:href="/img/revistas/gs/v29n2/seta.gif"/>

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -105,7 +105,9 @@ class TestHTML2SPSPipeline(unittest.TestCase):
     def test_pipe_hr(self):
         text = '<root><hr style="x" /></root>'
         raw, transformed = self._transform(text, self.pipeline.HrPipe())
-        self.assertEqual(etree.tostring(transformed), b'<root><p content-type="hr"/></root>')
+        self.assertEqual(
+            etree.tostring(transformed), b'<root><p content-type="hr"/></root>'
+        )
 
     def test_pipe_br(self):
         text = '<root><p align="x">bla<br/> continua outra linha</p><p baljlba="1"/><td><br/></td><sec><br/></sec></root>'
@@ -156,7 +158,7 @@ class TestHTML2SPSPipeline(unittest.TestCase):
         expected = [
             b"<list-item><p>Texto dentro de <b>li</b> 1</p></list-item>",
             b"<list-item><p>Texto dentro de <b>li</b> 2</p></list-item>",
-            b"<list-item><p>Texto dentro de 3</p></list-item>",
+            b"<list-item><p><b>Texto dentro de 3</b></p></list-item>",
             b"<list-item><p>Texto dentro de 4</p></list-item>",
         ]
         raw, transformed = self._transform(text, self.pipeline.LiPipe())
@@ -444,23 +446,22 @@ class TestHTML2SPSPipeline(unittest.TestCase):
             "). Correspondence should be addressed to Dr Yip at this address.",
         )
 
-    # def test_pipe_a_anchor(self):
-    #     node = self.etreeXML.find(".//font[@size='1']")
-    #     data = self.etreeXML, node
-    #     self.pipeline.APipe().transform(data)
+    def test_pipe_a_anchor(self):
+        node = self.etreeXML.find(".//font[@size='1']")
+        data = self.etreeXML, node
+        self.pipeline.APipe().transform(data)
 
-    #     text = etree.tostring(node).strip()
-    #     new_xml = etree.fromstring(text)
+        text = etree.tostring(node).strip()
+        new_xml = etree.fromstring(text)
 
-    #     self.assertEqual(new_xml.find("xref").attrib["rid"], "home")
+        self.assertIsNotNone(new_xml.find("xref"))
 
     def test_pipe_aname__removes_navigation_to_note_go_and_back(self):
         text = """<root><a href="#tx01">
             <graphic xmlns:ns2="http://www.w3.org/1999/xlink" ns2:href="/img/revistas/gs/v29n2/seta.gif"/>
         </a><a name="tx01" id="tx01"/></root>"""
 
-        raw, transformed = self._transform(
-            text, self.pipeline.ANamePipe(self.pipeline))
+        raw, transformed = self._transform(text, self.pipeline.ANamePipe(self.pipeline))
 
         node = transformed.find(".//xref")
         self.assertIsNone(node)
@@ -470,6 +471,21 @@ class TestHTML2SPSPipeline(unittest.TestCase):
 
         node = transformed.find(".//graphic")
         self.assertIsNotNone(node)
+        self.assertIsNotNone(node)
+
+    def test_pipe_aname__removes_navigation_to_note_go_and_back_case2(self):
+        text = """<root><a name="not01" id="not01"></a>TEXTO NOTA</root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.ANamePipe(self.pipeline))
+
+        node_fn = transformed.find(".//fn[p]")
+        self.assertIsNotNone(node_fn)
+        self.assertIsNone(node_fn.tail)
+
+        node_p = transformed.find(".//fn/p")
+        self.assertIsNotNone(node_p)
+
+        self.assertEqual(node_p.text, "TEXTO NOTA")
 
     def test_pipe_a_anchor__remove_xref_with_graphic(self):
         text = """<root><a href="#top">

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -28,9 +28,7 @@ class TestHTML2SPSPipeline(unittest.TestCase):
     def test_create_instance(self):
         expected_text = "<p>La nueva epoca de la revista<italic>Salud Publica de Mexico </italic></p>"
         pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
-        pid, raw, xml = pipeline.SetupPipe().transform(
-            ("S1234-56782018000100011", expected_text)
-        )
+        raw, xml = pipeline.SetupPipe().transform(expected_text)
         self.assertIn(expected_text, str(etree.tostring(xml)))
 
     def test_pipe_remove_empty_do_not_remove_img(self):
@@ -582,7 +580,8 @@ class TestHTML2SPSPipeline(unittest.TestCase):
         text = '<root><td width="" height="" style="style"><p>Teste</p></td></root>'
         raw, transformed = self._transform(text, self.pipeline.TdCleanPipe())
         self.assertEqual(
-            etree.tostring(transformed), b'<root><td style="style">Teste</td></root>'
+            etree.tostring(transformed),
+            b'<root><td style="style"><p>Teste</p></td></root>',
         )
 
     def test_pipe_blockquote(self):

--- a/tests/test_data_sanitization.py
+++ b/tests/test_data_sanitization.py
@@ -1,0 +1,60 @@
+import os
+import unittest
+from lxml import etree
+
+from documentstore_migracao.utils.convert_html_body import DataSanitizationPipeline
+
+
+class TestDataSanitizationPipeline(unittest.TestCase):
+    def _transform(self, text, pipe):
+        tree = etree.fromstring(text)
+        data = text, tree
+        raw, transformed = pipe.transform(data)
+        self.assertEqual(raw, text)
+        return raw, transformed
+
+    def setUp(self):
+        self.pipeline = DataSanitizationPipeline()
+
+    def test__wrap_graphic_in_extlink(self):
+        text = """<root><ext-link href="#top"><graphic xmlns:ns2="http://www.w3.org/1999/xlink" ns2:href="/img/revistas/gs/v29n2/seta.gif"/></ext-link></root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.GraphicInExtLink())
+        self.assertEqual(
+            etree.tostring(transformed),
+            b"""<root><ext-link href="#top"><p><inline-graphic xmlns:ns2="http://www.w3.org/1999/xlink" ns2:href="/img/revistas/gs/v29n2/seta.gif"/></p></ext-link></root>""",
+        )
+
+    def test__table_in_body(self):
+        text = """<root><body><table><tr><td>TEXTO</td></tr></table></body></root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.TableinBody())
+        self.assertEqual(
+            etree.tostring(transformed),
+            b"""<root><body><table-wrap><table><tr><td>TEXTO</td></tr></table></table-wrap></body></root>""",
+        )
+
+    def test__table_in_p(self):
+        text = """<root><p><table><tr><td>TEXTO</td></tr></table></p></root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.TableinP())
+        self.assertEqual(
+            etree.tostring(transformed),
+            b"""<root><p><table-wrap><table><tr><td>TEXTO</td></tr></table></table-wrap></p></root>""",
+        )
+
+    def test__add_p_in_fn(self):
+        text = """<root><fn>TEXTO</fn></root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.AddPinFN())
+        self.assertEqual(
+            etree.tostring(transformed), b"""<root><fn><p>TEXTO</p></fn></root>"""
+        )
+
+    def test__add_p_in_fn_case_2(self):
+        text = """<root><fn><p>TEXTO</p></fn></root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.AddPinFN())
+        self.assertEqual(
+            etree.tostring(transformed), b"""<root><fn><p>TEXTO</p></fn></root>"""
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -101,18 +101,6 @@ class TestUtilsXML(unittest.TestCase):
 
         self.assertIn(expected_text, str(etree.tostring(obj)))
 
-    @patch("documentstore_migracao.utils.xml.etree.fromstring")
-    def test_str2objXML_except(self, mk_fromstring):
-        def _side_effect(arg):
-            if arg == "<body></body>":
-                return b"<body></body>"
-            raise etree.XMLSyntaxError("Test Error - READING XML", 1, 1, 1)
-
-        mk_fromstring.side_effect = _side_effect
-        obj = xml.str2objXML("<a><b>bar</b></a>")
-
-        self.assertIn(b"<body></body>", obj)
-
     def test_file2objXML(self):
         file_path = os.path.join(SAMPLES_PATH, "any.xml")
         expected_text = "<root><a><b>bar</b></a></root>"


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR, cria um novo Pipeline para tratar caso a caso a conversão das tag do body dos arquivos XMLs e reorganiza as tarefas do pipeline atual

#### Onde a revisão poderia começar?
pelo arquivos:
* `documentstore_migracao/utils/convert_html_body.py`
* `documentstore_migracao/export/sps_package.py`
* `documentstore_migracao/utils/xml.py`

#### Como este poderia ser testado manualmente?
Rodando os comando de conversao e validação
```
$ ds_migracao convert && ds_migracao validate
```

#### Quais são tickets relevantes?
#73 #105 #113 #112 #106 

