### PR TITLE
Adiciona a capacidade de coletar os XMLs, PDFs e IMGs da estrutura de pasta do Site antigo do SciELO

### DIFF
--- a/documentstore_migracao/config.py
+++ b/documentstore_migracao/config.py
@@ -18,10 +18,12 @@ XML_ERRORS_PATH:
     arquivos .err cujo conteúdo é XML + mensagens de erro
 SPS_PKG_PATH:
     pacotes de XML validados e nomeados de acordo com SPS
+SITE_SPS_PKG_PATH:
+    Caminhio para os pacotes SPS XML gerados a partir da estrutura do Site antigo do SciELO
 INCOMPLETE_SPS_PKG_PATH:
     pacotes de XML validados e nomeados de acordo com SPS, mas com ativos digitais faltantes
-ERRORS_PATH:	
-    arquivos de erros    
+ERRORS_PATH:
+    arquivos de erros
 """
 
 _default = dict(
@@ -34,6 +36,7 @@ _default = dict(
     VALID_XML_PATH=os.path.join(BASE_PATH, "xml/xml_valid"),
     XML_ERRORS_PATH=os.path.join(BASE_PATH, "xml/xml_errors"),
     SPS_PKG_PATH=os.path.join(BASE_PATH, "xml/sps_packages"),
+    SITE_SPS_PKG_PATH=os.path.join(BASE_PATH, "xml/site_sps_packages"),
     INCOMPLETE_SPS_PKG_PATH=os.path.join(BASE_PATH, "xml/incomplete_sps_packages"),
     LOGGER_PATH=os.path.join(BASE_PATH, ""),
     GENERATOR_PATH=os.path.join(BASE_PATH, "xml/html"),

--- a/documentstore_migracao/main/migrate_articlemeta.py
+++ b/documentstore_migracao/main/migrate_articlemeta.py
@@ -4,6 +4,9 @@ import argparse
 
 from .base import base_parser, minio_parser, mongodb_parser
 
+from documentstore_migracao import config
+from documentstore_migracao.utils.build_ps_package import BuildPSPackage
+
 from documentstore_migracao.processing import (
     extracted,
     conversion,
@@ -86,6 +89,46 @@ def migrate_articlemeta_parser(sargs):
         help="Gera o pacote `SPS` apenas para o documento XML imformado",
     )
 
+    # GERACAO PACOTE SPS FROM SITE STRUTURE
+    pack_sps_parser_from_site = subparsers.add_parser(
+        "pack_from_site", help="Gera pacotes `SPS` a partir da estrutura do Site SciELO"
+    )
+    pack_sps_parser_from_site.add_argument(
+        "-a", "--acrons", dest="acrons", nargs="+", help="journal acronyms."
+    )
+
+    pack_sps_parser_from_site.add_argument(
+        "-Xfolder",
+        "--Xfolder",
+        dest="xml_folder",
+        required=True,
+        help="XML folder path.",
+    )
+
+    pack_sps_parser_from_site.add_argument(
+        "-Ifolder",
+        "--Ifolder",
+        dest="img_folder",
+        required=True,
+        help="IMG folder path.",
+    )
+
+    pack_sps_parser_from_site.add_argument(
+        "-Pfolder",
+        "--pfolder",
+        dest="pdf_folder",
+        required=True,
+        help="PDF folder path.",
+    )
+
+    pack_sps_parser_from_site.add_argument(
+        "-Ofolder",
+        "--ofolder",
+        dest="output_folder",
+        default=config.get('SITE_SPS_PKG_PATH'),
+        help="Output path.",
+    )
+
     # IMPORTACAO
     import_parser = subparsers.add_parser(
         "import",
@@ -123,6 +166,17 @@ def migrate_articlemeta_parser(sargs):
             packing.pack_article_xml(args.packFile)
         else:
             packing.pack_article_ALLxml()
+
+    elif args.command == "pack_from_site":
+        build_ps = BuildPSPackage(
+            args.acrons,
+            args.xml_folder,
+            args.img_folder,
+            args.pdf_folder,
+            args.output_folder,
+        )
+
+        build_ps.run()
 
     elif args.command == "import":
         mongo = ds_adapters.MongoDB(uri=args.uri, dbname=args.db)

--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -1,0 +1,273 @@
+#!/usr/bin/python
+# coding: utf-8
+
+import sys
+import argparse
+import textwrap
+
+import fs
+from fs import path, copy, errors
+from fs.walk import Walker
+
+
+import logging
+
+logging.basicConfig(format="%(asctime)s - %(message)s", level=logging.DEBUG)
+
+
+class BuildPSPackage(object):
+    """
+    Build PS package based on SciELO Site folder structure.
+
+    Folder Struture of legacy SciELO Site:
+
+        <INSTALLED_PATH>/bases/xml
+        <INSTALLED_PATH>/bases/pdf
+        <INSTALLED_PATH>/htdocs/img/revistas
+
+    """
+
+    def __init__(self, acrons, xml_folder, img_folder, pdf_folder, out_folder):
+        """
+        Param acrons: It list of acronym.
+
+        Example: ['mana', 'aa']
+        """
+        self.xml_folder = xml_folder
+        self.img_folder = img_folder
+        self.pdf_folder = pdf_folder
+        self.out_folder = out_folder
+
+        if acrons:
+            self.acrons = acrons
+        else:
+            self.acrons = [
+                acron for acron in self.xml_fs.listdir(".") if self.xml_fs.isdir(acron)
+            ]
+
+    def check_acrons(self):
+        """
+        The struture of the xml_folder:
+
+            xml
+             |---aa
+             |---mana
+             |---ars
+             |---ct
+
+        The sub-folder of this structure are acronyms.
+
+        This method must check if exists file system directory acronym.
+
+        Return True or False, if all directory exists or not.
+        """
+
+        with self.xml_fs as cwd:
+            for acron in self.acrons:
+                if not cwd.exists(acron) or not cwd.isdir(acron):
+                    logging.info("There ins`t folder with acronym: %s" % acron)
+                    return False
+
+        return True
+
+    @property
+    def xml_fs(self):
+        return fs.open_fs(self.xml_folder)
+
+    @property
+    def img_fs(self):
+        return fs.open_fs(self.img_folder)
+
+    @property
+    def pdf_fs(self):
+        return fs.open_fs(self.pdf_folder)
+
+    @property
+    def out_fs(self):
+        return fs.open_fs(self.out_folder)
+
+    def copy(self, src_path, dst_path, src_fs=None, dst_fs=None):
+
+        if not src_fs:
+            src_fs = self.xml_fs
+
+        if not dst_fs:
+            dst_fs = self.out_fs
+        try:
+            copy.copy_file(src_fs, src_path, dst_fs, dst_path)
+
+            logging.info(
+                "Copy asset: %s to: %s"
+                % (
+                    path.join(src_fs.root_path, src_path),
+                    path.join(dst_fs.root_path, dst_path),
+                )
+            )
+
+        except errors.ResourceNotFound as e:
+            logging.info(e)
+
+    def collect_xml(self, acron, xml):
+        issue_folder = path.basename(path.dirname(xml))
+
+        file_name_ext = path.basename(xml)
+
+        file_name, _ = path.splitext(file_name_ext)
+
+        target_folder = path.join(acron, issue_folder, file_name)
+
+        logging.info("Make dir package: %s" % target_folder)
+
+        self.out_fs.makedirs(target_folder, recreate=True)
+
+        xml_path = path.combine(acron, xml)
+
+        target_xml_path = path.join(acron, issue_folder, file_name, file_name_ext)
+
+        self.copy(xml_path, target_xml_path)
+        return issue_folder, file_name
+
+    def rename_pdf_trans_filename(self, filename):
+
+        if filename.find("_") == 3:
+            name, ext = path.splitext(path.basename(filename))
+
+            return "%s%s%s%s" % (name[3:], "-", name[0:2], ext)
+        else:
+            return path.basename(filename)
+
+    def collect_pdf(self, acron, issue_folder, pack_name):
+
+        walker = Walker(filter=["*" + pack_name + "*.pdf"], max_depth=2)
+
+        pdf_path = path.join(self.pdf_fs.root_path, acron, issue_folder)
+
+        for pdf in walker.files(fs.open_fs(pdf_path)):
+
+            pdf_path = path.join(acron, issue_folder, path.basename(pdf))
+
+            target_pdf_path = path.join(
+                acron, issue_folder, pack_name, self.rename_pdf_trans_filename(pdf)
+            )
+
+            self.copy(pdf_path, target_pdf_path, src_fs=self.pdf_fs)
+
+    def collect_img(self, acron, issue_folder, pack_name):
+
+        walker = Walker(
+            filter=["*" + pack_name + "*"], max_depth=2, exclude_dirs=["html"]
+        )
+
+        img_path = path.join(self.img_fs.root_path, acron, issue_folder)
+
+        for img in walker.files(fs.open_fs(img_path)):
+
+            img_path = path.join(acron, issue_folder, path.basename(img))
+
+            target_img_path = path.join(
+                acron, issue_folder, pack_name, path.basename(img)
+            )
+
+            self.copy(img_path, target_img_path, src_fs=self.img_fs)
+
+    def run(self):
+
+        if self.check_acrons():
+            for acron in self.acrons:
+
+                logging.info("Process acronym: %s" % acron)
+
+                walker = Walker(filter=["*.xml"], exclude=["*.*.xml"])
+
+                acron_folder = path.join(self.xml_fs.root_path, acron)
+
+                for xml in walker.files(fs.open_fs(acron_folder)):
+
+                    if len(path.iteratepath(xml)) == 2:
+
+                        logging.info("Process XML: %s" % xml)
+
+                        issue_folder, pack_name = self.collect_xml(acron, xml)
+
+                        self.collect_pdf(acron, issue_folder, pack_name)
+
+                        self.collect_img(acron, issue_folder, pack_name)
+
+        else:
+            return False
+
+
+def main():
+    usage = """\
+    Build PS package based on SciELO Site folder structure.
+
+    Folders used by this script are:
+
+        bases/xml
+        bases/pdf
+        htdocs/img/revistas
+
+    IMPORTANTE: This script must be execute on a SciELO Site instance.
+
+    Execute example: python build_ps_package.py  -Xfolder data/xml -Ifolder data/img -Pfolder data/pdf -Ofolder data/output
+
+    """
+
+    parser = argparse.ArgumentParser(textwrap.dedent(usage))
+
+    parser.add_argument(
+        "-a", "--acrons", dest="acrons", nargs="+", help="journal acronyms."
+    )
+
+    parser.add_argument(
+        "-Xfolder",
+        "--Xfolder",
+        dest="xml_folder",
+        required=True,
+        help="XML folder path.",
+    )
+
+    parser.add_argument(
+        "-Ifolder",
+        "--Ifolder",
+        dest="img_folder",
+        required=True,
+        help="IMG folder path.",
+    )
+
+    parser.add_argument(
+        "-Pfolder",
+        "--pfolder",
+        dest="pdf_folder",
+        required=True,
+        help="PDF folder path.",
+    )
+
+    parser.add_argument(
+        "-Ofolder",
+        "--ofolder",
+        dest="output_folder",
+        required=True,
+        help="Output path.",
+    )
+
+    parser.add_argument(
+        "-v", "--version", action="version", version="version: 0.1.beta"
+    )
+
+    args = parser.parse_args()
+
+    build_ps = BuildPSPackage(
+        args.acrons,
+        args.xml_folder,
+        args.img_folder,
+        args.pdf_folder,
+        args.output_folder,
+    )
+
+    return build_ps.run()
+
+
+if __name__ == "__main__":
+
+    sys.exit(main() or 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,3 +63,4 @@ WebTest==2.0.33
 xylose==1.35.1
 zope.deprecation==4.4.0
 zope.interface==4.6.0
+fs==2.4.5


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR tem com objetivo produzir os pacotes SPS a partir da estrutura do Site SciELO.

#### Onde a revisão poderia começar?

Para validar esse PR é possível revisando os módulos: 

- documentstore_migracao/utils/build_ps_package.py
- documentstore_migracao/main/migrate_articlemeta.py 
- documentstore_migracao/config.py

#### Como este poderia ser testado manualmente?

Montando as pastas compartilhadas da rede para a estrutura do Site de Homologação: 

sudo mount -t nfs -o nfsvers=4 <IP>:/var/www/scielo_br/bases/xml data/xml
sudo mount -t nfs -o nfsvers=4 <IP>:/var/www/scielo_br/bases/pdf data/pdf
sudo mount -t nfs -o nfsvers=4 <IP>:/var/www/scielo_br/htdocs/img/revistas data/img

Commando para teste: **ds_migracao pack_from_site -a rsp -Xfolder data/xml -Ifolder data/img -Pfolder data/pdf**

OBS: Caso necessário para roda posso informar de forma privada o endereço IP.

#### Algum cenário de contexto que queira dar?

Para execução desse script é necessário que tenhamos acesso as pastas do Site SciELO. 

**IMPORTANTE:** a pasta de saída para os pacotes, quando não informada pelo parâmetro --Ofolder, utilizamos a mesma pasta utilizada pela migração que atualmente é xml/sps_packages

É possível rodar esse script de forma independente: 

utils/build_ps_package.py -h

### Screenshots

Exemplo da saída da execução: 

![Screenshot 2019-05-21 16 59 11](https://user-images.githubusercontent.com/373745/58126667-d3a65300-7be9-11e9-9044-a1ba06fe511c.png)

#### Quais são tickets relevantes?

Tk: #81 

### Referências

Não há.
