### PR TITLE
Fix em Crash pela falta de acrônimo

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -92,7 +92,7 @@ class SPS_Package:
 
     @property
     def acron(self):
-        return self.xmltree.findtext('.//journal-id[@journal-id-type="publisher-id"]')
+        return self.xmltree.findtext('.//journal-id[@journal-id-type="publisher-id"]') or ""
 
     @property
     def publisher_id(self):
@@ -388,7 +388,7 @@ class SPS_Package:
         if not self.scielo_id:
             raise exceptions.XMLError("Não existe Scielo-Id no XML: %s", repr(self))
 
-        return f"{self.issn}_{self.acron}/{self.scielo_id}"
+        return f"{self.issn}/{self.scielo_id}"
 
     def transform_body(self):
 


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR corrige a dependencia do `acron` para o caminho do ativo digital no **Min.io**
Para mais detalhes TK #137 

#### Onde a revisão poderia começar?
Pelo Arquivo
* `documentstore_migracao/export/sps_package.py`

#### Como este poderia ser testado manualmente?
Reproduzir os passo citados no Ticket
>### Passos para reproduzir o problema
> 1. Extraia artigos da revista RSP via comando `pack_from_site`;
> 2. Aguarde a extração de um artigo que não possua o acrônimo do Periódico, ex: `S0034-8910.2013047003868`;
> 3. Realize a importação dos pacotes SPS;
> 4. Observe um erro relacionado ao uso do `acron` (`documentstore_migracao/export/sps_package.py` L: `228`)
> 5. Observe que no `Minio` o prefixo de bucket criado é o `1518-8787_None`;

#### Algum cenário de contexto que queira dar?
Essa correção utiliza a mesma tecnica de implementação que a utilizada no `opac-airflow`

### Screenshots
N/A

#### Quais são tickets relevantes?
#137 

### Referências

https://github.com/scieloorg/opac-airflow/blob/f06d67651fec7426b077ddf364d984f5886fd3fd/airflow/dags/operations/docs_utils.py#L137-L147

