### PR TITLE
[dsm][conversao][154-04] Aprimora e otimiza o Inferidor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 matrix:
   include:
-    - python: 3.6.8
+    - python: 3.7.4
       dist: xenial
       sudo: true
 before_install:

--- a/documentstore_migracao/config.py
+++ b/documentstore_migracao/config.py
@@ -2,7 +2,7 @@ import os
 from packtools.catalogs import XML_CATALOG
 
 BASE_PATH = os.path.dirname(os.path.dirname(__file__))
-CONVERSION_TAGS = os.path.join(BASE_PATH, "documentstore_migracao", "utils", "convert_html_body.txt")
+INFERERER_RULES_FILE_PATH = os.path.join(BASE_PATH, "documentstore_migracao", "utils", "convert_html_body.txt")
 
 """
 SOURCE_PATH:

--- a/documentstore_migracao/utils/convert_html_body.txt
+++ b/documentstore_migracao/utils/convert_html_body.txt
@@ -1,41 +1,53 @@
-corresp corresp
-figure fig
-tab table-wrap
-equ disp-formula
-ecu disp-formula
-form disp-formula
-quadro fig
-quadr fig
-quad fig
-qua fig
-cuadro fig
-fig fig
-annex app
-anex app
-app app
-graf fig
-graph fig
-frma disp-formula
-frm disp-formula
-for disp-formula
-anx app
-ane app
-apx app
-grf fig
-qdo fig
-qdr fig
-car disp-formula
-cdr fig
-fg fig
-cu fig
-gr fig
-eq disp-formula
-ap app
-nt fn
-fn fn
-back fn
-ref ref
-alg fig
-e disp-formula
-t table-wrap
-f fig
+corresp|corresp
+figure|fig
+tab|table-wrap
+equ|disp-formula
+ecu|disp-formula
+form|disp-formula
+esquema|fig
+scheme|fig
+box|fig
+chart|fig
+quadro|fig
+quadr|fig
+quad|fig
+qua|fig
+ilustr|fig
+illustr|fig
+cuadro|fig
+fig|fig
+example|fig
+anexo|app
+annex|app
+anex|app
+app|app
+graf|fig
+graph|fig
+frma|disp-formula
+frm|disp-formula
+for|disp-formula
+anx|app
+ane|app
+apx|app
+mapa|fig
+grf|fig
+qdo|fig
+qdr|fig
+car|disp-formula
+cdr|fig
+fg|fig
+cu|fig
+gr|fig
+eq|disp-formula
+ap|app
+nt|fn
+fn|fn
+back|fn
+ref|ref
+alg|fig
+e|disp-formula
+t|table-wrap
+f|fig
+img|fig
+supplementary|supplementary-material
+material|supplementary-material

--- a/documentstore_migracao/utils/convert_html_body_inferer.py
+++ b/documentstore_migracao/utils/convert_html_body_inferer.py
@@ -95,18 +95,6 @@ class Inferer:
                     return tag, self.ref_type(tag), clue + "".join(parts[1:])
 
 
-def write_json_file(file_path, data):
-    with open(file_path, "w") as fp:
-        s = json.dumps(data)
-        fp.write(s)
-
-
-def read_json_file(file_path):
-    if os.path.isfile(file_path):
-        with open(file_path, "r") as fp:
-            return json.loads(fp.read())
-
-
 class InfererRules:
 
     def __init__(self, rules_file_path):
@@ -167,11 +155,15 @@ class InfererRules:
         return d
 
     def get_data(self, json_file_path, classification_function):
-        data = read_json_file(json_file_path)
+        data = None
+        if os.path.isfile(json_file_path):
+            with open(json_file_path, "r") as fp:
+                data = json.loads(fp.read())
         if not data:
             data = classification_function()
             if data:
-                write_json_file(json_file_path, data)
+                with open(json_file_path, "w") as fp:
+                    fp.write(json.dumps(data))
         return data
 
     @property

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ regex==2019.4.14
 repoze.lru==0.7
 requests==2.21.0
 scielo-clea==0.3.0
-https://github.com/scieloorg/document-store/archive/master.tar.gz#egg=scielo_documentstore
+https://github.com/scieloorg/kernel/archive/master.tar.gz#egg=scielo-kernel
 simplejson==3.16.0
 six==1.12.0
 soupsieve==1.9

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requires = [
     "articlemetaapi>=1.26.6",
     "picles.plumber",
     "lxml",
-    "scielo-documentstore",
+    "scielo-kernel",
     "packtools",
     "paginate",
     "minio",
@@ -63,7 +63,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     dependency_links=[
-        "git://github.com/scieloorg/document-store.git@96585ce99fb09503605416dceb5207a4ac70c43e#egg=scielo_documentstore",
+        "git://github.com/scieloorg/kernel.git@71eda5b8a0f699cdc88d8251261c5e99c7e9d786#egg=scielo-kernel",
     ],
 
     entry_points="""\

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -643,7 +643,6 @@ class Test_RemovePWhichIsParentOfPPipe_Case1(unittest.TestCase):
 
         data = self.text, self.xml
         raw, transformed = self.pipe.transform(data)
-        print("?????", etree.tostring(transformed))
 
         self.assertEqual(len(transformed.findall(".//body//p")), 2)
         self.assertEqual(len(transformed.findall(".//body//*")), 2)
@@ -1575,7 +1574,6 @@ class TestConvertElementsWhichHaveIdPipeline(unittest.TestCase):
         <fn id="nt1"><label>1</label><p>Nota bla bla</p></fn></root>"""
         xml = etree.fromstring(text)
         text, xml = self.pipe.transform((text, xml))
-        print(etree.tostring(xml))
         nodes = xml.findall(".//fn")
         self.assertEqual(len(nodes), 1)
         nodes = xml.findall(".//fn")
@@ -1589,7 +1587,6 @@ class TestConvertElementsWhichHaveIdPipeline(unittest.TestCase):
 
 class TestDeduceAndSuggestConversionPipe(unittest.TestCase):
     def setUp(self):
-        pipeline = HTML2SPSPipeline("PID")
         pl = ConvertElementsWhichHaveIdPipeline()
         self.pipe = pl.DeduceAndSuggestConversionPipe()
         self.inferer = Inferer()
@@ -1641,11 +1638,6 @@ class TestDeduceAndSuggestConversionPipe(unittest.TestCase):
         expected_node = etree.fromstring(expected).findall(xpath)
         for i, node in enumerate(self.xml.findall(xpath)):
             with self.subTest(step + " " + str(i)):
-                if etree.tostring(node) != etree.tostring(expected_node[i]):
-                    print("-")
-                    print(etree.tostring(node))
-                    print(etree.tostring(expected_node[i]))
-
                 self.assertEqual(etree.tostring(node), etree.tostring(expected_node[i]))
 
     def test_add_xml_attribs_to_a_href_from_text(self):

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -1575,6 +1575,7 @@ class TestConvertElementsWhichHaveIdPipeline(unittest.TestCase):
         <fn id="nt1"><label>1</label><p>Nota bla bla</p></fn></root>"""
         xml = etree.fromstring(text)
         text, xml = self.pipe.transform((text, xml))
+        print(etree.tostring(xml))
         nodes = xml.findall(".//fn")
         self.assertEqual(len(nodes), 1)
         nodes = xml.findall(".//fn")
@@ -1640,9 +1641,14 @@ class TestDeduceAndSuggestConversionPipe(unittest.TestCase):
         expected_node = etree.fromstring(expected).findall(xpath)
         for i, node in enumerate(self.xml.findall(xpath)):
             with self.subTest(step + " " + str(i)):
+                if etree.tostring(node) != etree.tostring(expected_node[i]):
+                    print("-")
+                    print(etree.tostring(node))
+                    print(etree.tostring(expected_node[i]))
+
                 self.assertEqual(etree.tostring(node), etree.tostring(expected_node[i]))
 
-    def test_add_xml_attribs(self):
+    def test_add_xml_attribs_to_a_href_from_text(self):
         expected = """
         <root>
             <a href="#tab01" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01" xml_label="tabela 1">Tabela 1</a>
@@ -1652,72 +1658,75 @@ class TestDeduceAndSuggestConversionPipe(unittest.TestCase):
 
             <a href="f01.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f01" xml_label="figure 1">Figure 1</a>
 
-            <a href="f02.jpg">2</a>
+            <a href="f02.jpg" xml_tag="fn" xml_reftype="fn" xml_id="f02" xml_label="2">2</a>
 
             <img src="app.jpg"/>
 
             <a href="f03.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f03" xml_label="figure 3">Figure 3</a>
-            <a href="f03.jpg">3</a>
+            <a href="f03.jpg" xml_tag="fn" xml_reftype="fn" xml_id="f03" xml_label="3">3</a>
         </root>
         """
         self.pipe._add_xml_attribs_to_a_href_from_text(self.texts)
         self._assert(expected, "a_href_from_text")
 
+    def test_add_xml_attribs_to_a_name(self):
         expected = """
         <root>
-            <a href="#tab01" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01" xml_label="tabela 1">Tabela 1</a>
-            <a href="#tab01" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01" xml_label="tabela 1">Tabela 1</a>
-            <a name="tab01" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01" xml_label="tabela 1"/>
+            <a href="#tab01" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01">Tabela 1</a>
+            <a href="#tab01" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01">Tabela 1</a>
+            <a name="tab01" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01"/>
             <img src="tabela.jpg"/>
 
-            <a href="f01.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f01" xml_label="figure 1">Figure 1</a>
+            <a href="f01.jpg">Figure 1</a>
 
             <a href="f02.jpg">2</a>
 
             <img src="app.jpg"/>
 
-            <a href="f03.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f03" xml_label="figure 3">Figure 3</a>
+            <a href="f03.jpg">Figure 3</a>
             <a href="f03.jpg">3</a>
         </root>
         """
         self.pipe._add_xml_attribs_to_a_name(self.document.a_names)
         self._assert(expected, "a_names")
 
+    def test_add_xml_attribs_to_a_href_from_file_paths(self):
         expected = """
         <root>
-            <a href="#tab01" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01" xml_label="tabela 1">Tabela 1</a>
-            <a href="#tab01" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01" xml_label="tabela 1">Tabela 1</a>
-            <a name="tab01" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01" xml_label="tabela 1"/>
-            <img src="tabela.jpg"/>
+            <a href="#tab01">Tabela 1</a>
+            <a href="#tab01">Tabela 1</a>
+            <a name="tab01"/>
+            <img src="tabela.jpg" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01"/>
 
-            <a href="f01.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f01" xml_label="figure 1">Figure 1</a>
-
-            <a href="f02.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f02">2</a>
-
-            <img src="app.jpg"/>
-
-            <a href="f03.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f03" xml_label="figure 3">Figure 3</a>
-            <a href="f03.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f03" xml_label="figure 3">3</a>
-        </root>
-        """
-        self.pipe._add_xml_attribs_to_a_href_from_file_paths(self.files)
-        self._assert(expected, "file_paths")
-
-        expected = """
-        <root>
-            <a href="#tab01" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01" xml_label="tabela 1">Tabela 1</a>
-            <a href="#tab01" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01" xml_label="tabela 1">Tabela 1</a>
-            <a name="tab01" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01" xml_label="tabela 1"/>
-            <img src="tabela.jpg" xml_tag="table-wrap" xml_reftype="table" xml_id="tab01" xml_label="tabela 1"/>
-
-            <a href="f01.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f01" xml_label="figure 1">Figure 1</a>
+            <a href="f01.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f01">Figure 1</a>
 
             <a href="f02.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f02">2</a>
 
             <img src="app.jpg" xml_tag="app" xml_reftype="app" xml_id="app"/>
 
-            <a href="f03.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f03" xml_label="figure 3">Figure 3</a>
-            <a href="f03.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f03" xml_label="figure 3">3</a>
+            <a href="f03.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f03">Figure 3</a>
+            <a href="f03.jpg" xml_tag="fig" xml_reftype="fig" xml_id="f03">3</a>
+        </root>
+        """
+        self.pipe._add_xml_attribs_to_a_href_from_file_paths(self.files)
+        self._assert(expected, "file_paths")
+
+    def test_add_xml_attribs_to_img(self):
+        expected = """
+        <root>
+            <a href="#tab01">Tabela 1</a>
+            <a href="#tab01">Tabela 1</a>
+            <a name="tab01"/>
+            <img src="tabela.jpg"/>
+
+            <a href="f01.jpg">Figure 1</a>
+
+            <a href="f02.jpg">2</a>
+
+            <img src="app.jpg" xml_tag="app" xml_reftype="app" xml_id="app"/>
+
+            <a href="f03.jpg">Figure 3</a>
+            <a href="f03.jpg">3</a>
         </root>
         """
         self.pipe._add_xml_attribs_to_img(self.document.images)

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -1284,22 +1284,30 @@ class TestConversionToCorresp(unittest.TestCase):
         <a href="#back">*</a>
         <a name="home" id="home"/>
         <a name="back" id="back"/>
-        <a href="#home">*</a> Corresponding author</root>"""
+        <a href="#home">*</a> Corresponding author
+        </root>"""
         expected_1 = b"""<root>
-        <a href="#back">*</a>
-        <a name="back" id="back"/> * Corresponding author</root>"""
+        <a href="#back" xml_text="*">*</a>
+
+        <a name="back" id="back" xml_text="*"/>
+        <label href="#home" xml_text="*" label-of="back">*</label> Corresponding author
+        </root>"""
         expected_2 = b"""<root>
-        <xref ref-type="corresp" rid="back">*</xref>
-        <fn id="back" fn-type="corresp"/> * Corresponding author</root>"""
+        <xref ref-type="fn" rid="back">*</xref>
+
+        <fn id="back"/>
+        <label href="#home" xml_text="*" label-of="back">*</label> Corresponding author
+        </root>"""
 
         xml = etree.fromstring(text)
-        html_pl = HTML2SPSPipeline(pid="S1234-56782018000100011")
         pl = ConvertElementsWhichHaveIdPipeline()
-
         text, xml = pl.CompleteElementAWithNameAndIdPipe(
+            ).transform((text, xml))
+        text, xml = pl.CompleteElementAWithXMLTextPipe(
             ).transform((text, xml))
         text, xml = pl.EvaluateElementAToDeleteOrMarkAsFnLabelPipe(
             ).transform((text, xml))
+
         self.assertNotIn(b'<a href="#home">*</a>', etree.tostring(xml))
         self.assertEqual(
             [i for i in etree.tostring(xml).split() if i.strip()],
@@ -1308,7 +1316,7 @@ class TestConversionToCorresp(unittest.TestCase):
 
         text, xml = pl.DeduceAndSuggestConversionPipe().transform((text, xml))
         self.assertIn(
-            b'<a name="back" id="back" xml_tag="corresp" xml_reftype="corresp" xml_id="back"/>',
+            b'<a name="back" id="back" xml_text="*" xml_tag="fn" xml_reftype="fn" xml_id="back" xml_label="*"/>',
             etree.tostring(xml),
         )
 


### PR DESCRIPTION
#### O que esse PR faz?
Aprimora e otimiza o Inferidor. Acrescenta novos prefixos e tags. Otimiza a busca de prefixo e/ou tag. Ajustes no algoritmo para inferir os dados de conversão.

#### Onde a revisão poderia começar?
documentstore_migracao/utils/convert_html_body_inferer.py

#### Como este poderia ser testado manualmente?
`python setup.py test -s tests.test_convert_html_body.TestDeduceAndSuggestConversionPipe`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
Contribui na solução de #154 aprimorando a inferência do elemento ao qual deve ser convertido o a[@name] e/ou a[@href].

### Referências
n/a
