### PR TITLE
Adicionar `publication_months` e remoção do Remover mês de publicação

### DIFF
--- a/documentstore_migracao/utils/xylose_converter.py
+++ b/documentstore_migracao/utils/xylose_converter.py
@@ -162,7 +162,7 @@ def issue_to_kernel(issue):
     de dados equivalente ao persistido pelo Kernel em um banco
     mongodb"""
 
-    issn_id = issue.data['issue']['v35'][0]['_']
+    issn_id = issue.data["issue"]["v35"][0]["_"]
     _creation_date = parse_date(issue.publication_date)
     _metadata = {}
     _bundle = {
@@ -175,7 +175,6 @@ def issue_to_kernel(issue):
     _year = str(date_to_datetime(_creation_date).year)
     _month = str(date_to_datetime(_creation_date).month)
     _metadata["publication_year"] = set_metadata(_creation_date, _year)
-    _metadata["publication_month"] = set_metadata(_creation_date, _month)
 
     if issue.volume:
         _metadata["volume"] = set_metadata(_creation_date, issue.volume)
@@ -200,11 +199,14 @@ def issue_to_kernel(issue):
         ]
         _metadata["titles"] = set_metadata(_creation_date, _titles)
 
+    publication_months = {}
     if issue.start_month and issue.end_month:
-        _publication_season = [int(issue.start_month), int(issue.end_month)]
-        _metadata["publication_season"] = set_metadata(
-            _creation_date, sorted(set(_publication_season))
-        )
+        publication_months["start_month"] = int(issue.start_month)
+        publication_months["end_month"] = int(issue.end_month)
+    elif _month:
+        publication_months["month"] = int(_month)
+
+    _metadata["publication_months"] = set_metadata(_creation_date, publication_months)
 
     _id = scielo_ids_generator.issue_id(
         issn_id, _year, issue.volume, issue.number, _supplement

--- a/documentstore_migracao/utils/xylose_converter.py
+++ b/documentstore_migracao/utils/xylose_converter.py
@@ -201,8 +201,7 @@ def issue_to_kernel(issue):
 
     publication_months = {}
     if issue.start_month and issue.end_month:
-        publication_months["start_month"] = int(issue.start_month)
-        publication_months["end_month"] = int(issue.end_month)
+        publication_months["range"] = (int(issue.start_month), int(issue.end_month))
     elif _month:
         publication_months["month"] = int(_month)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -501,7 +501,7 @@ SAMPLE_ISSUES_KERNEL = [
         "items": [],
         "metadata": {
             "publication_year": [["1998-09-01T00:00:00.000000Z", "1998"]],
-            "publication_month": [["1998-09-01T00:00:00.000000Z", "9"]],
+            "publication_months": [["1998-09-01T00:00:00.000000Z", {"month": 9}]],
             "volume": [["1998-09-01T00:00:00.000000Z", "29"]],
             "number": [["1998-09-01T00:00:00.000000Z", "3"]],
             "publication_season": [["1998-09-01T00:00:00.000000Z", [9]]],

--- a/tests/test_xylose_converter.py
+++ b/tests/test_xylose_converter.py
@@ -261,7 +261,7 @@ class TestXyloseIssueConverter(unittest.TestCase):
         self.issue_json["v43"] = [{"m": "Feb./Feb."}]
         self.issue = issue_to_kernel(self._issue)
         self.assertEqual(
-            [["2019-01-29T00:00:00.000000Z", {"start_month": 2, "end_month": 2}]],
+            [["2019-01-29T00:00:00.000000Z", {"range": (2,2)}]],
             self.issue["metadata"]["publication_months"],
         )
 
@@ -269,7 +269,7 @@ class TestXyloseIssueConverter(unittest.TestCase):
         self.issue_json["v43"] = [{"m": "Jan./Jun."}]
         self.issue = issue_to_kernel(self._issue)
         self.assertEqual(
-            [["2019-01-29T00:00:00.000000Z", {"start_month": 1, "end_month": 6}]],
+            [["2019-01-29T00:00:00.000000Z", {"range": (1,6)}]],
             self.issue["metadata"]["publication_months"],
         )
 

--- a/tests/test_xylose_converter.py
+++ b/tests/test_xylose_converter.py
@@ -73,7 +73,6 @@ class TestXyloseJournalConverter(unittest.TestCase):
         self.assertEqual("0001-3714", journal["id"])
         self.assertEqual("0001-3714", journal["_id"])
 
-
     def test_bundle_metadata_fields_timestamps_and_created_date_should_be_equals(self):
         journal = journal_to_kernel(self._journal)
 
@@ -252,26 +251,26 @@ class TestXyloseIssueConverter(unittest.TestCase):
             self.issue["metadata"]["titles"],
         )
 
-    def test_issue_has_publication_month(self):
+    def test_issue_has_publication_months(self):
         self.assertEqual(
-            [["2019-01-29T00:00:00.000000Z", "1"]],
-            self.issue["metadata"]["publication_month"],
+            [["2019-01-29T00:00:00.000000Z", {"month": 1}]],
+            self.issue["metadata"]["publication_months"],
         )
 
-    def test_publication_season_start_and_end_is_equal(self):
+    def test_publication_months_start_and_end_is_equal(self):
         self.issue_json["v43"] = [{"m": "Feb./Feb."}]
         self.issue = issue_to_kernel(self._issue)
         self.assertEqual(
-            [["2019-01-29T00:00:00.000000Z", [2]]],
-            self.issue["metadata"]["publication_season"],
+            [["2019-01-29T00:00:00.000000Z", {"start_month": 2, "end_month": 2}]],
+            self.issue["metadata"]["publication_months"],
         )
 
-    def test_publication_season_range_of_six_months(self):
+    def test_publication_months_range_of_six_months(self):
         self.issue_json["v43"] = [{"m": "Jan./Jun."}]
         self.issue = issue_to_kernel(self._issue)
         self.assertEqual(
-            [["2019-01-29T00:00:00.000000Z", [1, 6]]],
-            self.issue["metadata"]["publication_season"],
+            [["2019-01-29T00:00:00.000000Z", {"start_month": 1, "end_month": 6}]],
+            self.issue["metadata"]["publication_months"],
         )
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR implementa o campo `publication_months` definido pelo scieloorg/document-store#159 e remove o campo `publication_month` e `publication_season` ja que não são mais utilizados

#### Onde a revisão poderia começar?
Pelos arquivos
* `documentstore_migracao/utils/xylose_converter.py`
* `tests/test_xylose_converter.py`

#### Como este poderia ser testado manualmente?
```
$ python setup.py test
```

#### Algum cenário de contexto que queira dar?
A estrutura desse campo foi definida em farias reuniões com o time de devs e com pessoas das areas de publicão de conteúdo, e para mais informações consultar os tickets e os comentarios atrelados no PR

### Screenshots
N/A

#### Quais são tickets relevantes?
#170 
#172