### PR TITLE
[dsm][conversao][154-02]Gera o ID e RID no final da conversão, pois fazer a alteração dos IDs

### DIFF
--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -926,24 +926,24 @@ class TestRemoveElementOrComment(unittest.TestCase):
 class TestAddAssetInfoToTablePipe(unittest.TestCase):
     def setUp(self):
         self.html_pl = HTML2SPSPipeline(pid="S1234-56782018000100011")
-        self.pipeline = ConvertElementsWhichHaveIdPipeline(self.html_pl)
+        self.pipeline = ConvertElementsWhichHaveIdPipeline()
 
     def test_pipe_table(self):
         text = """<root><table id="B1"><tr><td>Texto</td></tr></table></root>"""
         xml = etree.fromstring(text)
         data = text, xml
         raw, transformed = self.pipeline.AddAssetInfoToTablePipe(
-            super_obj=self.html_pl
-        ).transform(data)
+                    ).transform(data)
         table = transformed.find(".//table")
-        self.assertEqual(table.attrib.get("xml_id"), "b1")
+        self.assertEqual(table.attrib.get("xml_id"), "B1")
         self.assertEqual(table.attrib.get("xml_label"), "Tab")
 
 
 class TestCreateAssetElementsFromImgOrTableElementsPipe(unittest.TestCase):
     def setUp(self):
-        pipeline = ConvertElementsWhichHaveIdPipeline(HTML2SPSPipeline(pid="S1234-56782018000100011"))
-        self.pipe = pipeline.CreateAssetElementsFromImgOrTableElementsPipe(pipeline)
+        html_pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
+        pipeline = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pipeline.CreateAssetElementsFromImgOrTableElementsPipe()
 
     def _transform(self, text):
         xml = etree.fromstring(text)
@@ -1138,9 +1138,9 @@ class TestCreateAssetElementsFromImgOrTableElementsPipe(unittest.TestCase):
 class TestCreateAssetElementsFromExternalLinkElementsPipe(unittest.TestCase):
     def setUp(self):
         html_pl = HTML2SPSPipeline(pid="S1234-56782018000100011")
-        self.pipeline = ConvertElementsWhichHaveIdPipeline(html_pl)
+        self.pipeline = ConvertElementsWhichHaveIdPipeline()
         self.pipe = self.pipeline.CreateAssetElementsFromExternalLinkElementsPipe(
-            html_pl
+            
         )
 
     def _transform(self, text):
@@ -1195,8 +1195,8 @@ class TestConversionToAnnex(unittest.TestCase):
 
         xml = etree.fromstring(text)
         htmlpl = HTML2SPSPipeline(pid="S1234-56782018000100011")
-        pl = ConvertElementsWhichHaveIdPipeline(htmlpl)
-        text, xml = pl.DeduceAndSuggestConversionPipe(htmlpl).transform((text, xml))
+        pl = ConvertElementsWhichHaveIdPipeline()
+        text, xml = pl.DeduceAndSuggestConversionPipe().transform((text, xml))
         self.assertEqual(
             etree.tostring(xml),
             b"""<root>
@@ -1206,7 +1206,7 @@ class TestConversionToAnnex(unittest.TestCase):
         </root>""",
         )
 
-        text, xml = pl.ApplySuggestedConversionPipe(htmlpl).transform((text, xml))
+        text, xml = pl.ApplySuggestedConversionPipe().transform((text, xml))
         self.assertEqual(
             etree.tostring(xml),
             b"""<root>
@@ -1216,7 +1216,7 @@ class TestConversionToAnnex(unittest.TestCase):
         </root>""",
         )
         text, xml = pl.CreateAssetElementsFromExternalLinkElementsPipe(
-            htmlpl
+            
         ).transform((text, xml))
         self.assertEqual(
             etree.tostring(xml),
@@ -1228,7 +1228,7 @@ class TestConversionToAnnex(unittest.TestCase):
         )
 
         text, xml = pl.CreateAssetElementsFromImgOrTableElementsPipe(
-            htmlpl
+            
         ).transform((text, xml))
         self.assertEqual(
             etree.tostring(xml),
@@ -1251,7 +1251,7 @@ class TestConversionToTableWrap(unittest.TestCase):
         """
         xml = etree.fromstring(text)
         html_pl = HTML2SPSPipeline(pid="S1234-56782018000100011")
-        pl = html_pl.ConvertElementsWhichHaveIdPipe(html_pl)
+        pl = html_pl.ConvertElementsWhichHaveIdPipe()
         text, xml = pl.transform((text, xml))
         self.assertIsNone(xml.find(".//table-wrap/img"))
         self.assertIsNotNone(xml.find(".//table-wrap/graphic"))
@@ -1269,7 +1269,7 @@ class TestConversionToTableWrap(unittest.TestCase):
         raw = text
         xml = etree.fromstring(text)
         pl_html = HTML2SPSPipeline(pid="S1234-56782018000100011")
-        pl = pl_html.ConvertElementsWhichHaveIdPipe(pl_html)
+        pl = pl_html.ConvertElementsWhichHaveIdPipe()
         raw, xml = pl.transform((raw, xml))
         self.assertIsNone(xml.find(".//table-wrap[@id]/img"))
         self.assertIsNotNone(xml.find(".//table-wrap[@id]/graphic"))
@@ -1285,22 +1285,22 @@ class TestConversionToCorresp(unittest.TestCase):
 
         xml = etree.fromstring(text)
         html_pl = HTML2SPSPipeline(pid="S1234-56782018000100011")
-        pl = ConvertElementsWhichHaveIdPipeline(html_pl)
+        pl = ConvertElementsWhichHaveIdPipeline()
 
         text, xml = pl.RemoveInternalLinksToTextIdentifiedByAsteriskPipe(
-            html_pl).transform((text, xml))
+            ).transform((text, xml))
         self.assertNotIn(b'<a href="#home">*</a>', etree.tostring(xml))
         self.assertEqual(
             etree.tostring(xml), expected_after_internal_link_as_asterisk_pipe
         )
 
-        text, xml = pl.DeduceAndSuggestConversionPipe(html_pl).transform((text, xml))
+        text, xml = pl.DeduceAndSuggestConversionPipe().transform((text, xml))
         self.assertIn(
             b'<a name="back" id="back" xml_tag="corresp" xml_reftype="corresp" xml_id="back"/>',
             etree.tostring(xml),
         )
 
-        text, xml = pl.ApplySuggestedConversionPipe(html_pl).transform((text, xml))
+        text, xml = pl.ApplySuggestedConversionPipe().transform((text, xml))
         self.assertEqual(
             etree.tostring(xml), expected_after_anchor_and_internal_link_pipe
         )
@@ -1321,10 +1321,10 @@ class TestConversionToFig(unittest.TestCase):
 
         xml = etree.fromstring(text)
         html_pl = HTML2SPSPipeline(pid="S1234-56782018000100011")
-        pl = ConvertElementsWhichHaveIdPipeline(html_pl)
+        pl = ConvertElementsWhichHaveIdPipeline()
 
-        text, xml = pl.AddNameAndIdToElementAPipe(html_pl).transform((text, xml))
-        text, xml = pl.DeduceAndSuggestConversionPipe(html_pl).transform((text, xml))
+        text, xml = pl.AddNameAndIdToElementAPipe().transform((text, xml))
+        text, xml = pl.DeduceAndSuggestConversionPipe().transform((text, xml))
         _xml = etree.tostring(xml)
         self.assertIn(
             b'<a href="#fig01en" xml_tag="fig" xml_reftype="fig" xml_id="fig01en" xml_label="figure 1">Figure 1</a>',
@@ -1338,15 +1338,15 @@ class TestConversionToFig(unittest.TestCase):
             b'<img src="/img/revistas/jped/v86n3/en_a05fig01.gif" xml_tag="fig" xml_reftype="fig" xml_id="fig01en" xml_label="figure 1"/>',
             _xml,
         )
-        text, xml = pl.ApplySuggestedConversionPipe(html_pl).transform((text, xml))
+        text, xml = pl.ApplySuggestedConversionPipe().transform((text, xml))
         _xml = etree.tostring(xml)
         self.assertIn(b'<xref ref-type="fig" rid="fig01en">Figure 1</xref>', _xml)
         self.assertIn(b'<fig id="fig01en"/>', _xml)
-        text, xml = pl.CreateAssetElementsFromImgOrTableElementsPipe(html_pl).transform(
+        text, xml = pl.CreateAssetElementsFromImgOrTableElementsPipe().transform(
             (text, xml)
         )
         self.assertIsNotNone(xml.findall(".//fig/img"))
-        text, xml = pl.ImgPipe(html_pl).transform((text, xml))
+        text, xml = pl.ImgPipe().transform((text, xml))
         self.assertIsNotNone(xml.findall(".//fig/graphic"))
 
 
@@ -1383,7 +1383,7 @@ class Test_HTML2SPSPipeline(unittest.TestCase):
             </p></root>"""
         pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
         xml = etree.fromstring(text)
-        text, xml = pipeline.SetupPipe(pipeline).transform(text)
+        text, xml = pipeline.SetupPipe().transform(text)
         pipes = (
             pipeline.SaveRawBodyPipe(pipeline),
             pipeline.DeprecatedHTMLTagsPipe(),
@@ -1406,7 +1406,7 @@ class Test_HTML2SPSPipeline(unittest.TestCase):
             pipeline.UPipe(),
             pipeline.BPipe(),
             pipeline.StrongPipe(),
-            pipeline.ConvertElementsWhichHaveIdPipe(pipeline),
+            pipeline.ConvertElementsWhichHaveIdPipe(),
             pipeline.TdCleanPipe(),
             pipeline.TableCleanPipe(),
             pipeline.BlockquotePipe(),
@@ -1439,7 +1439,7 @@ class TestHTMLEscapingPipe(unittest.TestCase):
             </p></root>"""
         pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
         xml = etree.fromstring(text)
-        text, xml = pipeline.SetupPipe(pipeline).transform(text)
+        text, xml = pipeline.SetupPipe().transform(text)
         text, xml = pipeline.HTMLEscapingPipe().transform((text, xml))
         resultado_unicode = etree.tostring(xml, encoding="unicode")
         resultado_b = etree.tostring(xml)
@@ -1451,9 +1451,8 @@ class TestHTMLEscapingPipe(unittest.TestCase):
 class TestConvertElementsWhichHaveIdPipeline(unittest.TestCase):
     def setUp(self):
         self.html_pl = HTML2SPSPipeline(pid="S1234-56782018000100011")
-        self.pipe = self.html_pl.ConvertElementsWhichHaveIdPipe(
-            self.html_pl)
-        self.pl = ConvertElementsWhichHaveIdPipeline(self.html_pl)
+        self.pipe = self.html_pl.ConvertElementsWhichHaveIdPipe()
+        self.pl = ConvertElementsWhichHaveIdPipeline()
 
     def test_remove_thumb_img_pipe(self):
         text = """<root xmlns:xlink="http://www.w3.org/1999/xlink"><p><a href="/img/revistas/hoehnea/v37n3/a05img01.jpg"><img src="/img/revistas/hoehnea/v37n3/a05img01-thumb.jpg"/><br/> Clique para ampliar</a></p></root>"""
@@ -1470,7 +1469,7 @@ class TestConvertElementsWhichHaveIdPipeline(unittest.TestCase):
         text = """<root><a name="_ftnref19" href="#_ftn2" id="_ftnref19"><sup>1</sup></a></root>"""
         expected = b"""<root><a name="_ftnref19" id="_ftnref19"/><a href="#_ftn2"><sup>1</sup></a></root>"""
         xml = etree.fromstring(text)
-        text, xml = self.pl.AddNameAndIdToElementAPipe(self.html_pl).transform((text, xml))
+        text, xml = self.pl.AddNameAndIdToElementAPipe().transform((text, xml))
         self.assertEqual(etree.tostring(xml), expected)
 
     def test_pipe_asterisk_in_a_href(self):
@@ -1478,7 +1477,7 @@ class TestConvertElementsWhichHaveIdPipeline(unittest.TestCase):
         expected = b'<root><a name="1a" id="1a"/><sup>*</sup></root>'
         xml = etree.fromstring(text)
 
-        text, xml = self.pl.RemoveInternalLinksToTextIdentifiedByAsteriskPipe(self.html_pl
+        text, xml = self.pl.RemoveInternalLinksToTextIdentifiedByAsteriskPipe(
             ).transform((text, xml))
         self.assertEqual(etree.tostring(xml), expected)
 
@@ -1489,7 +1488,7 @@ class TestConvertElementsWhichHaveIdPipeline(unittest.TestCase):
             <p><img src="/img/revistas/trends/v33n3/a05tab01.jpg" xml_tag="app" xml_reftype="app" xml_id="anx01" xml_label="anexo 1"/></p>
             </root>"""
         xml = etree.fromstring(text)
-        text, xml = self.pl.ApplySuggestedConversionPipe(self.html_pl).transform((text, xml))
+        text, xml = self.pl.ApplySuggestedConversionPipe().transform((text, xml))
         self.assertEqual(
             etree.tostring(xml),
             b"""<root>
@@ -1506,7 +1505,7 @@ class TestConvertElementsWhichHaveIdPipeline(unittest.TestCase):
 
         raw, transformed = text, etree.fromstring(text)
         raw, transformed = self.pl.ApplySuggestedConversionPipe(
-            self.html_pl
+            
         ).transform((raw, transformed))
         node = transformed.find(".//xref")
         self.assertIsNone(node)
@@ -1519,7 +1518,6 @@ class TestConvertElementsWhichHaveIdPipeline(unittest.TestCase):
         expected = b"<root/>"
         xml = etree.fromstring(text)
         text, xml = self.pl.ApplySuggestedConversionPipe(
-            self.html_pl
             ).transform((text, xml))
         self.assertEqual(etree.tostring(xml), expected)
 
@@ -1527,7 +1525,7 @@ class TestConvertElementsWhichHaveIdPipeline(unittest.TestCase):
         text = """<root><a name="_ftnref19" title="" href="#_ftn2" id="_ftnref19"><sup>1</sup></a></root>"""
         raw, transformed = text, etree.fromstring(text)
         raw, transformed = self.pl.ApplySuggestedConversionPipe(
-            self.html_pl
+            
         ).transform((raw, transformed))
         node = transformed.find(".//xref")
         self.assertIsNone(node)
@@ -1577,8 +1575,8 @@ class TestConvertElementsWhichHaveIdPipeline(unittest.TestCase):
 class TestDeduceAndSuggestConversionPipe(unittest.TestCase):
     def setUp(self):
         pipeline = HTML2SPSPipeline("PID")
-        pl = ConvertElementsWhichHaveIdPipeline(pipeline)
-        self.pipe = pl.DeduceAndSuggestConversionPipe(pipeline)
+        pl = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pl.DeduceAndSuggestConversionPipe()
         self.inferer = Inferer()
         self.text = """
         <root>
@@ -1727,7 +1725,7 @@ class TestAPipe(unittest.TestCase):
             self.xml_txt = f.read()
         self.etreeXML = etree.fromstring(self.xml_txt)
         self.html_pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
-        self.pipeline = ConvertElementsWhichHaveIdPipeline(self.html_pipeline)
+        self.pipeline = ConvertElementsWhichHaveIdPipeline()
 
     def test_pipe_a__parser_node_external_link_for_uri(self):
         expected = {
@@ -1737,7 +1735,7 @@ class TestAPipe(unittest.TestCase):
         xml = etree.fromstring('<root><a href="http://bla.org">texto</a></root>')
         node = xml.find(".//a")
 
-        self.pipeline.APipe(super_obj=self.html_pipeline)._parser_node_external_link(node)
+        self.pipeline.APipe()._parser_node_external_link(node)
 
         self.assertEqual(set(expected.keys()), set(node.attrib.keys()))
         self.assertEqual(
@@ -1758,7 +1756,7 @@ class TestAPipe(unittest.TestCase):
         xml = etree.fromstring(text)
 
         node = xml.find(".//a")
-        self.pipeline.APipe(super_obj=self.html_pipeline)._create_email(node)
+        self.pipeline.APipe()._create_email(node)
 
         self.assertIn(
             node.attrib.get("{http://www.w3.org/1999/xlink}href"), "mailto:a@scielo.org"
@@ -1776,7 +1774,7 @@ class TestAPipe(unittest.TestCase):
         xml = etree.fromstring(text)
 
         node = xml.find(".//a")
-        self.pipeline.APipe(super_obj=self.html_pipeline)._create_email(node)
+        self.pipeline.APipe()._create_email(node)
         p = xml.find(".//p")
         self.assertEqual(p.text, "Enviar e-mail para ")
         email = p.find("email")
@@ -1791,7 +1789,7 @@ class TestAPipe(unittest.TestCase):
         xml = etree.fromstring(text)
 
         node = xml.find(".//a")
-        self.pipeline.APipe(super_obj=self.html_pipeline)._create_email(node)
+        self.pipeline.APipe()._create_email(node)
 
         self.assertEqual(
             xml.find(".//graphic").attrib.get("{http://www.w3.org/1999/xlink}href"),
@@ -1804,7 +1802,7 @@ class TestAPipe(unittest.TestCase):
         <p><a href="mailto:a@scielo.org">a@scielo.org</a></p>
         </root>"""
         raw, transformed = self._transform(
-            text, self.pipeline.APipe(super_obj=self.html_pipeline)
+            text, self.pipeline.APipe()
         )
 
         node = transformed.find(".//email")
@@ -1814,7 +1812,7 @@ class TestAPipe(unittest.TestCase):
     def test_pipe_a__create_email_mailto_empty(self):
         text = """<root><a href="mailto:">sfpyip@hku.hk</a>). Correspondence should be addressed to Dr Yip at this address.</root>"""
         raw, transformed = self._transform(
-            text, self.pipeline.APipe(super_obj=self.html_pipeline)
+            text, self.pipeline.APipe()
         )
 
         node = transformed.find(".//email")
@@ -1838,7 +1836,7 @@ class TestAPipe(unittest.TestCase):
             ns2:href="/img/revistas/gs/v29n2/seta.gif"/></a></root>"""
 
         raw, transformed = self._transform(
-            text, self.pipeline.APipe(super_obj=self.html_pipeline)
+            text, self.pipeline.APipe()
         )
 
         node = transformed.find(".//xref")
@@ -1853,7 +1851,7 @@ class TestAPipe(unittest.TestCase):
         text = """<root>Demographic and Health Surveys. Available from: <a href="#fn1">b</a></root>"""
 
         raw, transformed = self._transform(
-            text, self.pipeline.APipe(super_obj=self.html_pipeline)
+            text, self.pipeline.APipe()
         )
 
         self.assertEqual(
@@ -1865,7 +1863,7 @@ class TestAPipe(unittest.TestCase):
         text = """<root><table-wrap id="tab1" xref_id="tab1"/><a href="#tab1">Tabela 1</a> Demographic and Health Surveys. Available from: </root>"""
 
         raw, transformed = self._transform(
-            text, self.pipeline.APipe(super_obj=self.html_pipeline)
+            text, self.pipeline.APipe()
         )
 
         self.assertEqual(
@@ -1877,7 +1875,7 @@ class TestAPipe(unittest.TestCase):
         text = """<root><a href="#ref">(9,10)</a>Tabela 1 </root>"""
 
         raw, transformed = self._transform(
-            text, self.pipeline.APipe(super_obj=self.html_pipeline)
+            text, self.pipeline.APipe()
         )
 
         self.assertEqual(
@@ -1889,7 +1887,7 @@ class TestAPipe(unittest.TestCase):
         text = """<root><a href="#ref">9</a>Tabela 1 </root>"""
 
         raw, transformed = self._transform(
-            text, self.pipeline.APipe(super_obj=self.html_pipeline)
+            text, self.pipeline.APipe()
         )
 
         self.assertEqual(
@@ -1901,7 +1899,7 @@ class TestAPipe(unittest.TestCase):
         text = """<root><a href="#ref">(9-10)</a>Tabela 1 </root>"""
 
         raw, transformed = self._transform(
-            text, self.pipeline.APipe(super_obj=self.html_pipeline)
+            text, self.pipeline.APipe()
         )
 
         self.assertEqual(
@@ -1914,7 +1912,7 @@ class TestAPipe(unittest.TestCase):
         text = """<root><a href="#tabela1">Tabela 1</a> resultado global do levantamento efetuado <img src="/img/revistas/rsp/v8n3/05t1.gif"/></root>"""
 
         data = self._transform(text, self.pipeline.ImgPipe())
-        raw, transformed = self.pipeline.APipe(super_obj=self.html_pipeline).transform(data)
+        raw, transformed = self.pipeline.APipe().transform(data)
 
         self.assertEqual(
             etree.tostring(transformed),
@@ -1933,7 +1931,7 @@ class TestAPipe(unittest.TestCase):
         ]
         text = "".join(text)
         raw, transformed = self._transform(
-            text, self.pipeline.APipe(super_obj=self.html_pipeline)
+            text, self.pipeline.APipe()
         )
 
         nodes = transformed.findall(".//ext-link")
@@ -1957,14 +1955,14 @@ class TestAPipe(unittest.TestCase):
     def test_pipe_remove_a_without_href(self):
         text = "<root><a>Teste</a></root>"
         raw, transformed = self._transform(
-            text, self.pipeline.APipe(super_obj=self.html_pipeline)
+            text, self.pipeline.APipe()
         )
         self.assertIsNone(transformed.find(".//a"))
 
     def test_pipe_a_href_error(self):
         text = '<root><a href="error">Teste</a></root>'
         raw, transformed = self._transform(
-            text, self.pipeline.APipe(super_obj=self.html_pipeline)
+            text, self.pipeline.APipe()
         )
         self.assertEqual(
             etree.tostring(transformed).strip(),
@@ -1986,12 +1984,12 @@ class TestImgPipe(unittest.TestCase):
             self.xml_txt = f.read()
         self.etreeXML = etree.fromstring(self.xml_txt)
         self.html_pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
-        self.pipeline = ConvertElementsWhichHaveIdPipeline(self.html_pipeline)
+        self.pipeline = ConvertElementsWhichHaveIdPipeline()
 
     def test_pipe_img(self):
         text = '<root><img align="x" src="a04qdr04.gif"/><img align="x" src="a04qdr08.gif"/></root>'
         raw, transformed = self._transform(
-            text, self.pipeline.ImgPipe(super_obj=self.pipeline)
+            text, self.pipeline.ImgPipe()
         )
 
         nodes = transformed.findall(".//graphic")
@@ -2008,7 +2006,7 @@ class TestImgPipe(unittest.TestCase):
 class TestCompleteFnConversionPipe(unittest.TestCase):
     def setUp(self):
         self.html_pl = HTML2SPSPipeline(pid="pid")
-        self.pl = ConvertElementsWhichHaveIdPipeline(self.html_pl)
+        self.pl = ConvertElementsWhichHaveIdPipeline()
         self.pipe = self.pl.CompleteFnConversionPipe()
 
     def test__create_label__does_not_create_label(self):
@@ -2269,7 +2267,7 @@ class TestCompleteFnConversionPipe(unittest.TestCase):
         xml = etree.fromstring(text)
         text, xml = self.html_pl.BRPipe().transform((text, xml))
         text, xml = self.html_pl.ConvertElementsWhichHaveIdPipe(
-            self.html_pl).transform((text, xml))
+            ).transform((text, xml))
         p = xml.findall(".//p")
         self.assertEqual(
             xml.find(".//fn/label/bold").text, "Correspondence to:")
@@ -2304,7 +2302,7 @@ class TestCompleteFnConversionPipe(unittest.TestCase):
 
         xml = etree.fromstring(text)
         text, xml = self.html_pl.ConvertElementsWhichHaveIdPipe(
-            self.html_pl).transform((text, xml))
+            ).transform((text, xml))
         fn = xml.findall(".//fn")
         self.assertEqual(fn[0].find("label").text, "*")
         self.assertEqual(fn[1].find("label").text, "1")
@@ -2337,7 +2335,7 @@ class TestCompleteFnConversionPipe(unittest.TestCase):
         </p></fn></root>"""
         xml = etree.fromstring(text)
         text, xml = self.html_pl.ConvertElementsWhichHaveIdPipe(
-            self.html_pl).transform((text, xml))
+            ).transform((text, xml))
         self.assertEqual(xml.find(".//xref/sup").text, "*")
         self.assertEqual(xml.find(".//fn/label").text, "*")
         self.assertEqual(


### PR DESCRIPTION

#### O que esse PR faz?
Gera o ID e RID no final da conversão, pois fazer a alteração prematuramente atrapalha a correspondência entre os elementos

#### Onde a revisão poderia começar?
documentstore_migracao/utils/convert_html_body.py L:147

#### Como este poderia ser testado manualmente?
`python setup.py test`

#### Algum cenário de contexto que queira dar?
n/a
### Screenshots
n/a
#### Quais são tickets relevantes?
Contribui na solução de #154

### Referências
n/a
