### PR TITLE
Torna assíncrona a obtenção dos documentos em XML

### DIFF
--- a/documentstore_migracao/config.py
+++ b/documentstore_migracao/config.py
@@ -44,6 +44,7 @@ _default = dict(
     ERRORS_PATH=os.path.join(BASE_PATH, "xml/errors"),
     CACHE_PATH=os.path.join(BASE_PATH, ".cache"),
     VALIDATE_ALL="TRUE",
+    THREADPOOL_MAX_WORKERS=os.cpu_count() * 5,
 )
 
 

--- a/documentstore_migracao/main/__init__.py
+++ b/documentstore_migracao/main/__init__.py
@@ -1,15 +1,31 @@
 """ module to methods to main  """
 
 import sys
+import logging
 
 from .migrate_isis import migrate_isis_parser
 from .migrate_articlemeta import migrate_articlemeta_parser
 from .tools import tools_parser
 
 
+logger = logging.getLogger(__name__)
+
+
 def main_migrate_articlemeta():
     """ method main to script setup.py """
-    sys.exit(migrate_articlemeta_parser(sys.argv[1:]))
+    try:
+        sys.exit(migrate_articlemeta_parser(sys.argv[1:]))
+    except KeyboardInterrupt:
+        # É convencionado no shell que o programa finalizado pelo signal de
+        # código N deve retornar o código N + 128.
+        sys.exit(130)
+    except Exception as exc:
+        logger.exception(
+            "erro durante a execução da função "
+            "'migrate_articlemeta_parser' com os args %s",
+            sys.argv[1:],
+        )
+        sys.exit("Um erro inexperado ocorreu: %s" % exc)
 
 
 def main_migrate_isis():

--- a/documentstore_migracao/processing/extracted.py
+++ b/documentstore_migracao/processing/extracted.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from typing import List
+import concurrent.futures
 from tqdm import tqdm
 from documentstore_migracao.export import article
 from documentstore_migracao.utils import files
@@ -8,6 +9,19 @@ from documentstore_migracao import config
 
 
 logger = logging.getLogger(__name__)
+
+
+def get_and_write(pid, stage_path):
+    documents_pid = pid.strip()
+
+    logger.debug("\t coletando dados do Documento '%s'", documents_pid)
+    xml_article = article.ext_article_txt(documents_pid)
+
+    if xml_article:
+        file_path = os.path.join(config.get("SOURCE_PATH"), "%s.xml" % documents_pid)
+        logger.debug("\t Salvando arquivo '%s'", file_path)
+        files.write_file(file_path, xml_article)
+        files.register_latest_stage(stage_path, documents_pid)
 
 
 def extract_all_data(list_documents_pids: List[str]):
@@ -21,26 +35,31 @@ def extract_all_data(list_documents_pids: List[str]):
     logger.info("Iniciando extração dos Documentos")
     count = 0
 
-    try:
-        for documents_pid in tqdm(
-            iterable=pids_to_extract,
-            initial=len(pids_extracteds),
-            total=len(list_documents_pids),
-        ):
-            documents_pid = documents_pid.strip()
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=config.get("THREADPOOL_MAX_WORKERS")
+    ) as executor:
+        futures = {
+            executor.submit(get_and_write, pid, stage_path): pid
+            for pid in pids_to_extract
+        }
 
-            logger.debug("\t coletando dados do Documento '%s'", documents_pid)
-            xml_article = article.ext_article_txt(documents_pid)
-            if xml_article:
-                count += 1
+        with tqdm(total=len(list_documents_pids), initial=len(pids_extracteds)) as pbar:
+            try:
+                for future in concurrent.futures.as_completed(futures):
+                    pid = futures[future]
+                    pbar.update(1)
+                    try:
+                        result = future.result()
+                    except Exception as exc:
+                        logger.info("%r gerou uma exceção: %s" % (pid, exc))
+                    else:
+                        count += 1
 
-                file_path = os.path.join(
-                    config.get("SOURCE_PATH"), "%s.xml" % documents_pid
+            except KeyboardInterrupt:
+                logger.info(
+                    "Finalizando as tarefas pendentes antes de encerrar."
+                    " Isso poderá levar alguns segundos."
                 )
-                logger.debug("\t Salvando arquivo '%s'", file_path)
-                files.write_file(file_path, xml_article)
-                files.register_latest_stage(stage_path, documents_pid)
-    except KeyboardInterrupt:
-        ...
+                raise
 
     logger.info("\t Total de %s artigos", count)


### PR DESCRIPTION
#### O que esse PR faz?
Acelera em até 20x a obtenção dos documentos XML a partir do ArticleMeta, com o uso de concorrência.

#### Onde a revisão poderia começar?
Pelo módulo `processing/extracted.py`

#### Como este poderia ser testado manualmente?
Execute o comando `ds_migracao extract` antes e depois da aplicação do patch.

#### Algum cenário de contexto que queira dar?
A nova implementação trata `SIGINT` de forma a mitigar a perda de dados. Para isso o programa aguarda que todas as threads em execução sejam finalizadas antes de terminar, o que pode levar alguns vários segundos.

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

