### PR TITLE
Resolve bug na produção da URL quando há segmentos inválidos

### DIFF
--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -59,7 +59,14 @@ def download_asset(old_path, new_fname, dest_path):
     if old_path.startswith("http"):
         location = old_path
     else:
-        location = urljoin(config.get("STATIC_URL_FILE"), old_path)
+        try:
+            location = urljoin(config.get("STATIC_URL_FILE"), old_path)
+        except ValueError as exc:
+            return 'cannot join URL parts "%s" and "%s": %s' % (
+                config.get("STATIC_URL_FILE"),
+                old_path,
+                exc,
+            )
     try:
         request_file = request.get(location, timeout=int(config.get("TIMEOUT") or 10))
     except request.HTTPGetError as e:

--- a/tests/test_processing_packing.py
+++ b/tests/test_processing_packing.py
@@ -167,6 +167,14 @@ class TestProcessingPackingDownloadAsset(unittest.TestCase):
         error = packing.download_asset(old_path, new_fname, dest_path)
         self.assertIsNotNone(error)
 
+    def test_invalid_relative_URL_returns_error(self):
+        """
+        Testa correção do bug:
+        https://github.com/scieloorg/document-store-migracao/issues/158
+        """
+        error = packing.download_asset("//www. [ <a href=", "novo", TEMP_TEST_PATH)
+        self.assertTrue(error.startswith("cannot join URL parts"))
+
 
 class TestProcessingpack_PackingAssets(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
#### O que esse PR faz?
Resolve bug que causava erro ao tentar produzir uma URL com algum segmento inválido.

#### Onde a revisão poderia começar?
documentstore_migracao/processing/packing.py:64

#### Como este poderia ser testado manualmente?
```bash
python setup.py test
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#158 

### Referências
n/a

