### PR TITLE
Altera conversão para tratar as alterações no pub-date na SPS 1.9

### DIFF
--- a/documentstore_migracao/config.py
+++ b/documentstore_migracao/config.py
@@ -54,7 +54,7 @@ INITIAL_PATH = [get(k) for k, v in _default.items() if k.endswith("_PATH")]
 INITIAL_PATH = [item for item in INITIAL_PATH if item is not None]
 
 
-DOC_TYPE_XML = """<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "JATS-journalpublishing1.dtd">"""
+DOC_TYPE_XML = """<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "https://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd">"""
 
 os.environ["XML_CATALOG_FILES"] = XML_CATALOG
 

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -407,6 +407,26 @@ class SPS_Package:
 
         return self.xmltree
 
+    def transform_pubdate(self):
+        xpaths_to_change =(
+            ("pub-date[@pub-type='epub']", ("date-type", "pub",)),
+            ("pub-date[@pub-type='collection']", ("date-type", "collection",)),
+            ("pub-date[@pub-type='epub-ppub']", ("date-type", "collection",)),
+        )
+        for xpath, pubdate_element_attr in xpaths_to_change:
+            pubdate = self.article_meta.find(xpath)
+            if pubdate is not None:
+                pubdate.set(*pubdate_element_attr)
+                pubdate.attrib.pop("pub-type")
+        xpaths_to_update =(
+            ("pub-date[@date-type='pub']"),
+            ("pub-date[@date-type='collection']"),
+        )
+        for xpath in xpaths_to_update:
+            pubdate = self.article_meta.find(xpath)
+            if pubdate is not None:
+                pubdate.set("publication-format", "electronic")
+
 
 def sort_documents(documents):
     """

--- a/documentstore_migracao/processing/conversion.py
+++ b/documentstore_migracao/processing/conversion.py
@@ -17,12 +17,14 @@ def convert_article_xml(file_xml_path):
     obj_xmltree = xml.loadToXML(file_xml_path)
     obj_xml = obj_xmltree.getroot()
 
-    obj_xml.set("specific-use", "sps-1.8")
+    obj_xml.set("specific-use", "sps-1.9")
     obj_xml.set("dtd-version", "1.1")
 
     xml_sps = SPS_Package(obj_xmltree)
     # CONVERTE O BODY DO AM PARA SPS
     xml_sps.transform_body()
+    # CONVERTE PUB-DATE PARA SPS 1.9
+    xml_sps.transform_pubdate()
 
     # CONSTROI O SCIELO-id NO XML CONVERTIDO
     xml_sps.create_scielo_id()

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ minio==4.0.16
 more-itertools==6.0.0
 nose==1.3.7
 numpy==1.16.3
-packtools==2.4
+packtools==2.5
 paginate==0.5.6
 PasteDeploy==2.0.1
 pathlib2==2.3.3


### PR DESCRIPTION
#### O que esse PR faz?
Altera o módulo de conversão para gerar XMLs com `specific-use="sps-1.9"` e efetua as
adaptações da tag `pub-date` para a nova versão.
Para a validação, também atualiza a versão do Packtools.

#### Onde a revisão poderia começar?
Em `documentstore_migracao/processing/conversion.py`, L20.
Em `documentstore_migracao/export/sps_package.py`, L410.

#### Como este poderia ser testado manualmente?
Com XMLs já extraídos do Article Meta, executar o comando `SCIELO_COLLECTION=scl ds_migracao convert`. Os XMLs convertidos devem estar com `specific-use="sps-1.9"` e com `pub-date` de acordo com a especificação nova.

#### Algum cenário de contexto que queira dar?
Nenhum.

### Screenshots
N/A

#### Quais são tickets relevantes?
#92 

### Referências
__What's new SPS 1.9__:
https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt_BR/latest/whatsnew-1.9.html
__Documentação de `<pub-date>`__
https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt_BR/latest/tagset/elemento-pub-date.html
