### PR TITLE
Aumenta a resistência a falhas durante a extração de artigos

### DIFF
--- a/documentstore_migracao/config.py
+++ b/documentstore_migracao/config.py
@@ -39,6 +39,7 @@ _default = dict(
     GENERATOR_PATH=os.path.join(BASE_PATH, "xml/html"),
     CONSTRUCTOR_PATH=os.path.join(BASE_PATH, "xml/constructor"),
     ERRORS_PATH=os.path.join(BASE_PATH, "xml/errors"),
+    CACHE_PATH=os.path.join(BASE_PATH, ".cache"),
 )
 
 

--- a/documentstore_migracao/export/article.py
+++ b/documentstore_migracao/export/article.py
@@ -3,6 +3,9 @@ import logging
 from articlemeta.client import RestfulClient
 from documentstore_migracao import config
 from documentstore_migracao.utils import request
+from documentstore.domain import retry_gracefully
+from requests.exceptions import HTTPError, ConnectTimeout, ConnectionError
+from urllib3.exceptions import MaxRetryError
 
 logger = logging.getLogger(__name__)
 client = RestfulClient()
@@ -23,6 +26,7 @@ def get_articles(issn_journal):
     )
 
 
+@retry_gracefully(exc_list=[HTTPError, ConnectTimeout, MaxRetryError, ConnectionError])
 def ext_article(code, **ext_params):
     params = ext_params
     params.update({"collection": config.get("SCIELO_COLLECTION"), "code": code})

--- a/documentstore_migracao/processing/extracted.py
+++ b/documentstore_migracao/processing/extracted.py
@@ -21,23 +21,26 @@ def extract_all_data(list_documents_pids: List[str]):
     logger.info("Iniciando extração dos Documentos")
     count = 0
 
-    for documents_pid in tqdm(
-        iterable=pids_to_extract,
-        initial=len(pids_extracteds),
-        total=len(list_documents_pids),
-    ):
-        documents_pid = documents_pid.strip()
+    try:
+        for documents_pid in tqdm(
+            iterable=pids_to_extract,
+            initial=len(pids_extracteds),
+            total=len(list_documents_pids),
+        ):
+            documents_pid = documents_pid.strip()
 
-        logger.debug("\t coletando dados do Documento '%s'", documents_pid)
-        xml_article = article.ext_article_txt(documents_pid)
-        if xml_article:
-            count += 1
+            logger.debug("\t coletando dados do Documento '%s'", documents_pid)
+            xml_article = article.ext_article_txt(documents_pid)
+            if xml_article:
+                count += 1
 
-            file_path = os.path.join(
-                config.get("SOURCE_PATH"), "%s.xml" % documents_pid
-            )
-            logger.debug("\t Salvando arquivo '%s'", file_path)
-            files.write_file(file_path, xml_article)
-            files.register_latest_stage(stage_path, documents_pid)
+                file_path = os.path.join(
+                    config.get("SOURCE_PATH"), "%s.xml" % documents_pid
+                )
+                logger.debug("\t Salvando arquivo '%s'", file_path)
+                files.write_file(file_path, xml_article)
+                files.register_latest_stage(stage_path, documents_pid)
+    except KeyboardInterrupt:
+        ...
 
     logger.info("\t Total de %s artigos", count)

--- a/documentstore_migracao/processing/extracted.py
+++ b/documentstore_migracao/processing/extracted.py
@@ -11,10 +11,21 @@ logger = logging.getLogger(__name__)
 
 
 def extract_all_data(list_documents_pids: List[str]):
+    """Extrai documentos XML a partir de uma lista de PIDS
+    de entrada"""
+
+    pids_to_extract, pids_extracteds, stage_path = files.fetch_stages_info(
+        list_documents_pids, __name__
+    )
 
     logger.info("Iniciando extração dos Documentos")
     count = 0
-    for documents_pid in tqdm(list_documents_pids):
+
+    for documents_pid in tqdm(
+        iterable=pids_to_extract,
+        initial=len(pids_extracteds),
+        total=len(list_documents_pids),
+    ):
         documents_pid = documents_pid.strip()
 
         logger.debug("\t coletando dados do Documento '%s'", documents_pid)
@@ -27,5 +38,6 @@ def extract_all_data(list_documents_pids: List[str]):
             )
             logger.debug("\t Salvando arquivo '%s'", file_path)
             files.write_file(file_path, xml_article)
+            files.register_latest_stage(stage_path, documents_pid)
 
     logger.info("\t Total de %s artigos", count)

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ regex==2019.4.14
 repoze.lru==0.7
 requests==2.21.0
 scielo-clea==0.3.0
--e git://github.com/scieloorg/document-store.git@9422e6c8b8c25d5980c0c441b77293a42aaf77ec#egg=scielo_documentstore
+-e git://github.com/scieloorg/document-store.git@96585ce99fb09503605416dceb5207a4ac70c43e#egg=scielo_documentstore
 simplejson==3.16.0
 six==1.12.0
 soupsieve==1.9


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request adiciona o mecanismo para que durante a extração de artigos seja possível **parar** e **continuar** do mesmo ponto. Também adiciona o conceito de tentativas em decorrência de falhas relacionadas ao uso do HTTP durante a extração de artigos.

#### Onde a revisão poderia começar?
- `documentstore_migracao/utils/files.py` linhas `108:162`
- `documentstore_migracao/processing/extracted.py` linha `17`

#### Como este poderia ser testado manualmente?
Para testar manualmente este PR deve-se:
- Iniciar a extração de uma lista de pids
- Interromper a extração em algum ponto ao seu critério
- Executar a extração novamente
- A extração deve `continuar` de onde `parou`
---
- Iniciar a extração de uma lista de pids com loglevel `INFO`
- Causar instabilidades de conexão relacionadas com o `article meta`
- Observar as tentativas de obtenção do mesmo artigo algumas vezes

#### Algum cenário de contexto que queira dar?

Este PR não adiciona testes automatizados, a sua intenção é realizar uma discussão a respeito da abordagem para armazenar os passos já realizados pela ferramenta. Em caso de consenso os testes serão produzidos e o PR incrementado.

### Vídeos
[![asciicast](https://asciinema.org/a/aKb4e964ihQteD9B0pk1J2I56.svg)](https://asciinema.org/a/aKb4e964ihQteD9B0pk1J2I56)

#### Quais são tickets relevantes?
#25 

### Referências
N/A
