### PR TITLE
Fix bug #159 Entidade "Journal" grafada de maneira errada

### DIFF
--- a/documentstore_migracao/processing/inserting.py
+++ b/documentstore_migracao/processing/inserting.py
@@ -77,10 +77,7 @@ def get_document_renditions(
 
 
 def get_document_assets_path(
-    xml: lxml.etree,
-    folder_files: list,
-    folder: str,
-    prefered_types=[".tif"]
+    xml: lxml.etree, folder_files: list, folder: str, prefered_types=[".tif"]
 ) -> Tuple[dict, dict]:
     """Retorna a lista de assets e seus respectivos paths no
     filesystem. Também retorna um dicionário com `arquivos adicionais`
@@ -198,11 +195,15 @@ def register_document(folder: str, session_db, storage) -> None:
 
 
 def get_documents_bundle(session_db, data):
-    issns = list(set([
-        data[issn_type]
-        for issn_type in ("eissn", "pissn", "issn")
-        if data.get(issn_type)
-    ]))
+    issns = list(
+        set(
+            [
+                data[issn_type]
+                for issn_type in ("eissn", "pissn", "issn")
+                if data.get(issn_type)
+            ]
+        )
+    )
     is_issue = data.get("volume") or data.get("number")
     bad_bundle_id = []
     for issn in issns:
@@ -249,21 +250,11 @@ def create_aop_bundle(session_db, issn):
     )
     session_db.documents_bundles.add(data=manifest_data)
     session_db.changes.add(
-        {
-            "timestamp": utcnow(),
-            "entity": "DocumentsBundle",
-            "id": bundle_id,
-        }
+        {"timestamp": utcnow(), "entity": "DocumentsBundle", "id": bundle_id}
     )
     _journal.ahead_of_print_bundle = bundle_id
     session_db.journals.update(_journal)
-    session_db.changes.add(
-        {
-            "timestamp": utcnow(),
-            "entity": "journal",
-            "id": issn,
-        }
-    )
+    session_db.changes.add({"timestamp": utcnow(), "entity": "Journal", "id": issn})
     return session_db.documents_bundles.fetch(bundle_id)
 
 

--- a/documentstore_migracao/utils/logger.py
+++ b/documentstore_migracao/utils/logger.py
@@ -38,6 +38,7 @@ def configure_logger():
                 "documentstore_migracao.export.sps_package": SUB_DICT_CONFIG,
                 "documentstore_migracao.utils.convert_html_body": SUB_DICT_CONFIG,
                 "documentstore_migracao.processing.packing": SUB_DICT_CONFIG,
+                "documentstore_migracao.processing.conversion": SUB_DICT_CONFIG,
             },
             "root": {"level": "DEBUG", "handlers": ["console", "file"]},
         }

--- a/tests/test_inserting.py
+++ b/tests/test_inserting.py
@@ -19,7 +19,7 @@ from documentstore.domain import DocumentsBundle
 from documentstore.exceptions import DoesNotExist
 from documentstore_migracao.processing.inserting import (
     get_document_assets_path,
-    put_static_assets_into_storage
+    put_static_assets_into_storage,
 )
 from documentstore_migracao.utils.xml import loadToXML
 
@@ -71,11 +71,7 @@ class TestProcessingInserting(unittest.TestCase):
             ]
         )
         self.aop_data = dict(
-            [
-                ("eissn", "0001-3714"),
-                ("issn", "0001-3714"),
-                ("year", "2019"),
-            ]
+            [("eissn", "0001-3714"), ("issn", "0001-3714"), ("year", "2019")]
         )
         if not os.path.isdir(config.get("ERRORS_PATH")):
             os.makedirs(config.get("ERRORS_PATH"))
@@ -83,9 +79,7 @@ class TestProcessingInserting(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(config.get("ERRORS_PATH"))
 
-    @patch(
-        "documentstore_migracao.processing.inserting.scielo_ids_generator.issue_id"
-    )
+    @patch("documentstore_migracao.processing.inserting.scielo_ids_generator.issue_id")
     def test_get_documents_bundle_uses_scielo_ids_generator_issue_id_if_issue(
         self, mk_issue_bundle_id
     ):
@@ -101,9 +95,7 @@ class TestProcessingInserting(unittest.TestCase):
     @patch(
         "documentstore_migracao.processing.inserting.scielo_ids_generator.aops_bundle_id"
     )
-    @patch(
-        "documentstore_migracao.processing.inserting.scielo_ids_generator.issue_id"
-    )
+    @patch("documentstore_migracao.processing.inserting.scielo_ids_generator.issue_id")
     def test_get_documents_bundle_uses_scielo_ids_generator_aops_bundle_id_if_aop(
         self, mk_issue_bundle_id, mk_aops_bundle_id
     ):
@@ -135,18 +127,11 @@ class TestProcessingInserting(unittest.TestCase):
         self, mk_create_aop_bundle
     ):
         issns = ["1234-0001", "1234-0002", "1234-0003"]
-        data = {
-            "eissn": issns[0],
-            "pissn": issns[1],
-            "issn": issns[2],
-            "year": "2019",
-        }
+        data = {"eissn": issns[0], "pissn": issns[1], "issn": issns[2], "year": "2019"}
         session_db = MagicMock()
         session_db.documents_bundles.fetch.side_effect = DoesNotExist
         mk_create_aop_bundle.side_effect = DoesNotExist
-        self.assertRaises(
-            ValueError, inserting.get_documents_bundle, session_db, data
-        )
+        self.assertRaises(ValueError, inserting.get_documents_bundle, session_db, data)
         mk_create_aop_bundle.assert_has_calls(
             [call(session_db, issn) for issn in issns], True
         )
@@ -162,10 +147,7 @@ class TestProcessingInserting(unittest.TestCase):
         session_db.documents_bundles.fetch.side_effect = DoesNotExist
         mk_create_aop_bundle.side_effect = DoesNotExist
         self.assertRaises(
-            ValueError,
-            inserting.get_documents_bundle,
-            session_db,
-            self.aop_data
+            ValueError, inserting.get_documents_bundle, session_db, self.aop_data
         )
 
     @patch("documentstore_migracao.processing.inserting.create_aop_bundle")
@@ -179,26 +161,17 @@ class TestProcessingInserting(unittest.TestCase):
         result = inserting.get_documents_bundle(session_db, self.aop_data)
         self.assertEqual(result, mocked_aop_bundle)
 
-    def test_create_aop_bundle_gets_journal(
-        self
-    ):
+    def test_create_aop_bundle_gets_journal(self):
         issn = "1234-0001"
         session_db = MagicMock()
         inserting.create_aop_bundle(session_db, issn)
         session_db.journals.fetch.assert_called_once_with(issn)
 
-    def test_create_aop_bundle_raises_exception_if_journal_not_found(
-        self
-    ):
+    def test_create_aop_bundle_raises_exception_if_journal_not_found(self):
         issn = "1234-0001"
         session_db = MagicMock()
         session_db.journals.fetch.side_effect = DoesNotExist
-        self.assertRaises(
-            DoesNotExist,
-            inserting.create_aop_bundle,
-            session_db,
-            issn
-        )
+        self.assertRaises(DoesNotExist, inserting.create_aop_bundle, session_db, issn)
 
     @patch(
         "documentstore_migracao.processing.inserting.scielo_ids_generator.aops_bundle_id"
@@ -220,12 +193,12 @@ class TestProcessingInserting(unittest.TestCase):
     ):
         mk_utcnow.return_value = "2019-01-02T05:00:00.000000Z"
         expected = {
-            "_id" : "0001-3714-aop",
-            "created" : "2019-01-02T05:00:00.000000Z",
-            "updated" : "2019-01-02T05:00:00.000000Z",
-            "items" : [],
-            "metadata" : {},
-            "id" : "0001-3714-aop",
+            "_id": "0001-3714-aop",
+            "created": "2019-01-02T05:00:00.000000Z",
+            "updated": "2019-01-02T05:00:00.000000Z",
+            "items": [],
+            "metadata": {},
+            "id": "0001-3714-aop",
         }
         mk_bundle_manifest = Mock()
         MockManifestDomainAdapter.return_value = mk_bundle_manifest
@@ -235,7 +208,9 @@ class TestProcessingInserting(unittest.TestCase):
         )
         inserting.create_aop_bundle(session_db, SAMPLE_KERNEL_JOURNAL["id"])
         MockManifestDomainAdapter.assert_any_call(manifest=expected)
-        session_db.documents_bundles.add.assert_called_once_with(data=mk_bundle_manifest)
+        session_db.documents_bundles.add.assert_called_once_with(
+            data=mk_bundle_manifest
+        )
         session_db.changes.add.assert_any_call(
             {
                 "timestamp": "2019-01-02T05:00:00.000000Z",
@@ -245,9 +220,7 @@ class TestProcessingInserting(unittest.TestCase):
         )
 
     @patch("documentstore_migracao.processing.inserting.utcnow")
-    def test_create_aop_bundle_links_aop_bundle_to_journal(
-        self, mk_utcnow
-    ):
+    def test_create_aop_bundle_links_aop_bundle_to_journal(self, mk_utcnow):
         mk_utcnow.return_value = "2019-01-02T05:00:00.000000Z"
         mocked_journal_data = inserting.ManifestDomainAdapter(
             manifest=SAMPLE_KERNEL_JOURNAL
@@ -260,7 +233,7 @@ class TestProcessingInserting(unittest.TestCase):
         session_db.changes.add.assert_any_call(
             {
                 "timestamp": "2019-01-02T05:00:00.000000Z",
-                "entity": "journal",
+                "entity": "Journal",
                 "id": SAMPLE_KERNEL_JOURNAL["id"],
             }
         )
@@ -340,19 +313,18 @@ class TestProcessingInserting(unittest.TestCase):
         inserting.register_documents_in_documents_bundle(
             session_db, documents_sorted_in_bundles
         )
-        mk_get_documents_bundle.assert_any_call(
-            session_db, self.data
-        )
-        mk_get_documents_bundle.assert_any_call(
-            session_db, self.aop_data
-        )
+        mk_get_documents_bundle.assert_any_call(session_db, self.data)
+        mk_get_documents_bundle.assert_any_call(session_db, self.aop_data)
 
 
 class TestDocumentManifest(unittest.TestCase):
     @patch("documentstore_migracao.object_store.minio.MinioStorage")
     def setUp(self, mock_minio_storage):
         self.package_path = os.path.join(SAMPLES_PATH, "0034-8910-rsp-47-02-0231")
-        self.renditions_names = ["0034-8910-rsp-47-02-0231.pdf", "0034-8910-rsp-47-02-0231-en.pdf"]
+        self.renditions_names = [
+            "0034-8910-rsp-47-02-0231.pdf",
+            "0034-8910-rsp-47-02-0231-en.pdf",
+        ]
         self.renditions_urls_mock = [
             "prefix/0034-8910-rsp-47-02-0231.pdf.pdf",
             "prefix/0034-8910-rsp-47-02-0231.pdf-en.pdf",
@@ -365,7 +337,9 @@ class TestDocumentManifest(unittest.TestCase):
 
     def test_rendition_should_contains_file_name(self):
         self.assertEqual("0034-8910-rsp-47-02-0231.pdf", self.renditions[0]["filename"])
-        self.assertEqual("0034-8910-rsp-47-02-0231-en.pdf", self.renditions[1]["filename"])
+        self.assertEqual(
+            "0034-8910-rsp-47-02-0231-en.pdf", self.renditions[1]["filename"]
+        )
 
     def test_rendition_should_contains_url_link(self):
         self.assertEqual(self.renditions_urls_mock[0], self.renditions[0]["url"])
@@ -378,10 +352,10 @@ class TestDocumentManifest(unittest.TestCase):
     def test_rendition_should_contains_mimetype(self):
         self.assertEqual("application/pdf", self.renditions[0]["mimetype"])
         self.assertEqual("application/pdf", self.renditions[1]["mimetype"])
-    
+
     def test_renditon_should_contains_language(self):
         self.assertEqual("en", self.renditions[1]["lang"])
-    
+
     def test_rendtion_should_not_contains_language(self):
         self.assertIsNone(self.renditions[0].get("lang"))
 


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o bug reportado pelo issue #159, 

**obs**: foi aplicado o black nos arquivos modificados, por isso as modificações foram maiores do que a necessidade para a correção do BUG

#### Onde a revisão poderia começar?
pelo arquivos:
* `documentstore_migracao/processing/inserting.py`

#### Como este poderia ser testado manualmente?
```shell
$ python setup.py test -s tests.test_inserting.TestProcessingInserting
```

#### Algum cenário de contexto que queira dar?
Esse erro é pertinente pois ao o padrão do valor da chave `entity` no `dict` de _changes do kernel_ deve ser igual ao nome da classe que ele representa

#### Quais são tickets relevantes?
#159 