### PR TITLE
Cria elementos table-wrap, fig, disp-formula, fn, respectivos xref

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1309,7 +1309,8 @@ class AssetsPipeline(object):
 
             if node_label_caption is not None:
                 _node, label, caption = node_label_caption
-                _node.getparent().remove(_node)
+                if _node.getparent() is not None:
+                    _node.getparent().remove(_node)
                 return label, caption
 
         def _get_asset_node(self, img_or_table, xref_id, xref_reftype):

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ requires = [
     "paginate",
     "minio",
     "tqdm",
+    "fs",
 ]
 
 tests_require = [
@@ -35,8 +36,8 @@ tests_require = [
 setuptools.setup(
     name="documentstore-migracao",
     version="0.1",
-    author="Cesar Augustp",
-    author_email="cesar.bruschetta@scielo.org",
+    author="SciELO",
+    author_email="scielo-dev@googlegroups.com",
     description="",
     long_description=README + "\n\n" + CHANGES,
     long_description_content_type="text/markdown",
@@ -61,6 +62,10 @@ setuptools.setup(
         "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
         "Operating System :: OS Independent",
     ],
+    dependency_links=[
+        "git://github.com/scieloorg/document-store.git@96585ce99fb09503605416dceb5207a4ac70c43e#egg=scielo_documentstore",
+    ],
+
     entry_points="""\
         [console_scripts]
             ds_migracao=documentstore_migracao.main:main_migrate_articlemeta


### PR DESCRIPTION
#### O que esse PR faz?
Cria elementos table-wrap, fig, disp-formula, fn, respectivos xref. Estes elementos são criados a partir de a[@name], a[@id], a[@href] e img[@src] que são dos ativos digitais, a[@href] que são links internos.

#### Onde a revisão poderia começar?
- tests/test_convert_html_body.py
- documentstore_migracao/utils/convert_html_body.py

```
            self.CompleteAnchorPipe(super_obj=self),
            self.InternalLinkAsAsteriskPipe(super_obj=self),
            self.AnchorAndInternalLinkPipe(super_obj=self),
            self.AssetsPipe(super_obj=self),
```

```
class AssetsPipeline(object):
    def __init__(self, pid, index_body=1):
        self.pid = pid
        self.index_body = index_body
        self._ppl = plumber.Pipeline(
            self.SetupPipe(),
            self.AddAssetInfoToTablePipe(super_obj=self),
            self.AddAssetInfoToImgElementsPipe(super_obj=self),
            self.AddAssetInfoToLinkElementsPipe(super_obj=self),
            self.CreateAssetElementsFromExternalLinkElementsPipe(super_obj=self),
            self.CreateAssetElementsFromImgOrTableElementsPipe(super_obj=self),
        )
...
```
#### Como este poderia ser testado manualmente?
python setup.py test

#### Algum cenário de contexto que queira dar?

O algoritmo é:

1) Completar a[@name] e a[@id] (`CompleteAnchorPipe`)
2) Remove `<a id="*" name="*"/>` (`InternalLinkAsAsteriskPipe`)
3) Tentar identificar o tipo de elemento que o `a[@name]` e/ou `a[@id]` representa. No HTML, isso é um indicador de que o trecho seguinte merece destaque e pode ser uma imagem, notas de rodapé, referências bibliográficas. Esta identificação é feita pelo valor de `@name` e de `@id` que podem sugerir o tipo de elemento que eles representariam no XML: fn, table-wrap, fig, equation, ref... Também atualizar seus `a[@href="#"]` correspondendtes (`AnchorAndInternalLinkPipe`)
4) Tentar identificar os dados do ativo digital relacionado com table, verificando id de`table[@id]` e criando atributos temporários como "asset_label", "asset_new_id", "asset_elem_name" (`AddAssetInfoToTablePipe`)
5) Tentar identificar os dados do ativo digital relacionado com img, verificando o valor do src (path), inferindo qual é o tipo de ativo digital: table-wrap, fig, equation. (`AddAssetInfoToImgElementsPipe`). Considera que se a imagem aparece no texto mais de uma vez, possivelmente é uma imagem comum e não um ativo digital.
6) Tentar identificar os dados do ativo digital relacionado com `a[@href=/img/revistas...]` e cria atributos temporários como "asset_label", "asset_new_id", "asset_elem_name" (`AddAssetInfoToLinkElementsPipe`)
7) Para os `nodes` identificados no passo anterior (`a[@asset_new_id]`), converter para xref, criar um novo parágrafo e dentro criar o elemento do ativo digital correspondente (table-wrap, fig, equation), completar com o conteúdo (graphic, table, label).(`CreateAssetElementsFromExternalLinkElementsPipe`)
8) Para resolver os nodes: `img[@asset_new_id]` e `table[@asset_new_id]` identificados respectivamente nos passos 5 e 6, localizar o elemento do ativo digital correspondente (table-wrap, fig, equation) ou cria caso não exista, completa com label, caption, que podem estar localizados antes ou depois da imagem ou tabela. (`CreateAssetElementsFromImgOrTableElementsPipe`).

Foram usados os artigos 5, dos fasículos 3, de todas as revistas e todos os anos, somando:
 - 4054 arquivos no total (BR e SP)
 - 3977 eram os arquivos com erros antes destas alterações
 - 848 após estas correções

### Screenshots
N/A

#### Quais são tickets relevantes?
Resolve #109, #110 
Resolve alguns casos de #103, #71 
Não resolve #126

### Referências
https://jats.nlm.nih.gov/publishing/tag-library/1.2/element/table-wrap.html
https://jats.nlm.nih.gov/publishing/tag-library/1.2/element/disp-formula.html
https://jats.nlm.nih.gov/publishing/tag-library/1.2/element/fig.html
https://jats.nlm.nih.gov/publishing/tag-library/1.2/element/xref.html
