### PR TITLE
Corrige os caracteres acentuados no XML que estão sendo convertido a entidades

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -134,7 +134,6 @@ class HTML2SPSPipeline(object):
             self.RemoveEmptyPipe(),
             self.RemoveStyleAttributesPipe(),
             self.RemoveCommentPipe(),
-            self.FixLesserThanGraterThanPipe(),
             self.BRPipe(),
             self.PPipe(),
             self.DivPipe(),
@@ -983,7 +982,7 @@ class HTML2SPSPipeline(object):
             logger.info("Total de %s 'comentarios' processadas", len(comments))
             return data
 
-    class FixLesserThanGraterThanPipe(plumber.Pipe):
+    class HTMLEscapingPipe(plumber.Pipe):
         def parser_node(self, node):
             text = node.text
             if text:
@@ -991,7 +990,6 @@ class HTML2SPSPipeline(object):
 
         def transform(self, data):
             raw, xml = data
-
             _process(xml, "*", self.parser_node)
             return data
 

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -6,12 +6,15 @@ import os
 from urllib import request, error
 from copy import deepcopy
 from lxml import etree
+# from xml.sax.saxutils import unescape
 from documentstore_migracao.utils import files
 from documentstore_migracao.utils import xml as utils_xml
 from documentstore_migracao import config
 from documentstore_migracao.utils.convert_html_body_inferer import Inferer
 
+
 logger = logging.getLogger(__name__)
+
 
 def _remove_element_or_comment(node, remove_inner=False):
     parent = node.getparent()
@@ -131,7 +134,7 @@ class HTML2SPSPipeline(object):
             self.RemoveEmptyPipe(),
             self.RemoveStyleAttributesPipe(),
             self.RemoveCommentPipe(),
-            self.HTMLEscapingPipe(),
+            self.FixLesserThanGraterThanPipe(),
             self.BRPipe(),
             self.PPipe(),
             self.DivPipe(),
@@ -980,7 +983,7 @@ class HTML2SPSPipeline(object):
             logger.info("Total de %s 'comentarios' processadas", len(comments))
             return data
 
-    class HTMLEscapingPipe(plumber.Pipe):
+    class FixLesserThanGraterThanPipe(plumber.Pipe):
         def parser_node(self, node):
             text = node.text
             if text:

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -6,7 +6,6 @@ import os
 from urllib import request, error
 from copy import deepcopy
 from lxml import etree
-# from xml.sax.saxutils import unescape
 from documentstore_migracao.utils import files
 from documentstore_migracao.utils import xml as utils_xml
 from documentstore_migracao import config

--- a/documentstore_migracao/utils/string.py
+++ b/documentstore_migracao/utils/string.py
@@ -1,8 +1,8 @@
 """ module to methods to string format """
+import unicodedata
 
 DIGIT_CHARS = "bcdfghjkmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ3456789"
 chars_map = {dig: idx for idx, dig in enumerate(DIGIT_CHARS)}
 
-
-def normalize_spaces(_string):
+def normalize(_string):
     return " ".join(_string.split())

--- a/documentstore_migracao/utils/string.py
+++ b/documentstore_migracao/utils/string.py
@@ -1,17 +1,8 @@
 """ module to methods to string format """
-import re
-import unicodedata
-
 
 DIGIT_CHARS = "bcdfghjkmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ3456789"
 chars_map = {dig: idx for idx, dig in enumerate(DIGIT_CHARS)}
 
 
-def normalize(_string):
-
-    return unicodedata.normalize("NFKD", " ".join(_string.split()))
-
-
-def remove_spaces(_string):
-
-    return re.sub(" +", " ", _string).strip()
+def normalize_spaces(_string):
+    return " ".join(_string.split())

--- a/documentstore_migracao/utils/xml.py
+++ b/documentstore_migracao/utils/xml.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def str2objXML(_string):
-    _string = string.normalize_spaces(_string)
+    _string = string.normalize(_string)
     try:
         parser = etree.HTMLParser(remove_blank_text=True, recover=True)
         return etree.fromstring("<body>%s</body>" % (_string), parser=parser)

--- a/documentstore_migracao/utils/xml.py
+++ b/documentstore_migracao/utils/xml.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def str2objXML(_string):
-    _string = string.normalize(_string)
+    _string = string.normalize_spaces(_string)
     try:
         parser = etree.HTMLParser(remove_blank_text=True, recover=True)
         return etree.fromstring("<body>%s</body>" % (_string), parser=parser)

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -1907,3 +1907,33 @@ class TestFixBodyChildrenPipe(unittest.TestCase):
         pl = HTML2SPSPipeline(pid="pid")
         text, xml = pl.FixBodyChildrenPipe().transform((text, xml))
         self.assertEqual(etree.tostring(xml), expected)
+
+
+class Test_HTML2SPSPipeline(unittest.TestCase):
+ 
+    def test_pipeline(self):
+        text = """<root>
+            <p>La nueva época de la revista
+            <italic>Salud Pública de México </italic>
+            </p></root>"""
+        pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
+        _text, xml = pipeline.deploy(text)
+        resultado = etree.tostring(xml, encoding="unicode")
+        print("")
+        print("text", text)
+        print("resultado", resultado)
+        print("época" in resultado)
+        
+        self.assertIn("época", resultado)
+
+# class TestFixLesserThanAndGreaterThanPipe(unittest.TestCase):
+
+#     def test_x(self):
+#         texto = """<root><p></p></root>"""
+#         xml = etree.fromstring(texto)
+
+#         xml.find(".//p").text = "x < b"
+#         pl = HTML2SPSPipeline(pid="pid")
+#         text, xml = pl.FixLesserThanGraterThanPipe().transform((texto, xml))
+#         print(etree.tostring(xml))
+#         self.assertIn("x &lt; b", etree.tostring(xml))

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -1910,30 +1910,58 @@ class TestFixBodyChildrenPipe(unittest.TestCase):
 
 
 class Test_HTML2SPSPipeline(unittest.TestCase):
- 
+
     def test_pipeline(self):
         text = """<root>
+        <p>&#60;</p>
+        <p> a &lt; b</p>
             <p>La nueva época de la revista
             <italic>Salud Pública de México </italic>
             </p></root>"""
         pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
-        _text, xml = pipeline.deploy(text)
+        xml = etree.fromstring(text)
+        text, xml = pipeline.SetupPipe(pipeline).transform(text)
+        text, xml = pipeline.SaveRawBodyPipe(pipeline).transform((text, xml))
+        text, xml = pipeline.DeprecatedHTMLTagsPipe().transform((text, xml))
+        text, xml = pipeline.RemoveImgSetaPipe().transform((text, xml))
+        text, xml = pipeline.RemoveDuplicatedIdPipe().transform((text, xml))
+        text, xml = pipeline.RemoveExcedingStyleTagsPipe().transform((text, xml))
+        text, xml = pipeline.RemoveEmptyPipe().transform((text, xml))
+        text, xml = pipeline.RemoveStyleAttributesPipe().transform((text, xml))
+        text, xml = pipeline.RemoveCommentPipe().transform((text, xml))
+        text, xml = pipeline.BRPipe().transform((text, xml))
+        text, xml = pipeline.PPipe().transform((text, xml))
+        text, xml = pipeline.DivPipe().transform((text, xml))
+        text, xml = pipeline.LiPipe().transform((text, xml))
+        text, xml = pipeline.OlPipe().transform((text, xml))
+        text, xml = pipeline.UlPipe().transform((text, xml))
+        text, xml = pipeline.DefListPipe().transform((text, xml))
+        text, xml = pipeline.DefItemPipe().transform((text, xml))
+        text, xml = pipeline.IPipe().transform((text, xml))
+        text, xml = pipeline.EmPipe().transform((text, xml))
+        text, xml = pipeline.UPipe().transform((text, xml))
+        text, xml = pipeline.BPipe().transform((text, xml))
+        text, xml = pipeline.StrongPipe().transform((text, xml))
+        text, xml = pipeline.RemoveThumbImgPipe().transform((text, xml))
+        text, xml = pipeline.FixElementAPipe(pipeline).transform((text, xml))
+        text, xml = pipeline.InternalLinkAsAsteriskPipe(pipeline).transform((text, xml))
+        text, xml = pipeline.DocumentPipe(pipeline).transform((text, xml))
+        text, xml = pipeline.AnchorAndInternalLinkPipe(pipeline).transform((text, xml))
+        text, xml = pipeline.AssetsPipe(pipeline).transform((text, xml))
+        text, xml = pipeline.APipe(pipeline).transform((text, xml))
+        text, xml = pipeline.ImgPipe(pipeline).transform((text, xml))
+        text, xml = pipeline.TdCleanPipe().transform((text, xml))
+        text, xml = pipeline.TableCleanPipe().transform((text, xml))
+        text, xml = pipeline.BlockquotePipe().transform((text, xml))
+        text, xml = pipeline.HrPipe().transform((text, xml))
+        text, xml = pipeline.TagsHPipe().transform((text, xml))
+        text, xml = pipeline.DispQuotePipe().transform((text, xml))
+        text, xml = pipeline.GraphicChildrenPipe().transform((text, xml))
+        text, xml = pipeline.FixBodyChildrenPipe().transform((text, xml))
+        text, xml = pipeline.RemovePWhichIsParentOfPPipe().transform((text, xml))
+        text, xml = pipeline.RemoveRefIdPipe().transform((text, xml))
+        text, xml = pipeline.SanitizationPipe().transform((text, xml))
         resultado = etree.tostring(xml, encoding="unicode")
-        print("")
-        print("text", text)
-        print("resultado", resultado)
-        print("época" in resultado)
-        
         self.assertIn("época", resultado)
-
-# class TestFixLesserThanAndGreaterThanPipe(unittest.TestCase):
-
-#     def test_x(self):
-#         texto = """<root><p></p></root>"""
-#         xml = etree.fromstring(texto)
-
-#         xml.find(".//p").text = "x < b"
-#         pl = HTML2SPSPipeline(pid="pid")
-#         text, xml = pl.FixLesserThanGraterThanPipe().transform((texto, xml))
-#         print(etree.tostring(xml))
-#         self.assertIn("x &lt; b", etree.tostring(xml))
+        self.assertIn("&lt;", resultado)
+    

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import tempfile
 from requests.exceptions import HTTPError
 from unittest.mock import patch, MagicMock
 from lxml import etree
-from documentstore_migracao.utils.string import normalize_spaces
+from documentstore_migracao.utils.string import normalize
 from documentstore_migracao.utils import files, xml, request, dicts, string
 
 from . import SAMPLES_PATH, COUNT_SAMPLES_FILES
@@ -93,10 +93,10 @@ class TestUtilsFiles(unittest.TestCase):
 
 
 class TestString(unittest.TestCase):
-    def test_string_normalize_spaces_excludes_exceding_spaces(self):
+    def test_string_normalize_excludes_exceding_spaces(self):
         text = "<a><b>barão  </b>             \t\n<b>serão</b></a>"
         expected_text = "<a><b>barão </b> <b>serão</b></a>"
-        resultado = normalize_spaces(text)
+        resultado = normalize(text)
         self.assertEqual(expected_text, resultado)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import tempfile
 from requests.exceptions import HTTPError
 from unittest.mock import patch, MagicMock
 from lxml import etree
-
+from documentstore_migracao.utils.string import normalize_spaces
 from documentstore_migracao.utils import files, xml, request, dicts, string
 
 from . import SAMPLES_PATH, COUNT_SAMPLES_FILES
@@ -12,7 +12,6 @@ from . import SAMPLES_PATH, COUNT_SAMPLES_FILES
 
 class TestUtilsFiles(unittest.TestCase):
     def test_extract_filename_ext_by_path(self):
-
         filename, extension = files.extract_filename_ext_by_path(
             "xml/conversion/S0044-59672014000400003/S0044-59672014000400003.pt.xml"
         )
@@ -90,17 +89,22 @@ class TestUtilsFiles(unittest.TestCase):
 
     def test_sha1(self):
         str_hash = files.sha1(os.path.join(SAMPLES_PATH, "S0036-36341997000100001.xml"))
-
         self.assertEqual("efaa1e0fc26b5b5266be343526434a67c8aca530", str_hash)
+
+
+class TestString(unittest.TestCase):
+    def test_string_normalize_spaces_excludes_exceding_spaces(self):
+        text = "<a><b>barão  </b>             \t\n<b>serão</b></a>"
+        expected_text = "<a><b>barão </b> <b>serão</b></a>"
+        resultado = normalize_spaces(text)
+        self.assertEqual(expected_text, resultado)
 
 
 class TestUtilsXML(unittest.TestCase):
     def test_str2objXML(self):
-
-        expected_text = "<a><b>bar</b></a>"
+        expected_text = "<a><b>barão</b></a>"
         obj = xml.str2objXML(expected_text)
-
-        self.assertIn(expected_text, str(etree.tostring(obj)))
+        self.assertIn(expected_text, etree.tostring(obj, encoding="unicode"))
 
     def test_file2objXML(self):
         file_path = os.path.join(SAMPLES_PATH, "any.xml")
@@ -119,7 +123,6 @@ class TestUtilsXML(unittest.TestCase):
             xml.file2objXML(file_path)
 
     def test_objXML2file(self):
-
         xml_obj = etree.fromstring(
             """<root>
                 <p>TEXTO é ç á à è</p>
@@ -127,11 +130,9 @@ class TestUtilsXML(unittest.TestCase):
         )
         test_dir = tempfile.mkdtemp()
         file_name = os.path.join(test_dir, "test.xml")
-
         xml.objXML2file(file_name, xml_obj)
         with open(file_name) as f:
             text = f.read()
-
             self.assertIn("<?xml version='1.0' encoding='utf-8'?>", text)
             self.assertIn("é ç á à è", text)
 
@@ -169,10 +170,3 @@ class TestUtilsDicts(unittest.TestCase):
     def test_grouper(self):
         result = dicts.grouper(3, "abcdefg", "x")
         self.assertEqual(list(result)[0], ("a", "b", "c"))
-
-
-class TestUtilsStrings(unittest.TestCase):
-    def test_remove_spaces(self):
-        self.assertEqual(
-            string.remove_spaces("MUITO    ESPACO   PALAVRA"), "MUITO ESPACO PALAVRA"
-        )


### PR DESCRIPTION
#### O que esse PR faz?
Corrige os caracteres acentuados no XML que estão sendo convertido a entidades. Por exemplo, &amp;#x27; ao invés de ser representado por seu caracter, sendo que o original é um caracter. 
Foi removido o pipe: HTMLEscapingPipe. No entanto, não foi substituído pelo pipe xml.sax.saxutils.escape pois não encontrei o caso de uso para o pipe HTMLEscapingPipe.
Foi identificado um problema na função string.normalize() por usar unicodedata.normalize() alterava a codificação dos caracteres, decompondo os caracteres acentuados, por exemplo, é era convertido a e '.

#### Onde a revisão poderia começar?
documentstore_migracao/utils/string.py:7

#### Como este poderia ser testado manualmente?
python setup.py test -s tests.test_convert_html_body.Test_HTML2SPSPipeline 

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#146 

### Referências
n/a
