### PR TITLE
Adiciona o encoding na conversão dos xmls

### DIFF
--- a/documentstore_migracao/utils/xml.py
+++ b/documentstore_migracao/utils/xml.py
@@ -35,6 +35,7 @@ def objXML2file(file_path, obj_xml, pretty=False):
             doctype=config.DOC_TYPE_XML,
             xml_declaration=True,
             method="xml",
+            encoding="utf-8",
             pretty_print=pretty,
         ),
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import tempfile
 from requests.exceptions import HTTPError
 from unittest.mock import patch, MagicMock
 from lxml import etree
@@ -116,6 +117,23 @@ class TestUtilsXML(unittest.TestCase):
         file_path = os.path.join(SAMPLES_PATH, "file.txt")
         with self.assertRaises(etree.XMLSyntaxError):
             xml.file2objXML(file_path)
+
+    def test_objXML2file(self):
+
+        xml_obj = etree.fromstring(
+            """<root>
+                <p>TEXTO é ç á à è</p>
+            </root>"""
+        )
+        test_dir = tempfile.mkdtemp()
+        file_name = os.path.join(test_dir, "test.xml")
+
+        xml.objXML2file(file_name, xml_obj)
+        with open(file_name) as f:
+            text = f.read()
+
+            self.assertIn("<?xml version='1.0' encoding='utf-8'?>", text)
+            self.assertIn("é ç á à è", text)
 
 
 class TestUtilsRequest(unittest.TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR corrige o problema em https://github.com/scieloorg/document-store-migracao/issues/68#issuecomment-491956421, e que deu origem ao ticket #121, visando assim declarar a codificação padrão dos XMLs convertidos e resolver o problema relatado 

#### Onde a revisão poderia começar?
pelo arquivo: 
* `documentstore_migracao/utils/xml.py`

#### Como este poderia ser testado manualmente?
Apos atualizar o codigo, e rodar o comando de conversão `ds_migracao convert` deve notar na analize dos xmls contidos na pasta `xml/conversion/` que em seu cabeçalho se encontra encode `utf-8`, ex:

```xml
<?xml version='1.0' encoding='utf-8'?>
```

#### Quais são tickets relevantes?
#121 

