### PR TITLE
Resolve alguns problemas de PR relacionados com os #154

### DIFF
--- a/documentstore_migracao/processing/conversion.py
+++ b/documentstore_migracao/processing/conversion.py
@@ -48,7 +48,7 @@ def convert_article_ALLxml():
     logger.info("Iniciando Conversão do xmls")
     list_files_xmls = files.xml_files_list(config.get("SOURCE_PATH"))
     for file_xml in tqdm(list_files_xmls):
-
+        logger.info("CONVERTER %s" % file_xml)
         try:
             convert_article_xml(
                 os.path.join(config.get("SOURCE_PATH"), file_xml))

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1405,19 +1405,22 @@ class ConvertElementsWhichHaveIdPipeline(object):
 
     class CompleteElementAWithXMLTextPipe(plumber.Pipe):
         """
-        Adiciona o atributo @xml_text ao elemento a, com o valor de seu rótulo.
-        Por exemplo, identificar se <a href="#2">2</a> é nota de rodapé ou
-        é Fig 2.
+        Adiciona o atributo @xml_text ao elemento a, com o valor completo 
+        de seu rótulo. Por exemplo, explicitar se <a href="#2">2</a> é
+        nota de rodapé <a href="#2" xml_text="2">2</a> ou 
+        Fig 2 <a href="#2" xml_text="figure 2">2</a>.
         """
         def add_xml_text_to_a_href(self, xml):
             previous = etree.Element("none")
-            for i, node in enumerate(xml.findall(".//a[@href]")):
-                text = get_node_text(node).lower()
-                node.set("xml_text", text)
-                if text[0].isdigit():
-                    xml_text = previous.get("xml_text")
-                    if xml_text and " " in xml_text:
-                        label, number = xml_text.split(" ")
+            for node in xml.findall(".//a[@href]"):
+                text = get_node_text(node)
+                if text:
+                    text = text.lower()
+                    node.set("xml_text", text)
+                    xml_text = previous.get("xml_text") or ""
+                    splitted = xml_text.split()
+                    if text[0].isdigit() and len(splitted) >= 2:
+                        label, number = splitted[:2]
                         if number[0] <= text[0]:
                             node.set("xml_text", label + " " + text)
                             logger.info(

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -12,6 +12,9 @@ from documentstore_migracao.utils import xml as utils_xml
 from documentstore_migracao import config
 from documentstore_migracao.utils.convert_html_body_inferer import Inferer
 
+import faulthandler
+
+faulthandler.enable()
 
 logger = logging.getLogger(__name__)
 TIMEOUT = config.get("TIMEOUT") or 5
@@ -1981,32 +1984,38 @@ class FileLocation:
         _local = os.path.join(config.get("SITE_SPS_PKG_PATH"), _local)
         return _local.replace("//", "/")
 
-    def ent2char(self, data):
-        return html.unescape(data.decode("utf-8")).encode("utf-8").strip()
-
     @property
     def content(self):
         _content = self.local_content
         if not _content:
-            logger.info("Baixar %s" % self.remote)
-            self.download()
-            _content = self.local_content
+            _content = self.download()
+            if _content:
+                self.save(_content)
         logger.info("%s %s" % (len(_content or ""), self.local))
         return _content
 
     @property
     def local_content(self):
-        logger.info("Existe %s: %s" % (self.local, os.path.isfile(self.local)))
+        logger.info("Get local content from: %s" % self.local)
         if self.local and os.path.isfile(self.local):
+            logger.info("Found")
             with open(self.local, "rb") as fp:
                 return fp.read()
 
     def download(self):
+        logger.info("Download %s" % self.remote)
         r = requests.get(self.remote, timeout=TIMEOUT)
+        if r.status_code == 404:
+            logger.error(
+                "FAILURE. REQUIRES MANUAL INTERVENTION. Not found %s. " % self.remote)
+            return
         if not r.status_code == 200:
             logger.error(
-                "Falha ao acessar %s: %s" % (self.remote, r.status_code))
+                "%s: %s" % (self.remote, r.status_code))
             return
+        return r.content
+
+    def save(self, content):
         dirname = os.path.dirname(self.local)
         if not dirname.startswith(config.get("SITE_SPS_PKG_PATH")):
             logger.info(
@@ -2014,12 +2023,10 @@ class FileLocation:
                 % self.local
             )
             return
-        _content = r.content
         if not os.path.isdir(dirname):
             os.makedirs(dirname)
         with open(self.local, "wb") as fp:
-            fp.write(_content)
-        return _content
+            fp.write(content)
 
 
 def fix_img_revistas_path(node):
@@ -2078,10 +2085,12 @@ class Remote2LocalConversion:
         return []
 
     def remote_to_local(self):
-        self._import_all_href_html_files()
+        self._import_all_html_files_found_in_body()
         self._convert_a_href_into_images_or_media()
 
-    def _classify_a_href(self):
+    def _add_link_type_attribute_to_element_a(self):
+        if self.digital_assets_path is None:
+            return
         for node in self.xml.findall(".//*[@src]"):
             src = node.get("src")
             if ":" in src:
@@ -2139,22 +2148,25 @@ class Remote2LocalConversion:
                     a_href.set("link-type", "asset")
                 else:
                     logger.info("link-type=???")
-                logger.info("Classificou a[@href]: %s" % etree.tostring(a_href))
+                logger.info(
+                    "Classificou a[@href]: %s" % etree.tostring(a_href))
 
-    def _import_all_href_html_files(self):
-        self._classify_a_href()
+    def _import_all_html_files_found_in_body(self):
+        self._add_link_type_attribute_to_element_a()
         while True:
-            self._import_html_files_content()
-            self._classify_a_href()
             if self.body.find(".//a[@link-type='html']") is None:
                 break
+            self._import_files_marked_as_link_type_html()
+            self._add_link_type_attribute_to_element_a()
 
-    def _import_html_files_content(self):
+    def _import_files_marked_as_link_type_html(self):
         new_p_items = []
         for bodychild in self.body_children:
             for a_link_type in bodychild.findall(".//a[@link-type='html']"):
                 new_p = self._import_html_file_content(a_link_type)
-                if new_p is not None:
+                if new_p is None:
+                    a_link_type.set("link-type", "external")
+                else:
                     new_p_items.append((bodychild, new_p))
         for bodychild, new_p in new_p_items[::-1]:
             logger.info(


### PR DESCRIPTION
#### O que esse PR faz?
Resolve alguns problemas de PR relacionados com os #154:
1. Tenta baixar o arquivo HTML apenas 1 vez, caso não encontra o HTML, registra no log que houve falha e que é necessário ação manual, o `<a href=""/>` gerará um link externo.  Também melhora o nome de alguns atributos.
2. Resolve bug em CompleteElementAWithXMLTextPipe
3. Resolve problema de segment fault que surge após a incorporação do PR #189, no entanto, este problema não aconteceria se todos os PR que resolvem o issue #154 fosse incorporados.
4. Corrige a get_node_text para não retornar texto de comentário

#### Onde a revisão poderia começar?
Revisar por commmit:

1. documentstore_migracao/utils/convert_html_body.py L: 2167
2. documentstore_migracao/utils/convert_html_body.py L:1415
3. documentstore_migracao/utils/convert_html_body.py L:1829
4. documentstore_migracao/utils/convert_html_body.py L:92

#### Como este poderia ser testado manualmente?
1. `ds_migracao convert --file xml/source/S1413-41522006000300005.xml`
No migracao.log aparecerá a mensagem:
FAILURE. REQUIRES MANUAL INTERVENTION. Not found http://www.scielo.br/img/revistas/esa/v11n3/htm/fig03.htm

2 e 3. executando:
`ds_migracao convert`
4. `python setup.py test -s tests.test_convert_html_body.TestGetNodeText`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a
#### Quais são tickets relevantes?
relacionado com o PR 
https://github.com/scieloorg/document-store-migracao/pull/187
https://github.com/scieloorg/document-store-migracao/pull/189

### Referências
n/a
