### PR TITLE
[dsm][conversao][154]Muda a estratégia quanto à importação do conteúdo de HTML referenciados

### DIFF
--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2343,3 +2343,68 @@ class TestCompleteFnConversionPipe(unittest.TestCase):
         self.assertEqual(
             xml.find(".//fn/p/email").text, "chrisg@vortex.ufrgs.br")
         self.assertIn("Corresponding author", xml.find(".//fn/p").text, "*")
+
+
+class TestConvertRemote2LocalPipe(unittest.TestCase):
+
+    def test_transform_imports_html_content(self):
+        pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
+        text = """<root><body>
+        <p>
+        <a href="/img/revistas/eq/v33n3/html/a05tab01.htm">Tables 1-5</a>
+        </p>
+        </body></root>"""
+        xml = etree.fromstring(text)
+
+        text, xml = pipeline.ConvertRemote2LocalPipe().transform((text, xml))
+        self.assertEqual(
+            xml.find(".//a[@name]").get("name"), "a05tab01")
+
+        self.assertEqual(
+            xml.find(".//a[@href]").get("href"), "#a05tab01")
+
+    def test_transform_makes_remote_image_local(self):
+        pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
+        text = """<root><body>
+        <p>
+        <a href="/img/revistas/rbs/v28n3/05t1.gif">Table 1</a>
+        </p>
+        </body></root>"""
+        xml = etree.fromstring(text)
+
+        text, xml = pipeline.ConvertRemote2LocalPipe().transform((text, xml))
+        self.assertEqual(
+            xml.find(".//a[@name]").get("name"), "05t1")
+        self.assertEqual(
+            xml.find(".//a[@name]/img").get("src"),
+            "/img/revistas/rbs/v28n3/05t1.gif")
+        self.assertEqual(
+            xml.find(".//a[@href]").get("href"), "#05t1")
+
+    def test_transform_imports_html_content_once(self):
+        pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
+        text = """<root><body>
+        <p>
+        <a href="/img/revistas/eq/v33n3/html/a05tab01.htm">Tables 1-5</a>
+        </p>
+        <p>
+        <a href="/img/revistas/eq/v33n3/html/a05tab01.htm">Tables 1-5</a>
+        </p>
+        </body></root>"""
+        xml = etree.fromstring(text)
+
+        text, xml = pipeline.ConvertRemote2LocalPipe().transform((text, xml))
+        self.assertEqual(
+            xml.find(".//a[@name]").get("name"), "a05tab01")
+        self.assertEqual(
+            len(xml.findall(".//a[@name]")), 1)
+        self.assertEqual(
+            len(xml.findall(".//a[@href]")), 2)
+
+        a_href_items = xml.findall(".//a[@href]")
+        self.assertEqual(
+            a_href_items[0].get("href"), "#a05tab01")
+        self.assertEqual(
+            a_href_items[1].get("href"), "#a05tab01")
+
+    


### PR DESCRIPTION
#### O que esse PR faz?
Até então, a inserção de conteúdos externos provenientes de HTML mencionados no body, eram tratados em um pipe no meio do processo e as conversões eram aplicadas pontualmente neste HTML importado. Mas o problema é que tratar estes trechos de HTML isoladamente é ruim já que o trecho faz parte do body, não é um trecho isolado. Há links para dentro do conteúdo dos HTML externos. Sendo assim, o ideal é inserir todos os HTML externos dentro do body e assim tratá-lo de uma só vez como um todo.

Então, este código, no início da conversão, localiza os padrões: `<a href="/img/revistas/acron/volumenumero/html/file.htm"/>` e  `<a href="/img/revistas/acron/volumenumero/img.gif"/>` os converte por referências internas.

- faz a importação do conteúdo de HTML mencionado no body, importando todos os HTML, e inserindo seu conteúdo no body
- troca `<a href="/img/revistas/acron/volumenumero/img.gif"/>`  por `<a name="img"><img src="/img/revistas/acron/volumenumero/img.gif"/></a>` 

Por exemplo:

Caso 1: 
http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0100-46702008000300005&lng=en&nrm=iso&tlng=en

```html
<a href="/img/revistas/eq/v33n3/html/a05tab01.htm">Tables 1-5</a>
```
Conteúdo:
```html
<html>
<head>
<title>a05tab01</title>
</head>
<body>
<p align="center"><img src="../a05tab01.gif"></p>
<p>&nbsp;</p>
<p>&nbsp;</p>
<p align="center"><img src="../a05tab02.gif"></p>
<p>&nbsp;</p>
<p>&nbsp;</p>
<p align="center"><img src="../a05tab03.gif"></p>
<p>&nbsp;</p>
<p>&nbsp;</p>
<p align="center"><img src="../a05tab04.gif"></p>
<p>&nbsp;</p>
<p>&nbsp;</p>
<p align="center"><img src="../a05tab05.gif"></p>
</body>
</html>
```
Converte para:
```html
<a href="#a05tab01">Tables 1-5</a>
<p content-type="html">
    <a name="a05tab01">
        <p align="center"><img src="/img/revistas/eq/v33n3/a05tab01.gif"></p>
        <p>&nbsp;</p>
        <p>&nbsp;</p>
        <p align="center"><img src="/img/revistas/eq/v33n3/a05tab02.gif"></p>
        <p>&nbsp;</p>
        <p>&nbsp;</p>
        <p align="center"><img src="/img/revistas/eq/v33n3/a05tab03.gif"></p>
        <p>&nbsp;</p>
        <p>&nbsp;</p>
        <p align="center"><img src="/img/revistas/eq/v33n3/a05tab04.gif"></p>
        <p>&nbsp;</p>
        <p>&nbsp;</p>
        <p align="center"><img src="/img/revistas/eq/v33n3/a05tab05.gif"></p>
    </a>
</p>
```

Caso 2:
http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0101-31222006000300005&lng=en&nrm=iso&tlng=pt

```html
<a href="/img/revistas/rbs/v28n3/05t1.gif">Tabela    1</a>
```
Converte para:
```html
<a href="#05t1">Tabela    1</a>
<p content-type="asset">
    <a name="05t1"><img src="/img/revistas/rbs/v28n3/05t1.gif"/></a>
</p>
```

#### Onde a revisão poderia começar?
documentstore_migracao/utils/convert_html_body.py L:130

#### Como este poderia ser testado manualmente?
`python setup.py test -s tests.test_convert_html_body.TestConvertRemote2LocalPipe`

ou

`ds_migracao convert`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
Parte da solução de #154

### Referências
n/a