### PR TITLE
[conversao] Remover a tag 'a' com id duplicados

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -77,13 +77,17 @@ def wrap_content_node(node, elem_wrap="p"):
     node.getparent().replace(node, _node)
 
 
-def gera_id(_string):
+def gera_id(_string, index_body):
 
     number_item = re.search(r"([a-zA-Z]{1,3})(\d)([a-zA-Z])", _string)
     if number_item:
         name_item, number_item, sufix_item = number_item.groups("")
         rid = name_item + str(int(number_item)) + sufix_item
-        return rid
+    else:
+        rid = _string
+
+    ref_id = "%s-%s" % (rid, index_body)
+    return ref_id.lower()
 
 
 class CustomPipe(plumber.Pipe):
@@ -101,6 +105,7 @@ class HTML2SPSPipeline(object):
             self.SetupPipe(super_obj=self),
             self.SaveRawBodyPipe(super_obj=self),
             self.DeprecatedHTMLTagsPipe(),
+            self.RemoveDuplicatedIdPipe(),
             self.RemoveExcedingStyleTagsPipe(),
             self.RemoveEmptyPipe(),
             self.RemoveStyleAttributesPipe(),
@@ -110,8 +115,8 @@ class HTML2SPSPipeline(object):
             self.PPipe(),
             self.DivPipe(),
             self.ANamePipe(super_obj=self),
-            self.TablePipe(),
-            self.ImgPipe(),
+            self.TablePipe(super_obj=self),
+            self.ImgPipe(super_obj=self),
             self.LiPipe(),
             self.OlPipe(),
             self.UlPipe(),
@@ -119,7 +124,7 @@ class HTML2SPSPipeline(object):
             self.EmPipe(),
             self.UPipe(),
             self.BPipe(),
-            self.APipe(),
+            self.APipe(super_obj=self),
             self.StrongPipe(),
             self.TdCleanPipe(),
             self.TableCleanPipe(),
@@ -158,6 +163,19 @@ class HTML2SPSPipeline(object):
                 nodes = xml.findall(".//" + tag)
                 if len(nodes) > 0:
                     etree.strip_tags(xml, tag)
+            return data
+
+    class RemoveDuplicatedIdPipe(plumber.Pipe):
+        def transform(self, data):
+            raw, xml = data
+
+            nodes = xml.findall(".//*[@id]")
+            for node in nodes:
+                attr = node.attrib
+                d_ids = xml.findall(".//*[@id='%s']" % attr["id"])
+                if len(d_ids) > 1:
+                    _remove_element_or_comment(d_ids[1])
+
             return data
 
     class RemoveExcedingStyleTagsPipe(plumber.Pipe):
@@ -381,10 +399,7 @@ class HTML2SPSPipeline(object):
                 node.append(p)
 
             node.attrib.clear()
-            ref_id = "%s-%s" % (
-                gera_id(_id_name) or _id_name,
-                self.super_obj.index_body,
-            )
+            ref_id = gera_id(_id_name, self.super_obj.index_body)
             node.set("ref-id", ref_id)
             node.set("id", ref_id)
 
@@ -394,7 +409,7 @@ class HTML2SPSPipeline(object):
             _process(xml, "a[@name]", self.parser_node)
             return data
 
-    class TablePipe(plumber.Pipe):
+    class TablePipe(CustomPipe):
         def parser_node_table(self, node):
 
             _id = node.attrib.get("id")
@@ -403,9 +418,10 @@ class HTML2SPSPipeline(object):
                 _node = deepcopy(node)
                 p.append(_node)
 
-                id_name = gera_id(new_element[0] + id_name[-1])
-                if id_name:
-                    p.set("id", id_name)
+                id_name = gera_id(
+                    new_element[0] + id_name[-1], self.super_obj.index_body
+                )
+                p.set("id", id_name)
 
                 parent = node.getparent()
                 parent.append(p)
@@ -417,7 +433,7 @@ class HTML2SPSPipeline(object):
             _process(xml, "table[@id]", self.parser_node_table)
             return data
 
-    class ImgPipe(plumber.Pipe):
+    class ImgPipe(CustomPipe):
         def parser_node(self, node):
             node.tag = "graphic"
             _attrib = deepcopy(node.attrib)
@@ -434,16 +450,15 @@ class HTML2SPSPipeline(object):
                 id_name = filename.split("f")
                 new_element = "fig"
 
-            n_id = gera_id(new_element[0] + id_name[-1])
-            if n_id:
-                root = node.getroottree()
-                ref_node = root.find("//%s[@ref-id='%s']" % (new_element, n_id))
-                if ref_node is not None:
-                    _node = deepcopy(node)
-                    ref_node.append(_node)
+            n_id = gera_id(new_element[0] + id_name[-1], self.super_obj.index_body)
+            root = node.getroottree()
+            ref_node = root.find("//%s[@ref-id='%s']" % (new_element, n_id))
+            if ref_node is not None:
+                _node = deepcopy(node)
+                ref_node.append(_node)
 
-                    parent = node.getparent()
-                    parent.remove(node)
+                parent = node.getparent()
+                parent.remove(node)
 
         def transform(self, data):
             raw, xml = data
@@ -529,7 +544,7 @@ class HTML2SPSPipeline(object):
             _process(xml, "b", self.parser_node)
             return data
 
-    class APipe(plumber.Pipe):
+    class APipe(CustomPipe):
         def _parser_node_external_link(self, node, extlinktype="uri"):
             node.tag = "ext-link"
 
@@ -550,6 +565,11 @@ class HTML2SPSPipeline(object):
             node.attrib.clear()
             node.tag = "email"
 
+            if not href:
+                # devido ao caso do href estar mal formado devemos so trocar a tag
+                # e retorna para continuar o Pipe
+                return
+
             img = node.find("img")
             if img is not None:
                 graphic = etree.Element("graphic")
@@ -558,9 +578,6 @@ class HTML2SPSPipeline(object):
                 parent = node.getprevious() or node.getparent()
                 graphic.append(node)
                 parent.append(graphic)
-
-            if not href:
-                return
 
             if node.text and node.text.strip():
                 if href == node.text:
@@ -615,22 +632,23 @@ class HTML2SPSPipeline(object):
                 node.set("ref-type", "bibr")
 
             else:
-                rid = gera_id(xref_name)
-                if rid:
-                    ref_node = root.find("//*[@ref_id='%s']" % rid)
-                    node.set("rid", xref_name)
-                    if ref_node is not None:
-                        ref_type = ref_node.tag
-                        if ref_type == "table-wrap":
-                            ref_type = "table"
-                        node.set("ref-type", ref_type)
+                rid = gera_id(xref_name, self.super_obj.index_body)
+                ref_node = root.find("//*[@ref_id='%s']" % rid)
+
+                node.set("rid", rid)
+                if ref_node is not None:
+                    ref_type = ref_node.tag
+                    if ref_type == "table-wrap":
+                        ref_type = "table"
+                    node.set("ref-type", ref_type)
 
         def parser_node(self, node):
             try:
                 href = node.attrib["href"].strip()
             except KeyError:
-                logger.debug("\tTag 'a' sem href removendo node do xml")
-                _remove_element_or_comment(node)
+                if "id" not in node.attrib.keys():
+                    logger.debug("\tTag 'a' sem href removendo node do xml")
+                    _remove_element_or_comment(node)
             else:
                 if href.startswith("#"):
                     self._parser_node_anchor(node)

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -79,10 +79,10 @@ def wrap_content_node(node, elem_wrap="p"):
 
 def gera_id(_string, index_body):
 
-    number_item = re.search(r"([a-zA-Z]{1,3})(\d+)([a-zA-Z]?)", _string)
+    number_item = re.search(r"([a-zA-Z]{1,3})(\d+)([a-zA-Z0-9]+)?", _string)
     if number_item:
         name_item, number_item, sufix_item = number_item.groups("")
-        rid = name_item + str(int(number_item)) + sufix_item
+        rid = name_item + number_item + sufix_item
     else:
         rid = _string
 
@@ -170,11 +170,13 @@ class HTML2SPSPipeline(object):
             raw, xml = data
 
             nodes = xml.findall(".//*[@id]")
+            root = xml.getroottree()
             for node in nodes:
                 attr = node.attrib
-                d_ids = xml.findall(".//*[@id='%s']" % attr["id"])
+                d_ids = root.findall(".//*[@id='%s']" % attr["id"])
                 if len(d_ids) > 1:
-                    _remove_element_or_comment(d_ids[1])
+                    for index, d_n in enumerate(d_ids[1:]):
+                        d_n.set("id", "%s-duplicate-%s" % (attr["id"], index))
 
             return data
 

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -53,14 +53,28 @@ def _process(xml, tag, func):
 
 
 def wrap_node(node, elem_wrap="p"):
-    tag = node.tag
 
-    p = etree.Element(elem_wrap)
     _node = deepcopy(node)
+    p = etree.Element(elem_wrap)
     p.append(_node)
-    etree.strip_tags(p, tag)
+    node.getparent().replace(node, p)
 
     return p
+
+
+def wrap_content_node(node, elem_wrap="p"):
+
+    _node = deepcopy(node)
+    p = etree.Element(elem_wrap)
+    if _node.text:
+        p.text = _node.text
+    if _node.tail:
+        p.tail = _node.tail
+
+    _node.text = None
+    _node.tail = None
+    _node.append(p)
+    node.getparent().replace(node, _node)
 
 
 def gera_id(_string):
@@ -332,7 +346,6 @@ class HTML2SPSPipeline(object):
             return data
 
     class ANamePipe(CustomPipe):
-
         def find_a_href(self, root, _id_name):
             return root.find('.//a[@href="#{}"]'.format(_id_name))
 
@@ -346,10 +359,12 @@ class HTML2SPSPipeline(object):
             root = node.getroottree()
             if _id_name.startswith("tx"):
                 _remove_element_or_comment(node)
-                _remove_element_or_comment(self.find_a_href(root, _id_name))
+                _a_ref_node = self.find_a_href(root, _id_name)
+                if _a_ref_node is not None:
+                    _remove_element_or_comment(_a_ref_node)
             elif _id_name.startswith("t"):
                 a_href = self.find_a_href(root, _id_name)
-                if a_href and a_href.text and 'tab' in a_href.text.lower():
+                if a_href is not None and a_href.text and "tab" in a_href.text.lower():
                     node.tag = "table-wrap"
                 else:
                     node.tag = "fn"
@@ -358,13 +373,19 @@ class HTML2SPSPipeline(object):
             elif _id_name.startswith("n"):
                 node.tag = "fn"
 
+            if node.tag == "fn":
+                p = etree.Element("p")
+                p.text = (node.text or "") + (node.tail or "")
+                node.tail = None
+                node.text = None
+                node.append(p)
+
             node.attrib.clear()
             ref_id = "%s-%s" % (
                 gera_id(_id_name) or _id_name,
                 self.super_obj.index_body,
             )
-            if ref_id:
-                node.set("ref-id", ref_id)
+            node.set("ref-id", ref_id)
             node.set("id", ref_id)
 
         def transform(self, data):
@@ -443,7 +464,7 @@ class HTML2SPSPipeline(object):
                 if c_node.tag not in self.ALLOWED_CHILDREN
             ]
             for c_node in c_not_allowed:
-                node.replace(c_node, wrap_node(c_node, "p"))
+                wrap_node(c_node, "p")
 
             if node.text:
                 p = etree.Element("p")
@@ -574,14 +595,13 @@ class HTML2SPSPipeline(object):
                     node.remove(list_c_node[0])
                 _remove_element_or_comment(node)
 
-
             node.attrib.clear()
             root = node.getroottree()
 
             xref_name = href.replace("#", "")
             if xref_name == "ref":
 
-                rid = node.text
+                rid = node.text or ""
                 if not rid.isdigit():
                     rid = (
                         rid.replace("(", "")
@@ -590,6 +610,7 @@ class HTML2SPSPipeline(object):
                         .split(",")
                     )
                     rid = rid[0]
+
                 node.set("rid", "B%s" % rid)
                 node.set("ref-type", "bibr")
 
@@ -959,9 +980,9 @@ class DataSanitizationPipeline(object):
         self._ppl = plumber.Pipeline(
             self.SetupPipe(),
             self.GraphicInExtLink(),
-            self.HRTagPape(),
             self.TableinBody(),
             self.TableinP(),
+            self.AddPinFN(),
         )
 
     def deploy(self, raw):
@@ -975,17 +996,11 @@ class DataSanitizationPipeline(object):
             return data, new_obj
 
     class GraphicInExtLink(plumber.Pipe):
-        NEW_TAG = "p"
-
         def parser_node(self, node):
 
             graphic = node.find("graphic")
-            _graphic = deepcopy(graphic)
-            _graphic.tag = "inline-graphic"
-            p = etree.Element(self.NEW_TAG)
-            p.append(_graphic)
-            node.append(p)
-            node.remove(graphic)
+            graphic.tag = "inline-graphic"
+            wrap_node(graphic, "p")
 
         def transform(self, data):
             raw, xml = data
@@ -993,29 +1008,11 @@ class DataSanitizationPipeline(object):
             _process(xml, "ext-link[graphic]", self.parser_node)
             return data
 
-    class HRTagPape(plumber.Pipe):
-        def parser_node(self, node):
-
-            element = etree.fromstring(
-                "<table-wrap><table><tr><td><hr/></td></tr></table></table-wrap>"
-            )
-            node.getparent().replace(node, element)
-
-        def transform(self, data):
-            raw, xml = data
-
-            _process(xml, "hr", self.parser_node)
-            return data
-
     class TableinBody(plumber.Pipe):
         def parser_node(self, node):
 
             table = node.find("table")
-            _table = deepcopy(table)
-            w_wrap = etree.Element("table-wrap")
-            w_wrap.append(_table)
-            node.append(w_wrap)
-            node.remove(table)
+            wrap_node(table, "table-wrap")
 
         def transform(self, data):
             raw, xml = data
@@ -1028,4 +1025,15 @@ class DataSanitizationPipeline(object):
             raw, xml = data
 
             _process(xml, "p[table]", self.parser_node)
+            return data
+
+    class AddPinFN(plumber.Pipe):
+        def parser_node(self, node):
+            if node.text:
+                wrap_content_node(node, "p")
+
+        def transform(self, data):
+            raw, xml = data
+
+            _process(xml, "fn", self.parser_node)
             return data

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -79,7 +79,7 @@ def wrap_content_node(node, elem_wrap="p"):
 
 def gera_id(_string, index_body):
 
-    number_item = re.search(r"([a-zA-Z]{1,3})(\d)([a-zA-Z])", _string)
+    number_item = re.search(r"([a-zA-Z]{1,3})(\d+)([a-zA-Z]?)", _string)
     if number_item:
         name_item, number_item, sufix_item = number_item.groups("")
         rid = name_item + str(int(number_item)) + sufix_item
@@ -416,11 +416,10 @@ class HTML2SPSPipeline(object):
             if _id:
                 p = etree.Element("table-wrap")
                 _node = deepcopy(node)
+                _node.attrib.clear()
                 p.append(_node)
 
-                id_name = gera_id(
-                    new_element[0] + id_name[-1], self.super_obj.index_body
-                )
+                id_name = gera_id(_id, self.super_obj.index_body)
                 p.set("id", id_name)
 
                 parent = node.getparent()
@@ -635,8 +634,9 @@ class HTML2SPSPipeline(object):
                 node.set("ref-type", "bibr")
 
             else:
+
                 rid = gera_id(xref_name, self.super_obj.index_body)
-                ref_node = root.find("//*[@ref_id='%s']" % rid)
+                ref_node = root.find("//*[@ref-id='%s']" % rid)
 
                 node.set("rid", rid)
                 if ref_node is not None:

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -789,7 +789,7 @@ class TestHTML2SPSPipeline(unittest.TestCase):
         raw, transformed = self._transform(text, self.pipeline.RemoveDuplicatedIdPipe())
         self.assertEqual(
             etree.tostring(transformed),
-            b"""<root><a id="B1">Texto</a><p>Texto</p></root>""",
+            b"""<root><a id="B1">Texto</a><p>Texto</p><a id="B1-duplicate-0">Texto</a></root>""",
         )
 
 

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -767,6 +767,31 @@ class TestHTML2SPSPipeline(unittest.TestCase):
                 found = tree.findall(".//%s" % expected_tag)
                 self.assertIsNotNone(found)
 
+    def test_pipe_remove_ref_id(self):
+        text = """<root><a ref-id="B1" id="B1">Texto</a></root>"""
+        raw, transformed = self._transform(text, self.pipeline.RemoveRefIdPipe())
+        self.assertEqual(
+            etree.tostring(transformed), b"""<root><a id="B1">Texto</a></root>"""
+        )
+
+    def test_pipe_table(self):
+        text = """<root><table id="B1"><tr><td>Texto</td></tr></table></root>"""
+        raw, transformed = self._transform(
+            text, self.pipeline.TablePipe(super_obj=self.pipeline)
+        )
+        self.assertEqual(
+            etree.tostring(transformed),
+            b"""<root><table-wrap id="b1-1"><table><tr><td>Texto</td></tr></table></table-wrap></root>""",
+        )
+
+    def test_pipe_remove_id_duplicated(self):
+        text = """<root><a id="B1">Texto</a><p>Texto</p><a id="B1">Texto</a></root>"""
+        raw, transformed = self._transform(text, self.pipeline.RemoveDuplicatedIdPipe())
+        self.assertEqual(
+            etree.tostring(transformed),
+            b"""<root><a id="B1">Texto</a><p>Texto</p></root>""",
+        )
+
 
 class Test_RemovePWhichIsParentOfPPipe_Case1(unittest.TestCase):
     def setUp(self):

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -136,7 +136,9 @@ class TestHTML2SPSPipeline(unittest.TestCase):
 
     def test_pipe_img(self):
         text = '<root><img align="x" src="a04qdr04.gif"/><img align="x" src="a04qdr08.gif"/></root>'
-        raw, transformed = self._transform(text, self.pipeline.ImgPipe())
+        raw, transformed = self._transform(
+            text, self.pipeline.ImgPipe(super_obj=self.pipeline)
+        )
 
         nodes = transformed.findall(".//graphic")
 
@@ -362,7 +364,7 @@ class TestHTML2SPSPipeline(unittest.TestCase):
         xml = etree.fromstring('<root><a href="http://bla.org">texto</a></root>')
         node = xml.find(".//a")
 
-        self.pipeline.APipe()._parser_node_external_link(node)
+        self.pipeline.APipe(super_obj=self.pipeline)._parser_node_external_link(node)
 
         self.assertEqual(set(expected.keys()), set(node.attrib.keys()))
         self.assertEqual(
@@ -383,7 +385,7 @@ class TestHTML2SPSPipeline(unittest.TestCase):
         xml = etree.fromstring(text)
 
         node = xml.find(".//a")
-        self.pipeline.APipe()._create_email(node)
+        self.pipeline.APipe(super_obj=self.pipeline)._create_email(node)
 
         self.assertIn(
             node.attrib.get("{http://www.w3.org/1999/xlink}href"), "mailto:a@scielo.org"
@@ -401,7 +403,7 @@ class TestHTML2SPSPipeline(unittest.TestCase):
         xml = etree.fromstring(text)
 
         node = xml.find(".//a")
-        self.pipeline.APipe()._create_email(node)
+        self.pipeline.APipe(super_obj=self.pipeline)._create_email(node)
         p = xml.find(".//p")
         self.assertEqual(p.text, "Enviar e-mail para ")
         email = p.find("email")
@@ -416,7 +418,7 @@ class TestHTML2SPSPipeline(unittest.TestCase):
         xml = etree.fromstring(text)
 
         node = xml.find(".//a")
-        self.pipeline.APipe()._create_email(node)
+        self.pipeline.APipe(super_obj=self.pipeline)._create_email(node)
 
         self.assertEqual(
             xml.find(".//graphic").attrib.get("{http://www.w3.org/1999/xlink}href"),
@@ -429,7 +431,9 @@ class TestHTML2SPSPipeline(unittest.TestCase):
         text = """<root>
         <p><a href="mailto:a@scielo.org">a@scielo.org</a></p>
         </root>"""
-        raw, transformed = self._transform(text, self.pipeline.APipe())
+        raw, transformed = self._transform(
+            text, self.pipeline.APipe(super_obj=self.pipeline)
+        )
 
         node = transformed.find(".//email")
         self.assertEqual(node.text, "a@scielo.org")
@@ -437,7 +441,9 @@ class TestHTML2SPSPipeline(unittest.TestCase):
 
     def test_pipe_a__create_email_mailto_empty(self):
         text = """<root><a href="mailto:">sfpyip@hku.hk</a>). Correspondence should be addressed to Dr Yip at this address.</root>"""
-        raw, transformed = self._transform(text, self.pipeline.APipe())
+        raw, transformed = self._transform(
+            text, self.pipeline.APipe(super_obj=self.pipeline)
+        )
 
         node = transformed.find(".//email")
         self.assertEqual(node.text, "sfpyip@hku.hk")
@@ -449,7 +455,7 @@ class TestHTML2SPSPipeline(unittest.TestCase):
     def test_pipe_a_anchor(self):
         node = self.etreeXML.find(".//font[@size='1']")
         data = self.etreeXML, node
-        self.pipeline.APipe().transform(data)
+        self.pipeline.APipe(super_obj=self.pipeline).transform(data)
 
         text = etree.tostring(node).strip()
         new_xml = etree.fromstring(text)
@@ -492,7 +498,9 @@ class TestHTML2SPSPipeline(unittest.TestCase):
             <graphic xmlns:ns2="http://www.w3.org/1999/xlink" ns2:href="/img/revistas/gs/v29n2/seta.gif"/>
         </a></root>"""
 
-        raw, transformed = self._transform(text, self.pipeline.APipe())
+        raw, transformed = self._transform(
+            text, self.pipeline.APipe(super_obj=self.pipeline)
+        )
 
         node = transformed.find(".//xref")
         self.assertIsNone(node)
@@ -505,7 +513,9 @@ class TestHTML2SPSPipeline(unittest.TestCase):
     def test_pipe_a_anchor__remove_xref(self):
         text = """<root><a href="#topb">b</a> Demographic and Health Surveys. Available from: </root>"""
 
-        raw, transformed = self._transform(text, self.pipeline.APipe())
+        raw, transformed = self._transform(
+            text, self.pipeline.APipe(super_obj=self.pipeline)
+        )
 
         self.assertEqual(
             etree.tostring(transformed),
@@ -516,7 +526,9 @@ class TestHTML2SPSPipeline(unittest.TestCase):
     def test_pipe_a_anchor__keep_xref(self):
         text = """<root><a href="#tab1">Tabela 1</a> Demographic and Health Surveys. Available from: </root>"""
 
-        raw, transformed = self._transform(text, self.pipeline.APipe())
+        raw, transformed = self._transform(
+            text, self.pipeline.APipe(super_obj=self.pipeline)
+        )
 
         self.assertEqual(
             etree.tostring(transformed),
@@ -526,7 +538,9 @@ class TestHTML2SPSPipeline(unittest.TestCase):
     def test_pipe_a_anchor__xref_bibr_case1(self):
         text = """<root><a href="#ref">(9,10)</a>Tabela 1 </root>"""
 
-        raw, transformed = self._transform(text, self.pipeline.APipe())
+        raw, transformed = self._transform(
+            text, self.pipeline.APipe(super_obj=self.pipeline)
+        )
 
         self.assertEqual(
             etree.tostring(transformed),
@@ -536,7 +550,9 @@ class TestHTML2SPSPipeline(unittest.TestCase):
     def test_pipe_a_anchor__xref_bibr_case2(self):
         text = """<root><a href="#ref">9</a>Tabela 1 </root>"""
 
-        raw, transformed = self._transform(text, self.pipeline.APipe())
+        raw, transformed = self._transform(
+            text, self.pipeline.APipe(super_obj=self.pipeline)
+        )
 
         self.assertEqual(
             etree.tostring(transformed),
@@ -546,7 +562,9 @@ class TestHTML2SPSPipeline(unittest.TestCase):
     def test_pipe_a_anchor__xref_bibr_case3(self):
         text = """<root><a href="#ref">(9-10)</a>Tabela 1 </root>"""
 
-        raw, transformed = self._transform(text, self.pipeline.APipe())
+        raw, transformed = self._transform(
+            text, self.pipeline.APipe(super_obj=self.pipeline)
+        )
 
         self.assertEqual(
             etree.tostring(transformed),
@@ -558,7 +576,7 @@ class TestHTML2SPSPipeline(unittest.TestCase):
         text = """<root><a href="#tabela1">Tabela 1</a> resultado global do levantamento efetuado <img src="/img/revistas/rsp/v8n3/05t1.gif"/></root>"""
 
         data = self._transform(text, self.pipeline.ImgPipe())
-        raw, transformed = self.pipeline.APipe().transform(data)
+        raw, transformed = self.pipeline.APipe(super_obj=self.pipeline).transform(data)
 
         self.assertEqual(
             etree.tostring(transformed),
@@ -576,7 +594,9 @@ class TestHTML2SPSPipeline(unittest.TestCase):
             "</root>",
         ]
         text = "".join(text)
-        raw, transformed = self._transform(text, self.pipeline.APipe())
+        raw, transformed = self._transform(
+            text, self.pipeline.APipe(super_obj=self.pipeline)
+        )
 
         nodes = transformed.findall(".//ext-link")
         self.assertEqual(len(nodes), 4)
@@ -598,12 +618,16 @@ class TestHTML2SPSPipeline(unittest.TestCase):
 
     def test_pipe_remove_a_without_href(self):
         text = "<root><a>Teste</a></root>"
-        raw, transformed = self._transform(text, self.pipeline.APipe())
+        raw, transformed = self._transform(
+            text, self.pipeline.APipe(super_obj=self.pipeline)
+        )
         self.assertIsNone(transformed.find(".//a"))
 
     def test_pipe_a_href_error(self):
         text = '<root><a href="error">Teste</a></root>'
-        raw, transformed = self._transform(text, self.pipeline.APipe())
+        raw, transformed = self._transform(
+            text, self.pipeline.APipe(super_obj=self.pipeline)
+        )
         self.assertEqual(
             etree.tostring(transformed).strip(),
             b'<root><a href="error">Teste</a></root>',

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -105,7 +105,9 @@ class TestHTML2SPSPipeline(unittest.TestCase):
     def test_pipe_hr(self):
         text = '<root><hr style="x" /></root>'
         raw, transformed = self._transform(text, self.pipeline.HrPipe())
-        self.assertEqual(etree.tostring(transformed), b'<root><p content-type="hr"/></root>')
+        self.assertEqual(
+            etree.tostring(transformed), b'<root><p content-type="hr"/></root>'
+        )
 
     def test_pipe_br(self):
         text = '<root><p align="x">bla<br/> continua outra linha</p><p baljlba="1"/><td><br/></td><sec><br/></sec></root>'
@@ -156,7 +158,7 @@ class TestHTML2SPSPipeline(unittest.TestCase):
         expected = [
             b"<list-item><p>Texto dentro de <b>li</b> 1</p></list-item>",
             b"<list-item><p>Texto dentro de <b>li</b> 2</p></list-item>",
-            b"<list-item><p>Texto dentro de 3</p></list-item>",
+            b"<list-item><p><b>Texto dentro de 3</b></p></list-item>",
             b"<list-item><p>Texto dentro de 4</p></list-item>",
         ]
         raw, transformed = self._transform(text, self.pipeline.LiPipe())
@@ -444,23 +446,22 @@ class TestHTML2SPSPipeline(unittest.TestCase):
             "). Correspondence should be addressed to Dr Yip at this address.",
         )
 
-    # def test_pipe_a_anchor(self):
-    #     node = self.etreeXML.find(".//font[@size='1']")
-    #     data = self.etreeXML, node
-    #     self.pipeline.APipe().transform(data)
+    def test_pipe_a_anchor(self):
+        node = self.etreeXML.find(".//font[@size='1']")
+        data = self.etreeXML, node
+        self.pipeline.APipe().transform(data)
 
-    #     text = etree.tostring(node).strip()
-    #     new_xml = etree.fromstring(text)
+        text = etree.tostring(node).strip()
+        new_xml = etree.fromstring(text)
 
-    #     self.assertEqual(new_xml.find("xref").attrib["rid"], "home")
+        self.assertIsNotNone(new_xml.find("xref"))
 
     def test_pipe_aname__removes_navigation_to_note_go_and_back(self):
         text = """<root><a href="#tx01">
             <graphic xmlns:ns2="http://www.w3.org/1999/xlink" ns2:href="/img/revistas/gs/v29n2/seta.gif"/>
         </a><a name="tx01" id="tx01"/></root>"""
 
-        raw, transformed = self._transform(
-            text, self.pipeline.ANamePipe(self.pipeline))
+        raw, transformed = self._transform(text, self.pipeline.ANamePipe(self.pipeline))
 
         node = transformed.find(".//xref")
         self.assertIsNone(node)
@@ -470,6 +471,21 @@ class TestHTML2SPSPipeline(unittest.TestCase):
 
         node = transformed.find(".//graphic")
         self.assertIsNotNone(node)
+        self.assertIsNotNone(node)
+
+    def test_pipe_aname__removes_navigation_to_note_go_and_back_case2(self):
+        text = """<root><a name="not01" id="not01"></a>TEXTO NOTA</root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.ANamePipe(self.pipeline))
+
+        node_fn = transformed.find(".//fn[p]")
+        self.assertIsNotNone(node_fn)
+        self.assertIsNone(node_fn.tail)
+
+        node_p = transformed.find(".//fn/p")
+        self.assertIsNotNone(node_p)
+
+        self.assertEqual(node_p.text, "TEXTO NOTA")
 
     def test_pipe_a_anchor__remove_xref_with_graphic(self):
         text = """<root><a href="#top">

--- a/tests/test_data_sanitization.py
+++ b/tests/test_data_sanitization.py
@@ -1,0 +1,60 @@
+import os
+import unittest
+from lxml import etree
+
+from documentstore_migracao.utils.convert_html_body import DataSanitizationPipeline
+
+
+class TestDataSanitizationPipeline(unittest.TestCase):
+    def _transform(self, text, pipe):
+        tree = etree.fromstring(text)
+        data = text, tree
+        raw, transformed = pipe.transform(data)
+        self.assertEqual(raw, text)
+        return raw, transformed
+
+    def setUp(self):
+        self.pipeline = DataSanitizationPipeline()
+
+    def test__wrap_graphic_in_extlink(self):
+        text = """<root><ext-link href="#top"><graphic xmlns:ns2="http://www.w3.org/1999/xlink" ns2:href="/img/revistas/gs/v29n2/seta.gif"/></ext-link></root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.GraphicInExtLink())
+        self.assertEqual(
+            etree.tostring(transformed),
+            b"""<root><ext-link href="#top"><p><inline-graphic xmlns:ns2="http://www.w3.org/1999/xlink" ns2:href="/img/revistas/gs/v29n2/seta.gif"/></p></ext-link></root>""",
+        )
+
+    def test__table_in_body(self):
+        text = """<root><body><table><tr><td>TEXTO</td></tr></table></body></root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.TableinBody())
+        self.assertEqual(
+            etree.tostring(transformed),
+            b"""<root><body><table-wrap><table><tr><td>TEXTO</td></tr></table></table-wrap></body></root>""",
+        )
+
+    def test__table_in_p(self):
+        text = """<root><p><table><tr><td>TEXTO</td></tr></table></p></root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.TableinP())
+        self.assertEqual(
+            etree.tostring(transformed),
+            b"""<root><p><table-wrap><table><tr><td>TEXTO</td></tr></table></table-wrap></p></root>""",
+        )
+
+    def test__add_p_in_fn(self):
+        text = """<root><fn>TEXTO</fn></root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.AddPinFN())
+        self.assertEqual(
+            etree.tostring(transformed), b"""<root><fn><p>TEXTO</p></fn></root>"""
+        )
+
+    def test__add_p_in_fn_case_2(self):
+        text = """<root><fn><p>TEXTO</p></fn></root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.AddPinFN())
+        self.assertEqual(
+            etree.tostring(transformed), b"""<root><fn><p>TEXTO</p></fn></root>"""
+        )


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR, remove tags `a` que possuam ids duplicados no xmls 

#### Onde a revisão poderia começar?
Pelos arquivos:
* `documentstore_migracao/utils/convert_html_body.py`
*  `tests/test_convert_html_body.py`

#### Como este poderia ser testado manualmente?
Rodando os comando de conversao e validação
```
$ ds_migracao convert && ds_migracao validate
```

#### Quais são tickets relevantes?
#115 
