### PR TITLE
[dsm][conversao][154-03] Acrescenta atributos name, id, xml_text, nos elementos A que ajudarão a

### DIFF
--- a/documentstore_migracao/utils/convert_html_body_inferer.py
+++ b/documentstore_migracao/utils/convert_html_body_inferer.py
@@ -17,12 +17,6 @@ class Inferer:
     def tag_and_reftype_from_name(self, name):
         if not name:
             return
-        for prefix in ["not", "_ftnref"]:
-            if name.startswith(prefix) and name[len(prefix) :].isdigit():
-                return
-        for prefix in ["titulo", "title", "tx", "top", "home"]:
-            if name.startswith(prefix):
-                return
         for prefix, tag in STARTSWITH_RETURNS_TAG_AND_REFTYPE:
             if name.startswith(prefix):
                 if len(prefix) == 1 and not name[len(prefix) :].isdigit():


### PR DESCRIPTION
inferir os elementos aos quais serão convertidos

#### O que esse PR faz?
Acrescenta atributos name, id, xml_text, nos elementos A que ajudarão a inferir os elementos aos quais serão convertidos

#### Onde a revisão poderia começar?
documentstore_migracao/utils/convert_html_body.py Linha: 1068

#### Como este poderia ser testado manualmente?
`python setup.py test`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a
#### Quais são tickets relevantes?
Contribui na solução de #154 

### Referências
n/a
