### PR TITLE
Possibilita a importação de pacotes nativos

### DIFF
--- a/documentstore_migracao/main/migrate_articlemeta.py
+++ b/documentstore_migracao/main/migrate_articlemeta.py
@@ -125,7 +125,7 @@ def migrate_articlemeta_parser(sargs):
         "-Ofolder",
         "--ofolder",
         dest="output_folder",
-        default=config.get('SITE_SPS_PKG_PATH'),
+        default=config.get("SITE_SPS_PKG_PATH"),
         help="Output path.",
     )
 
@@ -136,6 +136,13 @@ def migrate_articlemeta_parser(sargs):
         parents=[mongodb_parser(sargs), minio_parser(sargs)],
     )
 
+    import_parser.add_argument(
+        "--folder",
+        default=config.get("SPS_PKG_PATH"),
+        metavar="",
+        help=f"""Entry path to import SPS packages. The default path
+        is: {config.get("SPS_PKG_PATH")}""",
+    )
     ################################################################################################
     args = parser.parse_args(sargs)
 
@@ -189,7 +196,9 @@ def migrate_articlemeta_parser(sargs):
             minio_secure=args.minio_is_secure,
         )
 
-        inserting.import_documents_to_kernel(session_db=DB_Session(), storage=storage)
+        inserting.import_documents_to_kernel(
+            session_db=DB_Session(), storage=storage, folder=args.folder
+        )
 
     else:
         raise SystemExit(

--- a/tests/test_migrate_articlemeta.py
+++ b/tests/test_migrate_articlemeta.py
@@ -72,7 +72,7 @@ class TestMigrateProcess(unittest.TestCase):
             ]
         )
         mk_import_documents_to_kernel.assert_called_once_with(
-            session_db=ANY, storage=ANY
+            session_db=ANY, storage=ANY, folder=ANY
         )
 
     def test_not_arg(self):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera a ferramenta de linha de comando utilizada para importar os pacotes SPS. As alterações são elencadas da seguinte maneira:

1) Possibilita o uso do argumento `--folder` para determinarmos qual pasta deve ser
utilizada para realizar a importação dos pacotes SPS.
1.1) A pasta padrão é a definida pela variável de ambiente `SPS_PKG_PATH`.
1.2) Agora é possível importar um único pacote SPS por meio do parâmetro `--folder`.

2) Altera a função `register_documents` para buscar os pacotes SPS em níveis hierárquicos
não definidos.
2.1) Os pacotes SPS montados a partir de documentos HTML possuem apenas um nível de pastas `pid/documento`.
2.2) Os pacotes SPS montados a partir do filesystem possuem 3 níveis de pastas.

#### Onde a revisão poderia começar?
- `documentstore_migracao/main/migrate_articlemeta.py` L: `139`

#### Como este poderia ser testado manualmente?
Para testar este PR manualmente deve-se:
- Realizar todo o processo de extração, conversão, validação e empacotamento de artigos originários do HTML;
- Realizar o empacotamento de artigos originários do xml `pack_from_site`;
- Executar o comando de importação sem o argumento `--folder`
- Executar o comando de importação com o argumento `--folder` apontando para a pasta root dos pacotes nativos xml `--folder --folder xml/site_sps_packages`;
- Verificar a importação de todos os pacotes SPS no banco de dados do Kernel.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots e Vídeos
[![asciicast](https://asciinema.org/a/LIzKo2PM5uqBGvjrC8t4QB61P.svg)](https://asciinema.org/a/LIzKo2PM5uqBGvjrC8t4QB61P)

#### Quais são tickets relevantes?
close #129 

### Referências
N/A

