### PR TITLE
Adicionar o pipe para tratar a Tag disp-quote #108

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -126,6 +126,7 @@ class HTML2SPSPipeline(object):
             self.BlockquotePipe(),
             self.HrPipe(),
             self.TagsHPipe(),
+            self.DispQuotePipe(),
             self.GraphicChildrenPipe(),
             self.RemovePWhichIsParentOfPPipe(),
             self.RemoveRefIdPipe(),
@@ -831,6 +832,65 @@ class HTML2SPSPipeline(object):
             tags = ["h1", "h2", "h3", "h4", "h5", "h6"]
             for tag in tags:
                 _process(xml, tag, self.parser_node)
+            return data
+
+    class DispQuotePipe(plumber.Pipe):
+        TAGS = [
+            "label",
+            "title",
+            "address",
+            "alternatives",
+            "array",
+            "boxed-text",
+            "chem-struct-wrap",
+            "code",
+            "fig",
+            "fig-group",
+            "graphic",
+            "media",
+            "preformat",
+            "supplementary-material",
+            "table-wrap",
+            "table-wrap-group",
+            "disp-formula",
+            "disp-formula-group",
+            "def-list",
+            "list",
+            "tex-math",
+            "mml:math",
+            "p",
+            "related-article",
+            "related-object",
+            "disp-quote",
+            "speech",
+            "statement",
+            "verse-group",
+            "attrib",
+            "permissions",
+        ]
+
+        def parser_node(self, node):
+            node.attrib.clear()
+            if node.text and node.text.strip():
+                new_p = etree.Element("p")
+                new_p.text = node.text
+                node.text = None
+                node.insert(0, new_p)
+
+            for c_node in node.getchildren():
+                if c_node.tail and c_node.tail.strip():
+                    new_p = etree.Element("p")
+                    new_p.text = c_node.tail
+                    c_node.tail = None
+                    c_node.addnext(new_p)
+
+                if c_node.tag not in self.TAGS:
+                    wrap_node(c_node, "p")
+
+        def transform(self, data):
+            raw, xml = data
+
+            _process(xml, "disp-quote", self.parser_node)
             return data
 
     class GraphicChildrenPipe(plumber.Pipe):

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -747,6 +747,30 @@ class TestHTML2SPSPipeline(unittest.TestCase):
             etree.tostring(transformed), b"""<root><x>TEXT 1</x><y>TEXT 2 </y></root>"""
         )
 
+    def test_pipe_disp_quote(self):
+        text = """<root><disp-quote>TEXT</disp-quote></root>"""
+        raw, transformed = self._transform(text, self.pipeline.DispQuotePipe())
+        self.assertEqual(
+            etree.tostring(transformed),
+            b"""<root><disp-quote><p>TEXT</p></disp-quote></root>""",
+        )
+
+    def test_pipe_disp_quote_case2(self):
+        text = """<root><disp-quote><p>TEXT 1</p>TEXT 2</disp-quote></root>"""
+        raw, transformed = self._transform(text, self.pipeline.DispQuotePipe())
+        self.assertEqual(
+            etree.tostring(transformed),
+            b"""<root><disp-quote><p>TEXT 1</p><p>TEXT 2</p></disp-quote></root>""",
+        )
+
+    def test_pipe_disp_quote_case3(self):
+        text = """<root><disp-quote><italic>TEXT 1</italic></disp-quote></root>"""
+        raw, transformed = self._transform(text, self.pipeline.DispQuotePipe())
+        self.assertEqual(
+            etree.tostring(transformed),
+            b"""<root><disp-quote><p><italic>TEXT 1</italic></p></disp-quote></root>""",
+        )
+
     def test__process(self):
         def f(node):
             node.tag = node.tag.upper()


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR cria um novo pipeline para a tag `disp-quote` que visa implementar a correção para o problema reportado pelo ticker #108 

#### Onde a revisão poderia começar?
Pelo arquivos
* `documentstore_migracao/utils/convert_html_body.py`
* `tests/test_convert_html_body.py`

#### Como este poderia ser testado manualmente?
```
$ python setup.py test -s tests.test_convert_html_body.TestHTML2SPSPipeline
```

#### Quais são tickets relevantes?
#108 

