### PR TITLE
Pipeline para converter as tags para def-list, def-items,

### DIFF
--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -233,6 +233,36 @@ class TestHTML2SPSPipeline(unittest.TestCase):
                 self.assertEqual(len(node.attrib), 1)
                 self.assertEqual(node.attrib["list-type"], "bullet")
 
+    def test_pipe_dl(self):
+        text = """
+            <root>
+            <dl><dd>Black hot drink</dd></dl>
+            <dl><dd>Milk</dd></dl>
+            </root>
+        """
+        raw, transformed = self._transform(text, self.pipeline.DefListPipe())
+
+        nodes = transformed.findall(".//def-list")
+        self.assertEqual(len(nodes), 2)
+        for node in nodes:
+            with self.subTest(node=node):
+                self.assertEqual(len(node.attrib), 0)
+
+    def test_pipe_dd(self):
+        text = """
+            <root>
+            <dl><dd>Black hot drink</dd></dl>
+            <dl><dd>Milk</dd></dl>
+            </root>
+        """
+        raw, transformed = self._transform(text, self.pipeline.DefItemPipe())
+
+        nodes = transformed.findall(".//def-item")
+        self.assertEqual(len(nodes), 2)
+        for node in nodes:
+            with self.subTest(node=node):
+                self.assertEqual(len(node.attrib), 0)
+
     def test_pipe_i(self):
         text = """
             <root>

--- a/tests/test_data_sanitization.py
+++ b/tests/test_data_sanitization.py
@@ -58,3 +58,24 @@ class TestDataSanitizationPipeline(unittest.TestCase):
         self.assertEqual(
             etree.tostring(transformed), b"""<root><fn><p>TEXTO</p></fn></root>"""
         )
+
+    def test__add_def_in_defItem(self):
+        text = """<root><def-list><def-item>TEXTO<p>poly(A)polymerase I</p></def-item></def-list></root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.WrapNodeInDefItem())
+        self.assertEqual(len(transformed.findall(".//term")), 1)
+        self.assertEqual(len(transformed.findall(".//def")), 1)
+        self.assertEqual(
+            etree.tostring(transformed),
+            b"""<root><def-list><def-item><term>TEXTO</term><def><p>poly(A)polymerase I</p></def></def-item></def-list></root>""",
+        )
+
+    def test__add_def_in_defItem_case2(self):
+        text = """<root><def-list><def-item><graphic xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="email.gif"/></def-item></def-list></root>"""
+
+        raw, transformed = self._transform(text, self.pipeline.WrapNodeInDefItem())
+        self.assertEqual(len(transformed.findall(".//def")), 1)
+        self.assertEqual(
+            etree.tostring(transformed),
+            b"""<root><def-list><def-item><def><graphic xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="email.gif"/></def></def-item></def-list></root>""",
+        )


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR implementa os pipelines necessários para fazer a conversão de tags conforme descrito no Ticket #107 

#### Onde a revisão poderia começar?
Pelos arquivos
* `documentstore_migracao/utils/convert_html_body.py`
* `tests/test_convert_html_body.py`
* `tests/test_data_sanitization.py`

#### Como este poderia ser testado manualmente?
```
$ python setup.py test -s tests.test_convert_html_body
```

#### Quais são tickets relevantes?
fix #107 

