### PR TITLE
Adição da contagem de fig, table e equation nos XML convertidos

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -390,14 +390,8 @@ class SPS_Package:
 
     def transform_article_meta_count(self):
         count_tree = self.xmltree.find(".//counts")
-        elements = [
-            ("fig-count", "fig"),
-            ("table-count", "table"),
-            ("equation-count", "equation"),
-        ]
-        for e_count, element in elements:
-            count = len(self.xmltree.xpath("//body//%s" % element))
-            count_tree.find(e_count).set("count", str(count))
+        if count_tree is not None:
+            count_tree.getparent().remove(count_tree)
 
         return self.xmltree
 

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -388,6 +388,19 @@ class SPS_Package:
 
         return self.xmltree
 
+    def transform_article_meta_count(self):
+        count_tree = self.xmltree.find(".//counts")
+        elements = [
+            ("fig-count", "fig"),
+            ("table-count", "table"),
+            ("equation-count", "equation"),
+        ]
+        for e_count, element in elements:
+            count = len(self.xmltree.xpath("//body//%s" % element))
+            count_tree.find(e_count).set("count", str(count))
+
+        return self.xmltree
+
     def create_scielo_id(self):
         PATHS = [".//article-meta"]
 
@@ -412,17 +425,17 @@ class SPS_Package:
         return self.xmltree
 
     def transform_pubdate(self):
-        xpaths_to_change =(
-            ("pub-date[@pub-type='epub']", ("date-type", "pub",)),
-            ("pub-date[@pub-type='collection']", ("date-type", "collection",)),
-            ("pub-date[@pub-type='epub-ppub']", ("date-type", "collection",)),
+        xpaths_to_change = (
+            ("pub-date[@pub-type='epub']", ("date-type", "pub")),
+            ("pub-date[@pub-type='collection']", ("date-type", "collection")),
+            ("pub-date[@pub-type='epub-ppub']", ("date-type", "collection")),
         )
         for xpath, pubdate_element_attr in xpaths_to_change:
             pubdate = self.article_meta.find(xpath)
             if pubdate is not None:
                 pubdate.set(*pubdate_element_attr)
                 pubdate.attrib.pop("pub-type")
-        xpaths_to_update =(
+        xpaths_to_update = (
             ("pub-date[@date-type='pub']"),
             ("pub-date[@date-type='collection']"),
         )

--- a/documentstore_migracao/processing/conversion.py
+++ b/documentstore_migracao/processing/conversion.py
@@ -29,7 +29,7 @@ def convert_article_xml(file_xml_path):
     # CONSTROI O SCIELO-id NO XML CONVERTIDO
     xml_sps.create_scielo_id()
 
-    # Ajustar o conteúdo de <counts>
+    # Remove a TAG <counts> do XML
     xml_sps.transform_article_meta_count()
 
     languages = "-".join(xml_sps.languages)

--- a/documentstore_migracao/processing/conversion.py
+++ b/documentstore_migracao/processing/conversion.py
@@ -29,6 +29,9 @@ def convert_article_xml(file_xml_path):
     # CONSTROI O SCIELO-id NO XML CONVERTIDO
     xml_sps.create_scielo_id()
 
+    # Ajustar o conteúdo de <counts>
+    xml_sps.transform_article_meta_count()
+
     languages = "-".join(xml_sps.languages)
     _, fname = os.path.split(file_xml_path)
     fname, fext = fname.rsplit(".", 1)

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -1555,5 +1555,4 @@ class Test_ArticleMetaCount(unittest.TestCase):
     def test__transform_article_meta_count(self):
         result = self.sps_package.transform_article_meta_count()
 
-        self.assertEqual(result.find(".//fig-count").attrib["count"], "1")
-        self.assertEqual(result.find(".//table-count").attrib["count"], "1")
+        self.assertIsNone(result.find(".//counts"))

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -99,8 +99,8 @@ class Test_MatchPubDate1(unittest.TestCase):
     def test_transform_pubdate(self):
         self.sps_package.transform_pubdate()
         xpaths_results = (
-            ('pub-date[@date-type="pub"]', ("2010", "5", "13"),),
-            ('pub-date[@date-type="collection"]', ("2012", "2", "3"),),
+            ('pub-date[@date-type="pub"]', ("2010", "5", "13")),
+            ('pub-date[@date-type="collection"]', ("2012", "2", "3")),
         )
         for xpath, result in xpaths_results:
             with self.subTest(xpath=xpath, result=result):
@@ -133,9 +133,7 @@ class Test_MatchPubDate1_Season(unittest.TestCase):
         self.assertEqual(self.sps_package.document_pubdate, ("2010", "05", "13"))
 
     def test_documents_bundle_pubdate(self):
-        self.assertEqual(
-            self.sps_package.documents_bundle_pubdate, ("2012", "", "")
-        )
+        self.assertEqual(self.sps_package.documents_bundle_pubdate, ("2012", "", ""))
 
     def test_transform_pubdate(self):
         self.sps_package.transform_pubdate()
@@ -145,7 +143,9 @@ class Test_MatchPubDate1_Season(unittest.TestCase):
         self.assertEqual(pubdate.findtext("year"), "2010")
         self.assertEqual(pubdate.findtext("month"), "5")
         self.assertEqual(pubdate.findtext("day"), "13")
-        pubdate = self.sps_package.article_meta.find('pub-date[@date-type="collection"]')
+        pubdate = self.sps_package.article_meta.find(
+            'pub-date[@date-type="collection"]'
+        )
         self.assertIsNotNone(pubdate)
         self.assertEqual(pubdate.get("publication-format"), "electronic")
         self.assertEqual(pubdate.findtext("year"), "2012")
@@ -178,8 +178,8 @@ class Test_MatchPubDate2(unittest.TestCase):
     def test_transform_pubdate(self):
         self.sps_package.transform_pubdate()
         xpaths_results = (
-            ('pub-date[@date-type="pub"]', ("2010", "4", "1"),),
-            ('pub-date[@date-type="collection"]', ("2012", None, None),),
+            ('pub-date[@date-type="pub"]', ("2010", "4", "1")),
+            ('pub-date[@date-type="collection"]', ("2012", None, None)),
         )
         for xpath, result in xpaths_results:
             with self.subTest(xpath=xpath, result=result):
@@ -218,8 +218,8 @@ class Test_MatchPubDate3(unittest.TestCase):
     def test_transform_pubdate(self):
         self.sps_package.transform_pubdate()
         xpaths_results = (
-            ('pub-date[@date-type="pub"]', ("2010", "9", "10"),),
-            ('pub-date[@date-type="collection"]', ("2011", None, None),),
+            ('pub-date[@date-type="pub"]', ("2010", "9", "10")),
+            ('pub-date[@date-type="collection"]', ("2011", None, None)),
         )
         for xpath, result in xpaths_results:
             with self.subTest(xpath=xpath, result=result):
@@ -260,8 +260,8 @@ class Test_MatchPubDate4(unittest.TestCase):
     def test_transform_pubdate(self):
         self.sps_package.transform_pubdate()
         xpaths_results = (
-            ('pub-date[@date-type="pub"]', ("2010", "9", "1"),),
-            ('pub-date[@date-type="collection"]', ("2012", "2", None),),
+            ('pub-date[@date-type="pub"]', ("2010", "9", "1")),
+            ('pub-date[@date-type="collection"]', ("2012", "2", None)),
         )
         for xpath, result in xpaths_results:
             with self.subTest(xpath=xpath, result=result):
@@ -1534,3 +1534,26 @@ class Test_DocumentsSort_MoreThanOneBundle(unittest.TestCase):
             for i, location in enumerate(result[docs_bundle_id]["items"]):
                 with self.subTest((docs_bundle_id, i)):
                     self.assertEqual(location, expected[docs_bundle_id][i])
+
+
+class Test_ArticleMetaCount(unittest.TestCase):
+    def setUp(self):
+        xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><article-meta>
+            <counts>
+                <fig-count count="0"/>
+                <table-count count="0"/>
+                <equation-count count="0"/>
+            </counts>
+            <body>
+                <fig id="i01"><graphic xlink:href="/img/fbpe/rm/v30n1/0002i01.gif"/></fig>
+                <table-wrap id="tab01"><label>Tabela 1</label><table><tr><td>TEXTO</td></tr></table></table-wrap>
+            </body>
+        </article-meta></article>"""
+        xmltree = etree.fromstring(xml)
+        self.sps_package = SPS_Package(xmltree, None)
+
+    def test__transform_article_meta_count(self):
+        result = self.sps_package.transform_article_meta_count()
+
+        self.assertEqual(result.find(".//fig-count").attrib["count"], "1")
+        self.assertEqual(result.find(".//table-count").attrib["count"], "1")


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR Implementa a contagem e a marcação no XML da quantidade de elementos `fig`, `table` e `equation` presentes em todos os `bodys` do XML

#### Onde a revisão poderia começar?
Pelos Arquivos
* `documentstore_migracao/export/sps_package.py`
* `tests/test_sps_package.py`

#### Como este poderia ser testado manualmente?

Pelo comando de test do utilitario
```shell
$ python setup.py test -s tests.test_sps_package.Test_ArticleMetaCount
```
Pelo processo de conversão, que apos executar o comando de  conversão `ds_migracao convert`, verifique abrindo um xml convertido que no bloco tags `<counts />` deve ser apresentado algo como o exemplo abaixo:

```xml
      <counts>
        <fig-count count="4"/>
        <table-count count="2"/>
        <equation-count count="0"/>
        <ref-count count="55"/>
        <page-count count="10"/>
      </counts>
```

#### Quais são tickets relevantes?
#131 

### Referências
https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt_BR/latest/tagset/elemento-counts.html
