### PR TITLE
Adequa subject areas ao padrão do Kernel

### DIFF
--- a/documentstore_migracao/utils/xylose_converter.py
+++ b/documentstore_migracao/utils/xylose_converter.py
@@ -112,9 +112,7 @@ def journal_to_kernel(journal):
             _metadata["status"].append([parse_date(status[0]), _status])
 
     if journal.subject_areas:
-        _metadata["subject_areas"] = set_metadata(
-            _creation_date, [area.upper() for area in journal.subject_areas]
-        )
+        _metadata["subject_areas"] = set_metadata(_creation_date, journal.subject_areas)
 
     if journal.sponsors:
         _sponsors = [{"name": sponsor} for sponsor in journal.sponsors]

--- a/tests/test_xylose_converter.py
+++ b/tests/test_xylose_converter.py
@@ -139,7 +139,7 @@ class TestXyloseJournalConverter(unittest.TestCase):
     def test_journal_has_subject_areas(self):
         journal = journal_to_kernel(self._journal)
         self.assertEqual(
-            ["HEALTH SCIENCES"], get_metadata_item(journal, "subject_areas")
+            ["Health Sciences"], get_metadata_item(journal, "subject_areas")
         )
 
     def test_journal_has_sponsors(self):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adequa conteúdo das subject areas ao esperado pelo domínio do Kernel. Foi removida a transformação para caixa alta.

#### Onde a revisão poderia começar?
- `documentstore_migracao/utils/xylose_converter.py` L: `115`

#### Como este poderia ser testado manualmente?
Para testar este PR deve-se:
- Realizar a migração da base `title`;
- Iniciar uma instância do Kernel;
- Acessar um `journal` migrado;
- Observar a propriedade `subject_areas` e seu conteúdo sem transformações de caixa alta.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#185 

### Referências
N/A