### PR TITLE
Adição do dockerfile para projeto `publishing-showcase`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.DS_Store
+xml/
+isis/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.7-alpine
+
+ COPY . /app
+RUN apk add --no-cache --virtual .build-deps \
+        make gcc libxml2-dev libxslt-dev musl-dev g++ git openjdk8 \
+    && apk add libxml2 libxslt \
+    && pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r /app/requirements.txt \
+    && pip install -e /app
+
+ WORKDIR /app
+ENV PYTHONUNBUFFERED 1
+
+ RUN chown -R nobody:nogroup /app
+USER nobody
+
+ CMD ["/bin/sh"]  


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR adicionar os arquivos `Dockerfile` e `.dockerignore` e permite que seja criado uma docker para o utilitario de migração, e assim facilitando sua integração na stack do `publishing-showcase`, e facilitando também a execução das rotinas de migração e teste que estamos realizando nesse projeto

#### Onde a revisão poderia começar?
Pelo Arquivo:
* `.dockerignore`
* `Dockerfile`

#### Como este poderia ser testado manualmente?
Apos atualizar a ambiente, execute o comando de build do docker 
    ```
    $ docker build -t documentstore_migracao:latest ./
    ```
e depois suba a docker 
    ```
    $ docker run -ti documentstore_migracao:latest sh
    ```
e dentro da docker execute o processo de migração normal mente

#### Algum cenário de contexto que queira dar?
EU criei essa docker para que foce possível adicionar o utilitario de migração no stack do `publishing-showcase` e com isso rodar com mais facilidades toda a pilha de tarefas decorrentes do processo

### Screenshots
N/A
