### PR TITLE
Detecta idioma correto dos PDFs na importação dos pacotes

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -238,17 +238,18 @@ class SPS_Package:
                 new_fname = self.asset_name(f_name)
                 node.set(attr_name, "%s%s" % (new_fname, ext))
                 replacements.append((old_path, new_fname))
+        return replacements
 
-        # RENDITION PDF
+    def get_renditions_metadata(self):
+        renditions = []
+        metadata = {}
         obj_article = article.get_article(self.publisher_id)
         if obj_article:
-            pdfs = obj_article.fulltexts().get("pdf", {})
-            for l_pdf, u_pdf in pdfs.items():
-                f_name, ext = files.extract_filename_ext_by_path(u_pdf)
-                new_fname = self.asset_name(f_name)
-                replacements.append((u_pdf, new_fname))
-
-        return replacements
+            metadata = obj_article.fulltexts().get("pdf", {})
+            for lang, url in metadata.items():
+                filename, ext = files.extract_filename_ext_by_path(url)
+                renditions.append((url, filename))
+        return renditions, metadata
 
     @property
     def volume(self):

--- a/documentstore_migracao/object_store/minio.py
+++ b/documentstore_migracao/object_store/minio.py
@@ -97,10 +97,15 @@ class MinioStorage:
         url = self._client.presigned_get_object(self.bucket_name, media_path)
         return url.split("?")[0]
 
-    def register(self, file_path, prefix="") -> str:
+    def register(self, file_path, prefix="", original_uri=None) -> str:
         object_name = self._generator_object_name(file_path, prefix)
         metadata = {"origin_name": os.path.basename(file_path)}
+        if original_uri is not None:
+            metadata.update({"origin_uri": original_uri})
 
+        logger.debug(
+            "Registering %s in %s with metadata %s", file_path, object_name, metadata
+        )
         try:
             self._client.fput_object(
                 self.bucket_name,

--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import logging
+import json
 
 from tqdm import tqdm
 from requests.compat import urljoin
@@ -29,8 +30,19 @@ def pack_article_xml(file_xml_path):
     asset_replacements = list(set(sps_package.replace_assets_names()))
     logger.info("%s possui %s ativos digitais", file_xml_path, len(asset_replacements))
 
+    renditions, renditions_metadata = sps_package.get_renditions_metadata()
+    logger.info("%s possui %s renditions", file_xml_path, len(renditions))
+
     package_path = packing_assets(
-        asset_replacements, pkg_path, bad_pkg_path, sps_package.package_name
+        asset_replacements + renditions,
+        pkg_path,
+        bad_pkg_path,
+        sps_package.package_name
+    )
+
+    files.write_file(
+        os.path.join(package_path, "manifest.json"),
+        json.dumps(renditions_metadata)
     )
 
     xml.objXML2file(

--- a/tests/test_inserting.py
+++ b/tests/test_inserting.py
@@ -12,6 +12,7 @@ from . import (
 
 import os
 import shutil
+import json
 
 from documentstore_migracao.processing import inserting
 from documentstore_migracao.utils import manifest
@@ -448,9 +449,21 @@ class TestDocumentManifest(unittest.TestCase):
         ]
 
         mock_minio_storage.register.side_effect = self.renditions_urls_mock
+        self.json_manifest = os.path.join(self.package_path, "manifest.json")
+        with open(self.json_manifest, 'w') as json_file:
+            json_file.write(
+                json.dumps({
+                    "pt": "rsp/v47n2/0034-8910-rsp-47-02-0231.pdf",
+                    "en": "rsp/v47n2/0034-8910-rsp-47-02-0231-en.pdf",
+                })
+            )
+
         self.renditions = inserting.get_document_renditions(
             self.package_path, self.renditions_names, "prefix", mock_minio_storage
         )
+
+    def tearDown(self):
+        os.remove(self.json_manifest)
 
     def test_rendition_should_contains_file_name(self):
         self.assertEqual("0034-8910-rsp-47-02-0231.pdf", self.renditions[0]["filename"])
@@ -474,7 +487,7 @@ class TestDocumentManifest(unittest.TestCase):
         self.assertEqual("en", self.renditions[1]["lang"])
 
     def test_rendtion_should_not_contains_language(self):
-        self.assertIsNone(self.renditions[0].get("lang"))
+        self.assertEqual("pt", self.renditions[0]["lang"])
 
 
 class TestDocumentRegister(unittest.TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera empacotamento para obter URLs legadas das manifestações de documentos 
e respectivos idiomas e registra essas URLs junto com o objeto no Object Store.

Foram alterados os empacotamentos de documentos HTML e XML nativos para gerar um arquivo 
JSON `manifest.json` com as URLs legadas das manifestações e respectivos idiomas.
Para os artigos HTML, estes dados são obtidos do Article Meta, enquanto para os XMLs 
nativos, as URLs são inferidas através das manifestações do pacote e os idiomas do XML.

Na importação, tenta ler o arquivo `manifest.json` do pacote do documento. Em caso de 
sucesso, tentará associar as manifestações à sua URL legada e registrá-la no `metadata` 
do objeto no Object Store (Minio). Também melhora a detecção do idioma da manifestação.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commit, pois estão organizados em etapa de empacotamento e importação.

#### Como este poderia ser testado manualmente?
- Executar a etapa de empacotamento de artigos HTML
- Verificar a criação de arquivo `manifest.json` no diretório de cada pacote de documento contendo JSON onde as chaves são os idiomas e os valores são as URLs legadas de cada manifestação
- Executar a etapa de importação de pacotes
- Verificar o registro/atualização das manifestações no Object Store. É possível validar através dos seguintes comandos:
```
from minio import Minio
client = Minio(
    "<host:porta>",
    access_key="<access_key>",
    secret_key="<secret_key>",
    secure=False)
minio_obj = client.stat_object(
    "documentstore",
    "<nome_do_objeto>")
minio_obj.metadata
```
- o `metadata` deve conter a chave `X-Amz-Meta-Origin_uri` com a URL legada da manifestação
- Repita os passos anteriores empacotando artigos XML nativos.

#### Algum cenário de contexto que queira dar?
As URLs legadas das manifestações devem permanecer funcionando, mesmo após a migração do conteúdo do site atual para o site novo. Para isso, é necessário que elas sejam armazenadas. Optamos por armazená-las no Object Store para não adicionar informações adicionais no Kernel e podem ser consultadas no momento da sincronização dos dados com o OPAC.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#184 e scieloorg/document-store-migracao/issues/144

### Referências
Nenhuma.
