### PR TITLE
Adição de parâmetro para gerar scielo_id

### DIFF
--- a/documentstore_migracao/main/tools.py
+++ b/documentstore_migracao/main/tools.py
@@ -34,21 +34,26 @@ def tools_parser(sargs):
     )
 
     # CONSTRUCTOR XML
+    parents_construction = paths_parser(
+        sargs,
+        **{
+            "d_source": config.get("VALID_XML_PATH"),
+            "h_source": "Pasta onde esta os xml para transformação, default: VALID_XML_PATH",
+            "d_desc": config.get("CONSTRUCTOR_PATH"),
+            "h_desc": "Pasta onde sera salvo os XML alterados, default: CONSTRUCTOR_PATH",
+        }
+    )
+    parents_construction.add_argument(
+        "--in-place", type=bool, default=False,
+        help="Realiza a alteração dos mesmos arquivos xmls que foram recebidos como source"
+    )
     construction_parser = subparsers.add_parser(
         "construction",
         help="Alterá todos os XML contidos na pasta informada pelo argumento '--source-path' ou '-p' "
         "ou o default é a pasta 'VALID_XML_PATH' e salva os arquivos na pasta informada pelo '--desc-path' ou '-d' "
         "ou o default é a pasta 'CONSTRUCTOR_PATH' e gerando a tag `article-id` com o scielo-id nos xml",
         parents=[
-            paths_parser(
-                sargs,
-                **{
-                    "d_source": config.get("VALID_XML_PATH"),
-                    "h_source": "Pasta onde esta os xml para transformação, default: VALID_XML_PATH",
-                    "d_desc": config.get("CONSTRUCTOR_PATH"),
-                    "h_desc": "Pasta onde sera salvo os XML alterados, default: CONSTRUCTOR_PATH",
-                }
-            )
+            parents_construction
         ],
     )
 
@@ -64,7 +69,7 @@ def tools_parser(sargs):
         generation.article_ALL_html_generator(args.source_path, args.desc_path)
 
     elif args.command == "construction":
-        constructor.article_ALL_constructor(args.source_path, args.desc_path)
+        constructor.article_ALL_constructor(args.source_path, args.desc_path, args.in_place)
 
     else:
         raise SystemExit(

--- a/documentstore_migracao/main/tools.py
+++ b/documentstore_migracao/main/tools.py
@@ -44,7 +44,7 @@ def tools_parser(sargs):
         }
     )
     parents_construction.add_argument(
-        "--in-place", type=bool, default=False,
+        "--in-place", action='store_true', default=False,
         help="Realiza a alteração dos mesmos arquivos xmls que foram recebidos como source"
     )
     construction_parser = subparsers.add_parser(

--- a/documentstore_migracao/tools/constructor.py
+++ b/documentstore_migracao/tools/constructor.py
@@ -1,7 +1,11 @@
 import os
 import logging
+
+import fs
 from lxml import etree
 from tqdm import tqdm
+from fs import path
+from fs.walk import Walker
 
 from documentstore_migracao.utils import files, string, xml
 from documentstore_migracao.export.sps_package import SPS_Package
@@ -10,7 +14,7 @@ from documentstore_migracao import config
 logger = logging.getLogger(__name__)
 
 
-def article_xml_constructor(file_xml_path: str, dest_path: str) -> None:
+def article_xml_constructor(file_xml_path: str, dest_path: str, in_place: bool) -> None:
 
     logger.debug("file: %s", file_xml_path)
 
@@ -20,17 +24,23 @@ def article_xml_constructor(file_xml_path: str, dest_path: str) -> None:
     # CONSTROI O SCIELO-id NO XML CONVERTIDO
     xml_sps.create_scielo_id()
 
-    new_file_xml_path = os.path.join(dest_path, os.path.basename(file_xml_path))
+    if in_place:
+        new_file_xml_path = file_xml_path
+    else:
+        new_file_xml_path = os.path.join(dest_path, os.path.basename(file_xml_path))
+
     xml.objXML2file(new_file_xml_path, xml_sps.xmltree, pretty=True)
 
 
-def article_ALL_constructor(source_path: str, dest_path: str) -> None:
+def article_ALL_constructor(source_path: str, dest_path: str, in_place:bool=False) -> None:
 
     logger.info("Iniciando Construção dos XMLs")
-    list_files_xmls = files.xml_files_list(source_path)
-    for file_xml in tqdm(list_files_xmls):
+    walker = Walker(filter=["*.xml"], exclude=["*.*.xml"])
 
+    list_files_xmls = walker.files(fs.open_fs(source_path))
+    for file_xml in tqdm(list_files_xmls):
+        file_xml = source_path + file_xml
         try:
-            article_xml_constructor(os.path.join(source_path, file_xml), dest_path)
+            article_xml_constructor(file_xml, dest_path, in_place)
         except Exception as ex:
             logger.info("não foi possível gerar o XML do Arquivo %s: %s", file_xml, ex)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -20,7 +20,7 @@ class TestMainTools(unittest.TestCase):
 
         with utils.environ(VALID_XML_PATH="/tmp", CONSTRUCTOR_PATH="/tmp"):
             tools_parser(["construction"])
-            mk_article_ALL_constructor.assert_called_once_with("/tmp", "/tmp")
+            mk_article_ALL_constructor.assert_called_once_with("/tmp", "/tmp", False)
 
 
 class TestProcessingConstructor(unittest.TestCase):
@@ -28,7 +28,7 @@ class TestProcessingConstructor(unittest.TestCase):
     def test_article_xml_constructor(self, mk_write_file):
 
         constructor.article_xml_constructor(
-            os.path.join(SAMPLES_PATH, "S0044-59672003000300001.pt.xml"), "/tmp"
+            os.path.join(SAMPLES_PATH, "S0044-59672003000300001.pt.xml"), "/tmp", False
         )
         mk_write_file.assert_called_with(
             "/tmp/S0044-59672003000300001.pt.xml", ANY, pretty=True
@@ -37,15 +37,15 @@ class TestProcessingConstructor(unittest.TestCase):
     @patch("documentstore_migracao.tools.constructor.article_xml_constructor")
     def test_article_ALL_constructor(self, mk_article_xml_constructor):
 
-        constructor.article_ALL_constructor(SAMPLES_PATH, "/tmp")
-        mk_article_xml_constructor.assert_called_with(ANY, "/tmp")
+        constructor.article_ALL_constructor(SAMPLES_PATH, "/tmp", False)
+        mk_article_xml_constructor.assert_called_with(ANY, "/tmp", False)
 
     @patch("documentstore_migracao.tools.constructor.article_xml_constructor")
     def test_article_ALL_constructor_with_exception(self, mk_article_xml_constructor):
 
         mk_article_xml_constructor.side_effect = KeyError("Test Error - constructor")
         with self.assertLogs("documentstore_migracao.tools.constructor") as log:
-            constructor.article_ALL_constructor(SAMPLES_PATH, "/tmp")
+            constructor.article_ALL_constructor(SAMPLES_PATH, "/tmp", False)
 
         has_message = False
         for log_message in log.output:


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR altera os o comando `ds_tools construction` para que seja possível ler uma pasta com varios sub-niveis e permite que seja possível alterar o proprio local do xml, e adicionar o scielo_id, e depois é possivel gerar o zip para o processamento do airflow

#### Onde a revisão poderia começar?
Pelos arquivos:
* `documentstore_migracao/main/tools.py`
* `documentstore_migracao/tools/constructor.py`
* `tests/test_tools.py`

#### Como este poderia ser testado manualmente?
Pelos teste unitarios:
   ```
   $ python setup.py test
   ```
ou 
   Executando o utilitario de migração e verificando se os xmls gerado contem o  `scielo_id`
```
   $ ds_tools construction -p ./xml/site_sps_packages/csp --in-place=true
```

#### Algum cenário de contexto que queira dar?
Essa alterações se deram para ser um complemento do comando `ds_migracao pack_from_site` e que apos coletar os xmls nativos, seja adicionado o `scielo_id` na propria estrutura de pasta ja criada, para que depois seja mais facil criar os pacotes sps para o airflow


### Screenshots
N/A