### PR TITLE
Incluir os PDFs do documento no seu pacote SciELO PS

### DIFF
--- a/documentstore_migracao/__init__.py
+++ b/documentstore_migracao/__init__.py
@@ -1,6 +1,8 @@
 import sys
 import os
+import faulthandler
 
+faulthandler.enable()
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from documentstore_migracao.utils import logger, files

--- a/documentstore_migracao/__init__.py
+++ b/documentstore_migracao/__init__.py
@@ -1,8 +1,6 @@
 import sys
 import os
-import faulthandler
 
-faulthandler.enable()
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from documentstore_migracao.utils import logger, files

--- a/documentstore_migracao/export/article.py
+++ b/documentstore_migracao/export/article.py
@@ -26,6 +26,10 @@ def get_articles(issn_journal):
     )
 
 
+def get_article(code):
+    return client.document(collection=config.get("SCIELO_COLLECTION"), code=code)
+
+
 @retry_gracefully(exc_list=[HTTPError, ConnectTimeout, MaxRetryError, ConnectionError])
 def ext_article(code, **ext_params):
     params = ext_params

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -241,11 +241,12 @@ class SPS_Package:
 
         # RENDITION PDF
         obj_article = article.get_article(self.publisher_id)
-        pdfs = obj_article.fulltexts()["pdf"]
-        for l_pdf, u_pdf in pdfs.items():
-            f_name, ext = files.extract_filename_ext_by_path(u_pdf)
-            new_fname = self.asset_name(f_name)
-            replacements.append((u_pdf, new_fname))
+        if obj_article:
+            pdfs = obj_article.fulltexts()["pdf"]
+            for l_pdf, u_pdf in pdfs.items():
+                f_name, ext = files.extract_filename_ext_by_path(u_pdf)
+                new_fname = self.asset_name(f_name)
+                replacements.append((u_pdf, new_fname))
 
         return replacements
 
@@ -399,7 +400,12 @@ class SPS_Package:
             _, obj_html_body = convert.deploy(txt_body)
 
             # sobrecreve o html escapado anterior pelo novo xml tratado
-            body.getparent().replace(body, obj_html_body.find("body"))
+            if obj_html_body.tag != "body":
+                obj_html_body = obj_html_body.find("body")
+            if obj_html_body is None:
+                raise TypeError("XML: %s esta sem Body" % (self.publisher_id))
+
+            body.getparent().replace(body, obj_html_body)
 
         return self.xmltree
 

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -242,7 +242,7 @@ class SPS_Package:
         # RENDITION PDF
         obj_article = article.get_article(self.publisher_id)
         if obj_article:
-            pdfs = obj_article.fulltexts()["pdf"]
+            pdfs = obj_article.fulltexts().get("pdf", {})
             for l_pdf, u_pdf in pdfs.items():
                 f_name, ext = files.extract_filename_ext_by_path(u_pdf)
                 new_fname = self.asset_name(f_name)

--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -56,7 +56,10 @@ def pack_article_ALLxml():
 
 def download_asset(old_path, new_fname, dest_path):
     """Returns msg, if error"""
-    location = urljoin(config.get("STATIC_URL_FILE"), old_path)
+    if old_path.startswith("http"):
+        location = old_path
+    else:
+        location = urljoin(config.get("STATIC_URL_FILE"), old_path)
     try:
         request_file = request.get(location, timeout=int(config.get("TIMEOUT") or 10))
     except request.HTTPGetError as e:

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1059,7 +1059,7 @@ class HTML2SPSPipeline(object):
                     node.text = ""
                     node.insert(0, new_p)
 
-                for child in node.iter():
+                for child in node.iterchildren():
                     if child.tail and child.tail.strip():
                         new_p = etree.Element("p")
                         new_p.text = child.tail

--- a/tests/test_processing_packing.py
+++ b/tests/test_processing_packing.py
@@ -49,6 +49,7 @@ class TestProcessingPacking(unittest.TestCase):
             VALID_XML_PATH=SAMPLES_PATH,
             SPS_PKG_PATH=SAMPLES_PATH,
             INCOMPLETE_SPS_PKG_PATH=SAMPLES_PATH,
+            SCIELO_COLLECTION="scl",
         ):
             packing.pack_article_xml(
                 os.path.join(SAMPLES_PATH, "S0044-59672003000300002_sps_completo.xml")
@@ -70,10 +71,11 @@ class TestProcessingPacking(unittest.TestCase):
                     "1809-4392-aa-33-03-353-370-ga02fig01.gif",
                     "1809-4392-aa-33-03-353-370-ga02tab01a.gif",
                     "1809-4392-aa-33-03-353-370-ga02tab01b.gif",
+                    "1809-4392-aa-33-03-353-370-gv33n3a02.pdf",
                 },
                 files,
             )
-            self.assertEqual(10, len(files))
+            self.assertEqual(11, len(files))
 
     def test_pack_article_xml_has_no_media(self):
         with utils.environ(


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR implementa a logica de baixar os PDF dos pacotes SPS dos artigos extraidos do `AM` e convertido para `XML` como descrito no TK #93, e tambem corrige o Bug de `Segmentation fault` que acontecia durante a conversão dos XMLs

#### Onde a revisão poderia começar?
Pelos arqtivos:
* `documentstore_migracao/export/sps_package.py`
* `documentstore_migracao/export/article.py`
* `documentstore_migracao/processing/packing.py`
* `tests/test_processing_packing.py`

FIX `Segmentation fault`
* `documentstore_migracao/utils/convert_html_body.py`
* `documentstore_migracao/__init__.py`

#### Como este poderia ser testado manualmente?
Apos os comandos de `extract` -> `convert` -> `validate` execute o comando de `pack`
```
$  ds_migracao pack
```
e apos o processo verifique que nos pacotes SPS dentro da pasta `xml/sps_packages/<PID>/` encontrasse também os `PDF` e mídias digitais 

#### Quais são tickets relevantes?
#93 

