### PR TITLE
Adiciona atualização de arquivos XMLs nativos com dados da base artigo (em CSV)

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -379,9 +379,7 @@ class SPS_Package:
 
     @property
     def is_ahead_of_print(self):
-        has_no_volume = self.volume is None or self.volume == 0
-        has_no_number = self.number is None or self.number == 0
-        if has_no_volume and has_no_number:
+        if not bool(self.volume) and not bool(self.number):
             return True
         return False
 
@@ -420,8 +418,7 @@ class SPS_Package:
         )
         pub_date = self._match_pubdate(xpaths)
         is_collection_pubdate = (
-            pub_date.get("date-type") == "collection" or \
-            pub_date.get("pub-type") == "collection"
+            pub_date.get("date-type", pub_date.get("pub-type")) == "collection"
         )
         if not is_collection_pubdate:
             return parse_date(pub_date)

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -103,6 +103,42 @@ class SPS_Package:
         except IndexError:
             return None
 
+    @publisher_id.setter
+    def publisher_id(self, value):
+        if self.publisher_id is None:
+            pid_node = etree.Element("article-id")
+            pid_node.set("pub-id-type", "publisher-id")
+            pid_node.text = value
+            self.article_meta.append(pid_node)
+        else:
+            pid_node = self.article_meta.xpath(
+                './/article-id[not(@specific-use="scielo") and not(@specific-use="previous-pid") and @pub-id-type="publisher-id"]'
+            )[0]
+            pid_node.text = value
+
+    @property
+    def aop_pid(self):
+        try:
+            return self.xmltree.xpath(
+                './/article-id[@specific-use="previous-pid" and @pub-id-type="publisher-id"]/text()'
+            )[0]
+        except IndexError:
+            return None
+
+    @aop_pid.setter
+    def aop_pid(self, value):
+        if self.aop_pid is None:
+            pid_node = etree.Element("article-id")
+            pid_node.set("pub-id-type", "publisher-id")
+            pid_node.set("specific-use", "previous-pid")
+            pid_node.text = value
+            self.article_meta.append(pid_node)
+        else:
+            pid_node = self.article_meta.xpath(
+                './/article-id[@specific-use="previous-pid" and @pub-id-type="publisher-id"]'
+            )[0]
+            pid_node.text = value
+
     @property
     def journal_meta(self):
         data = []

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -109,7 +109,7 @@ class SPS_Package:
             pid_node = etree.Element("article-id")
             pid_node.set("pub-id-type", "publisher-id")
             pid_node.text = value
-            self.article_meta.append(pid_node)
+            self.article_meta.insert(0, pid_node)
         else:
             pid_node = self.article_meta.xpath(
                 './/article-id[not(@specific-use="scielo") and not(@specific-use="previous-pid") and @pub-id-type="publisher-id"]'
@@ -132,7 +132,7 @@ class SPS_Package:
             pid_node.set("pub-id-type", "publisher-id")
             pid_node.set("specific-use", "previous-pid")
             pid_node.text = value
-            self.article_meta.append(pid_node)
+            self.article_meta.insert(1, pid_node)
         else:
             pid_node = self.article_meta.xpath(
                 './/article-id[@specific-use="previous-pid" and @pub-id-type="publisher-id"]'
@@ -376,6 +376,14 @@ class SPS_Package:
     @property
     def order(self):
         return tuple(item[1] for item in self.order_meta)
+
+    @property
+    def is_ahead_of_print(self):
+        has_no_volume = self.volume is None or self.volume == 0
+        has_no_number = self.number is None or self.number == 0
+        if has_no_volume and has_no_number:
+            return True
+        return False
 
     def _match_pubdate(self, pubdate_xpaths):
         """

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -103,18 +103,50 @@ class SPS_Package:
         except IndexError:
             return None
 
-    @publisher_id.setter
-    def publisher_id(self, value):
-        if self.publisher_id is None:
+    def _get_scielo_pid(self, specific_use):
+        try:
+            return self.xmltree.xpath(
+                f'.//article-id[@specific-use="{specific_use}"]/text()'
+            )[0]
+        except IndexError:
+            return None
+
+    def _set_scielo_pid(self, attr_value, specific_use, value):
+        if attr_value is None:
             pid_node = etree.Element("article-id")
             pid_node.set("pub-id-type", "publisher-id")
+            pid_node.set("specific-use", specific_use)
             pid_node.text = value
             self.article_meta.insert(0, pid_node)
         else:
             pid_node = self.article_meta.xpath(
-                './/article-id[not(@specific-use="scielo") and not(@specific-use="previous-pid") and @pub-id-type="publisher-id"]'
+                f'.//article-id[@specific-use="{specific_use}"]'
             )[0]
             pid_node.text = value
+
+    @property
+    def scielo_pid_v1(self):
+        return self._get_scielo_pid("scielo-v1")
+
+    @scielo_pid_v1.setter
+    def scielo_pid_v1(self, value):
+        self._set_scielo_pid(self.scielo_pid_v1, "scielo-v1", value)
+
+    @property
+    def scielo_pid_v2(self):
+        return self._get_scielo_pid("scielo-v2")
+
+    @scielo_pid_v2.setter
+    def scielo_pid_v2(self, value):
+        self._set_scielo_pid(self.scielo_pid_v2, "scielo-v2", value)
+
+    @property
+    def scielo_pid_v3(self):
+        return self._get_scielo_pid("scielo-v3")
+
+    @scielo_pid_v3.setter
+    def scielo_pid_v3(self, value):
+        self._set_scielo_pid(self.scielo_pid_v3, "scielo-v3", value)
 
     @property
     def aop_pid(self):

--- a/documentstore_migracao/main/migrate_articlemeta.py
+++ b/documentstore_migracao/main/migrate_articlemeta.py
@@ -129,6 +129,14 @@ def migrate_articlemeta_parser(sargs):
         help="Output path.",
     )
 
+    pack_sps_parser_from_site.add_argument(
+        "-Article-csvfile",
+        "--article-csvfile",
+        dest="articles_csvfile",
+        required=True,
+        help="Article CSV data file from ISIS bases",
+    )
+
     # IMPORTACAO
     import_parser = subparsers.add_parser(
         "import",
@@ -199,6 +207,7 @@ def migrate_articlemeta_parser(sargs):
             args.img_folder,
             args.pdf_folder,
             args.output_folder,
+            args.articles_csvfile,
         )
 
         build_ps.run()

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -1,0 +1,188 @@
+import io
+import shutil
+import csv
+import tempfile
+import pathlib
+from unittest import TestCase, mock
+
+from lxml import etree
+
+from . import utils
+from documentstore_migracao.utils import build_ps_package, xml
+from documentstore_migracao.export.sps_package import SPS_Package
+
+
+CSV_FIELDNAMES = (
+    "PID",
+    "PID AOP",
+    "FILE",
+    "DATA (COLLECTION)",
+    "DATA PRIMEIRO PROCESSAMENTO",
+    "DATA DO ULTIMO PROCESSAMENTO",
+)
+
+
+def create_xml(xml_file_path, article_meta_xml, sps_version="sps-1.9"):
+    xml_string = utils.build_xml(article_meta_xml, "10.1590/S0074-02761962000200006")
+    with pathlib.Path(xml_file_path).open(mode="wb", encoding="utf-8") as xmlfile:
+        xmlfile.write(
+            etree.tostring(
+                etree.fromstring(xml_string),
+                xml_declaration=True,
+                method="xml",
+                encoding="utf-8",
+                pretty_print=True,
+            )
+        )
+
+
+def fake_csv():
+    return io.StringIO(
+        "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,\n"
+        "S0101-01012019000100002,S0101-01012019005000001,test/v1n1/1806-0013-test-01-01-0002.xml,20190200,20190115,20190507\n"
+        "S0101-01012019000100003,,test/v1n1/1806-0013-test-01-01-0003.xml,,,\n"
+    )
+
+
+class TestBuildSPSPackageBase(TestCase):
+    def setUp(self):
+        self.builder = build_ps_package.BuildPSPackage(
+            "test",
+            "/data/xmls",
+            "/data/imgs",
+            "/data/pdfs",
+            "/data/output",
+            "/data/article_data_file.csv",
+        )
+        self.article_data_reader = csv.DictReader(fake_csv(), fieldnames=CSV_FIELDNAMES)
+
+
+class TestBuildSPSPackagePIDUpdade(TestBuildSPSPackageBase):
+
+    def test__update_sps_package_object_updates_pid_if_it_is_none(self):
+        mk_sps_package = mock.Mock(spec=SPS_Package, aop_pid=None, publisher_id=None)
+        pack_name = "1806-0013-test-01-01-0001"
+        result = self.builder._update_sps_package_object(
+            self.article_data_reader, mk_sps_package, pack_name
+        )
+        self.assertEqual(result.publisher_id, "S0101-01012019000100001")
+
+    def test__update_sps_package_object_does_not_update_pid_if_it_is_not_none(self):
+        mk_sps_package = mock.Mock(
+            spec=SPS_Package, publisher_id="S0101-01012019000100999"
+        )
+        pack_name = "1806-0013-test-01-01-0001"
+        result = self.builder._update_sps_package_object(
+            self.article_data_reader, mk_sps_package, pack_name
+        )
+        self.assertEqual(result.publisher_id, "S0101-01012019000100999")
+
+
+class TestBuildSPSPackageAOPPIDUpdade(TestBuildSPSPackageBase):
+
+    def test__update_sps_package_object_updates_aop_pid_if_pid_is_none(self):
+        mk_sps_package = mock.Mock(spec=SPS_Package, aop_pid=None, publisher_id=None)
+        pack_name = "1806-0013-test-01-01-0002"
+        result = self.builder._update_sps_package_object(
+            self.article_data_reader, mk_sps_package, pack_name
+        )
+        self.assertEqual(result.aop_pid, "S0101-01012019005000001")
+
+    def test__update_sps_package_object_updates_aop_pid_if_pid_is_found(self):
+        mk_sps_package = mock.Mock(
+            spec=SPS_Package, aop_pid=None, publisher_id="S0101-01012019000100002"
+        )
+        pack_name = "1806-0013-test-01-01-0002"
+        result = self.builder._update_sps_package_object(
+            self.article_data_reader, mk_sps_package, pack_name
+        )
+        self.assertEqual(result.aop_pid, "S0101-01012019005000001")
+
+    def test__update_sps_package_object_does_not_update_aop_pid_if_it_is_not_aop(self):
+        article_data = (
+            ("S0101-01012019000100001", "1806-0013-test-01-01-0001"),
+            (None, "1806-0013-test-01-01-0003"),
+        )
+        for publisher_id, pack_name in article_data:
+            with self.subTest(publisher_id=publisher_id, pack_name=pack_name):
+                mk_sps_package = mock.Mock(
+                    spec=SPS_Package, aop_pid=None, publisher_id=publisher_id
+                )
+                result = self.builder._update_sps_package_object(
+                    self.article_data_reader, mk_sps_package, pack_name
+                )
+                self.assertIsNone(result.aop_pid)
+
+
+class TestBuildSPSPackageAOPPubDate(TestBuildSPSPackageBase):
+
+    def test__update_sps_package_object_does_not_update_pubdate_if_it_is_aop(self):
+        mk_sps_package = mock.Mock(
+            spec=SPS_Package,
+            aop_pid=None,
+            publisher_id="S0101-01012019000100003",
+            is_ahead_of_print=True,
+        )
+        pack_name = "1806-0013-test-01-01-0003"
+        result = self.builder._update_sps_package_object(
+            self.article_data_reader, mk_sps_package, pack_name
+        )
+        mk_sps_package.document_pubdate.assert_not_called()
+        mk_sps_package.documents_bundle_pubdate.assert_not_called()
+
+
+class TestBuildSPSPackageRollingPassDocumentPubDate(TestBuildSPSPackageBase):
+
+    def setUp(self):
+        super().setUp()
+        self.pack_name = "1806-0013-test-01-01-0002"
+        self.mk_sps_package = mock.Mock(
+            spec=SPS_Package,
+            aop_pid=None,
+            publisher_id="S0101-01012019000100002",
+            is_ahead_of_print=False,
+            document_pubdate=("2012", "01", "15",)
+        )
+
+    def test__update_sps_package_object_completes_documents_bundle_pubdate(self):
+        self.mk_sps_package.documents_bundle_pubdate = ("", "", "",)
+        result = self.builder._update_sps_package_object(
+            self.article_data_reader, self.mk_sps_package, self.pack_name
+        )
+        self.assertEqual(result.documents_bundle_pubdate, ("2019", "02", "",))
+
+    def test__update_sps_package_object_does_not_change_documents_bundle_pubdate(self):
+        self.mk_sps_package.documents_bundle_pubdate = ("2012", "", "",)
+        result = self.builder._update_sps_package_object(
+            self.article_data_reader, self.mk_sps_package, self.pack_name
+        )
+        self.assertEqual(result.documents_bundle_pubdate, ("2012", "", "",))
+
+
+class TestBuildSPSPackageDocumentInRegularIssuePubDate(TestBuildSPSPackageBase):
+
+    def setUp(self):
+        super().setUp()
+        self.pack_name = "1806-0013-test-01-01-0002"
+        self.mk_sps_package = mock.Mock(
+            spec=SPS_Package,
+            aop_pid=None,
+            publisher_id="S0101-01012019000100002",
+            is_ahead_of_print=False,
+        )
+
+    def test__update_sps_package_object_completes_document_pubdate(self):
+        self.mk_sps_package.documents_bundle_pubdate = ("2012", "02", "03",)
+        self.mk_sps_package.document_pubdate = ("", "", "",)
+        result = self.builder._update_sps_package_object(
+            self.article_data_reader, self.mk_sps_package, self.pack_name
+        )
+        self.assertEqual(result.document_pubdate, ("2019", "01", "15",))
+
+    def test__update_sps_package_object_does_not_change_document_pubdate(self):
+        self.mk_sps_package.documents_bundle_pubdate = ("2012", "02", "",)
+        self.mk_sps_package.document_pubdate = ("2012", "01", "15",)
+        result = self.builder._update_sps_package_object(
+            self.article_data_reader, self.mk_sps_package, self.pack_name
+        )
+        self.assertEqual(result.document_pubdate, ("2012", "01", "15",))

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -1265,3 +1265,83 @@ class Test_ArticleMetaCount(unittest.TestCase):
         result = self.sps_package.transform_article_meta_count()
 
         self.assertIsNone(result.find(".//counts"))
+
+
+class Test_ArticleMetaPublisherId(unittest.TestCase):
+    def setUp(self):
+        article_meta_xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><article-meta>
+        </article-meta></article>"""
+        article_ids = """
+            <article-id pub-id-type="publisher-id">S0074-02761962000200006</article-id>
+            <article-id pub-id-type="other">00006</article-id>
+        """
+        xml = build_xml(article_meta_xml, "", article_ids=article_ids)
+        xmltree = etree.fromstring(xml)
+        self.sps_package = SPS_Package(xmltree)
+
+    def test_publisher_id(self):
+        self.assertEqual(self.sps_package.publisher_id, "S0074-02761962000200006")
+
+    def test_change_publisher_id(self):
+        self.sps_package.publisher_id = "S0074-02761962000200123"
+        self.assertEqual(self.sps_package.publisher_id, "S0074-02761962000200123")
+
+
+class Test_ArticleMetaNoPublisherId(unittest.TestCase):
+    def setUp(self):
+        article_meta_xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><article-meta>
+        </article-meta></article>"""
+        article_ids = """
+            <article-id pub-id-type="other">00006</article-id>
+        """
+        xml = build_xml(article_meta_xml, "", article_ids=article_ids)
+        xmltree = etree.fromstring(xml)
+        self.sps_package = SPS_Package(xmltree)
+
+    def test_publisher_id(self):
+        self.assertIsNone(self.sps_package.publisher_id)
+
+    def test_set_publisher_id(self):
+        self.sps_package.publisher_id = "S0074-02761962000200123"
+        self.assertEqual(self.sps_package.publisher_id, "S0074-02761962000200123")
+
+
+class Test_ArticleMetaAOPPID(unittest.TestCase):
+    def setUp(self):
+        article_meta_xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><article-meta>
+        </article-meta></article>"""
+        article_ids = """
+            <article-id pub-id-type="publisher-id">S0074-02761962000200006</article-id>
+            <article-id pub-id-type="publisher-id" specific-use="previous-pid">S0074-02761962005000001</article-id>
+            <article-id pub-id-type="other">00006</article-id>
+        """
+        xml = build_xml(article_meta_xml, "", article_ids=article_ids)
+        xmltree = etree.fromstring(xml)
+        self.sps_package = SPS_Package(xmltree)
+
+    def test_aop_pid(self):
+        self.assertEqual(self.sps_package.aop_pid, "S0074-02761962005000001")
+
+    def test_change_aop_pid(self):
+        self.sps_package.aop_pid = "S0074-02761962005000001"
+        self.assertEqual(self.sps_package.aop_pid, "S0074-02761962005000001")
+
+
+class Test_ArticleMetaNoAOPPID(unittest.TestCase):
+    def setUp(self):
+        article_meta_xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><article-meta>
+        </article-meta></article>"""
+        article_ids = """
+            <article-id pub-id-type="publisher-id">S0074-02761962000200006</article-id>
+            <article-id pub-id-type="other">00006</article-id>
+        """
+        xml = build_xml(article_meta_xml, "", article_ids=article_ids)
+        xmltree = etree.fromstring(xml)
+        self.sps_package = SPS_Package(xmltree)
+
+    def test_aop_pid(self):
+        self.assertIsNone(self.sps_package.aop_pid)
+
+    def test_set_aop_pid(self):
+        self.sps_package.aop_pid = "S0074-02761962005000001"
+        self.assertEqual(self.sps_package.aop_pid, "S0074-02761962005000001")

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -31,7 +31,7 @@ def build_xml(
     if doi:
         doi_elem = '<article-id pub-id-type="doi">{}</article-id>'.format(doi)
     return """
-        <article xmlns:xlink="http://www.w3.org/1999/xlink">
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" specific-use="sps-1.9">
         <front>
         <journal-meta>
             {journal_meta}
@@ -494,7 +494,7 @@ class Test_SPS_Package_VolNumFpageLpage(unittest.TestCase):
                 ("fpage", "fpage"),
                 ("lpage", "lpage"),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", ""),
             ),
         )
@@ -502,7 +502,7 @@ class Test_SPS_Package_VolNumFpageLpage(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("2010", "", ""), ""),
+            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
 
@@ -544,7 +544,7 @@ class Test_SPS_Package_VolFpageLpage(unittest.TestCase):
                 ("fpage", "fpage"),
                 ("lpage", "lpage"),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", ""),
             ),
         )
@@ -552,7 +552,7 @@ class Test_SPS_Package_VolFpageLpage(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("2010", "", ""), ""),
+            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
 
@@ -594,7 +594,7 @@ class Test_SPS_Package_NumFpageLpage(unittest.TestCase):
                 ("fpage", "fpage"),
                 ("lpage", "lpage"),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", ""),
             ),
         )
@@ -602,7 +602,7 @@ class Test_SPS_Package_NumFpageLpage(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("2010", "", ""), ""),
+            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
 
@@ -652,7 +652,7 @@ class Test_SPS_Package_VolNumSpeFpageLpage(unittest.TestCase):
                 ("fpage", "fpage"),
                 ("lpage", "lpage"),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", ""),
             ),
         )
@@ -660,7 +660,7 @@ class Test_SPS_Package_VolNumSpeFpageLpage(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("2010", "", ""), ""),
+            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
 
@@ -704,7 +704,7 @@ class Test_SPS_Package_VolSpeNumFpageLpage(unittest.TestCase):
                 ("fpage", "fpage"),
                 ("lpage", "lpage"),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", ""),
             ),
         )
@@ -712,7 +712,7 @@ class Test_SPS_Package_VolSpeNumFpageLpage(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("2010", "", ""), ""),
+            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
 
@@ -756,7 +756,7 @@ class Test_SPS_Package_VolSpeFpageLpage(unittest.TestCase):
                 ("fpage", "fpage"),
                 ("lpage", "lpage"),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", ""),
             ),
         )
@@ -764,7 +764,7 @@ class Test_SPS_Package_VolSpeFpageLpage(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("2010", "", ""), ""),
+            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
 
@@ -814,7 +814,7 @@ class Test_SPS_Package_VolSuplFpageLpage(unittest.TestCase):
                 ("fpage", "fpage"),
                 ("lpage", "lpage"),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", ""),
             ),
         )
@@ -822,7 +822,7 @@ class Test_SPS_Package_VolSuplFpageLpage(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("2010", "", ""), ""),
+            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
 
@@ -872,7 +872,7 @@ class Test_SPS_Package_VolSuplAFpageLpage(unittest.TestCase):
                 ("fpage", "fpage"),
                 ("lpage", "lpage"),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", ""),
             ),
         )
@@ -880,7 +880,7 @@ class Test_SPS_Package_VolSuplAFpageLpage(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("2010", "", ""), ""),
+            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
 
@@ -930,7 +930,7 @@ class Test_SPS_Package_VolNumSuplFpageLpage(unittest.TestCase):
                 ("fpage", "fpage"),
                 ("lpage", "lpage"),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", ""),
             ),
         )
@@ -938,7 +938,7 @@ class Test_SPS_Package_VolNumSuplFpageLpage(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("2010", "", ""), ""),
+            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
 
@@ -987,7 +987,7 @@ class Test_SPS_Package_Vol2SuplAFpageLpage(unittest.TestCase):
                 ("fpage", "fpage"),
                 ("lpage", "lpage"),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", ""),
             ),
         )
@@ -995,7 +995,7 @@ class Test_SPS_Package_Vol2SuplAFpageLpage(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("2010", "", ""), ""),
+            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
 
@@ -1036,7 +1036,7 @@ class Test_SPS_Package_Vol5Elocation(unittest.TestCase):
                 ("fpage", ""),
                 ("lpage", ""),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", "elocation"),
             ),
         )
@@ -1044,7 +1044,7 @@ class Test_SPS_Package_Vol5Elocation(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "", "", ("2010", "", ""), ("2010", "", ""), "elocation"),
+            ("00006", "", "", ("2010", "", ""), ("", "", ""), "elocation"),
         )
 
 
@@ -1088,7 +1088,7 @@ class Test_SPS_Package_VolElocation(unittest.TestCase):
                 ("fpage", ""),
                 ("lpage", ""),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", "elocation"),
             ),
         )
@@ -1096,7 +1096,7 @@ class Test_SPS_Package_VolElocation(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "", "", ("2010", "", ""), ("2010", "", ""), "elocation"),
+            ("00006", "", "", ("2010", "", ""), ("", "", ""), "elocation"),
         )
 
 
@@ -1132,7 +1132,7 @@ class Test_SPS_Package_Aop_HTML(unittest.TestCase):
                 ("fpage", ""),
                 ("lpage", ""),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", ""),
             ),
         )
@@ -1140,7 +1140,7 @@ class Test_SPS_Package_Aop_HTML(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "", "", ("2010", "", ""), ("2010", "", ""), ""),
+            ("00006", "", "", ("2010", "", ""), ("", "", ""), ""),
         )
 
 
@@ -1179,7 +1179,7 @@ class Test_SPS_Package_Aop_XML(unittest.TestCase):
                 ("fpage", ""),
                 ("lpage", ""),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", ""),
             ),
         )
@@ -1187,7 +1187,7 @@ class Test_SPS_Package_Aop_XML(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "", "", ("2010", "", ""), ("2010", "", ""), ""),
+            ("00006", "", "", ("2010", "", ""), ("", "", ""), ""),
         )
 
 
@@ -1233,7 +1233,7 @@ class Test_SPS_Package_Article_HTML(unittest.TestCase):
                 ("fpage", ""),
                 ("lpage", ""),
                 ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
                 ("elocation-id", ""),
             ),
         )
@@ -1241,7 +1241,7 @@ class Test_SPS_Package_Article_HTML(unittest.TestCase):
     def test_order(self):
         self.assertEqual(
             self.sps_package.order,
-            ("00006", "", "", ("2010", "", ""), ("2010", "", ""), ""),
+            ("00006", "", "", ("2010", "", ""), ("", "", ""), ""),
         )
 
 
@@ -1345,3 +1345,129 @@ class Test_ArticleMetaNoAOPPID(unittest.TestCase):
     def test_set_aop_pid(self):
         self.sps_package.aop_pid = "S0074-02761962005000001"
         self.assertEqual(self.sps_package.aop_pid, "S0074-02761962005000001")
+
+
+class Test_DocumentPubdateSPS1_9(unittest.TestCase):
+    def setUp(self):
+        self.xml = """<article specific-use="sps-1.9"><article-meta>
+            <pub-date publication-format="electronic" date-type="collection">
+                <year>2012</year><month>2</month><day>3</day></pub-date>
+        </article-meta></article>"""
+        xmltree = etree.fromstring(self.xml)
+        self.sps_package = SPS_Package(xmltree, None)
+
+    def test_document_pubdate(self):
+        self.assertEqual(self.sps_package.document_pubdate, ("", "", ""))
+
+    def test_set_document_pubdate(self):
+        self.sps_package.document_pubdate = ("2010", "07", "20")
+        self.assertEqual(self.sps_package.document_pubdate, ("2010", "07", "20"))
+
+    def test_set_incomplete_document_pubdate(self):
+        self.sps_package.document_pubdate = ("2010", "", "")
+        self.assertEqual(self.sps_package.document_pubdate, ("2010", "", ""))
+
+
+class Test_DocumentPubdateSPS1_8(unittest.TestCase):
+    def setUp(self):
+        self.xml = """<article specific-use="sps-1.8"><article-meta>
+            <pub-date pub-type="epub-ppub">
+                <year>2012</year><month>2</month><day>3</day></pub-date>
+        </article-meta></article>"""
+        xmltree = etree.fromstring(self.xml)
+        self.sps_package = SPS_Package(xmltree, None)
+
+    def test_document_pubdate(self):
+        self.assertEqual(self.sps_package.document_pubdate, ("2012", "02", "03"))
+
+    def test_set_document_pubdate(self):
+        self.sps_package.document_pubdate = ("2010", "07", "20")
+        self.assertEqual(self.sps_package.document_pubdate, ("2010", "07", "20"))
+
+    def test_set_incomplete_document_pubdate(self):
+        self.sps_package.document_pubdate = ("2010", "", "")
+        self.assertEqual(self.sps_package.document_pubdate, ("2010", "", ""))
+
+
+class Test_DocumentPubdateSPS1_4(unittest.TestCase):
+    def setUp(self):
+        self.xml = """<article specific-use="sps-1.4"><article-meta>
+            <pub-date pub-type="epub-ppub">
+                <year>2012</year><month>2</month></pub-date>
+        </article-meta></article>"""
+        xmltree = etree.fromstring(self.xml)
+        self.sps_package = SPS_Package(xmltree, None)
+
+    def test_document_pubdate(self):
+        self.assertEqual(self.sps_package.document_pubdate, ("2012", "02", ""))
+
+    def test_set_document_pubdate(self):
+        self.sps_package.document_pubdate = ("2010", "07", "20")
+        self.assertEqual(self.sps_package.document_pubdate, ("2010", "07", "20"))
+
+    def test_set_incomplete_document_pubdate(self):
+        self.sps_package.document_pubdate = ("2010", "", "")
+        self.assertEqual(self.sps_package.document_pubdate, ("2010", "", ""))
+
+
+class Test_DocumentsBundlePubdateSPS1_9(unittest.TestCase):
+    def setUp(self):
+        self.xml = """<article specific-use="sps-1.9"><article-meta>
+            <pub-date publication-format="electronic" date-type="pub">
+                <year>2010</year><month>5</month><day>13</day></pub-date>
+        </article-meta></article>"""
+        xmltree = etree.fromstring(self.xml)
+        self.sps_package = SPS_Package(xmltree, None)
+
+    def test_documents_bundle_pubdate(self):
+        self.assertEqual(self.sps_package.documents_bundle_pubdate, ("", "", ""))
+
+    def test_set_documents_bundle_pubdate(self):
+        self.sps_package.documents_bundle_pubdate = ("2012", "10", "21")
+        self.assertEqual(self.sps_package.documents_bundle_pubdate, ("2012", "10", "21"))
+
+    def test_set_incomplete_documents_bundle_pubdate(self):
+        self.sps_package.documents_bundle_pubdate = ("2012", "", "")
+        self.assertEqual(self.sps_package.documents_bundle_pubdate, ("2012", "", ""))
+
+
+class Test_DocumentsBundlePubdateSPS1_8(unittest.TestCase):
+    def setUp(self):
+        self.xml = """<article specific-use="sps-1.8"><article-meta>
+            <pub-date pub-type="epub">
+                <year>2010</year><month>5</month><day>13</day></pub-date>
+        </article-meta></article>"""
+        xmltree = etree.fromstring(self.xml)
+        self.sps_package = SPS_Package(xmltree, None)
+
+    def test_documents_bundle_pubdate(self):
+        self.assertEqual(self.sps_package.documents_bundle_pubdate, ("", "", ""))
+
+    def test_set_documents_bundle_pubdate(self):
+        self.sps_package.documents_bundle_pubdate = ("2012", "10", "21")
+        self.assertEqual(self.sps_package.documents_bundle_pubdate, ("2012", "10", "21"))
+
+    def test_set_incomplete_documents_bundle_pubdate(self):
+        self.sps_package.documents_bundle_pubdate = ("2012", "", "")
+        self.assertEqual(self.sps_package.documents_bundle_pubdate, ("2012", "", ""))
+
+
+class Test_DocumentsBundlePubdateSPS1_4(unittest.TestCase):
+    def setUp(self):
+        self.xml = """<article specific-use="sps-1.4"><article-meta>
+            <pub-date pub-type="epub">
+                <year>2010</year><month>5</month><day>13</day></pub-date>
+        </article-meta></article>"""
+        xmltree = etree.fromstring(self.xml)
+        self.sps_package = SPS_Package(xmltree, None)
+
+    def test_documents_bundle_pubdate(self):
+        self.assertEqual(self.sps_package.documents_bundle_pubdate, ("", "", ""))
+
+    def test_set_documents_bundle_pubdate(self):
+        self.sps_package.documents_bundle_pubdate = ("2012", "10", "21")
+        self.assertEqual(self.sps_package.documents_bundle_pubdate, ("2012", "10", "21"))
+
+    def test_set_incomplete_documents_bundle_pubdate(self):
+        self.sps_package.documents_bundle_pubdate = ("2012", "", "")
+        self.assertEqual(self.sps_package.documents_bundle_pubdate, ("2012", "", ""))

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -3,54 +3,12 @@ from unittest import mock
 
 from lxml import etree
 
+from . import utils
 from documentstore_migracao.export.sps_package import (
     parse_value,
     parse_issue,
     SPS_Package
 )
-
-
-def build_xml(
-    article_meta_children_xml, doi, journal_meta="", article_ids="", pub_date=""
-):
-    default_journal_meta = """
-        <journal-id journal-id-type="publisher-id">acron</journal-id>
-                <issn pub-type="epub">1234-5678</issn>
-                <issn pub-type="ppub">0123-4567</issn>
-        """
-    default_article_ids = """
-        <article-id pub-id-type="publisher-id">S0074-02761962000200006</article-id>
-        <article-id pub-id-type="other">00006</article-id>
-    """
-    default_pubdate = """
-        <pub-date date-type="collection">
-                <year>2010</year>
-            </pub-date>
-    """
-    doi_elem = ""
-    if doi:
-        doi_elem = '<article-id pub-id-type="doi">{}</article-id>'.format(doi)
-    return """
-        <article xmlns:xlink="http://www.w3.org/1999/xlink" specific-use="sps-1.9">
-        <front>
-        <journal-meta>
-            {journal_meta}
-        </journal-meta>
-        <article-meta>
-            {article_meta_doi}
-            {article_ids}
-            {article_meta_children_xml}
-            {pub_date}
-        </article-meta>
-        </front>
-        </article>
-        """.format(
-        article_meta_children_xml=article_meta_children_xml,
-        article_meta_doi=doi_elem,
-        article_ids=article_ids or default_article_ids,
-        journal_meta=journal_meta or default_journal_meta,
-        pub_date=pub_date or default_pubdate,
-    )
 
 
 def pubdate_xml(year, month, day):
@@ -66,7 +24,7 @@ def pubdate_xml(year, month, day):
 
 
 def sps_package(article_meta_xml, doi="10.1590/S0074-02761962000200006"):
-    xml = build_xml(article_meta_xml, doi)
+    xml = utils.build_xml(article_meta_xml, doi)
     xmltree = etree.fromstring(xml)
     return SPS_Package(xmltree, "a01")
 
@@ -505,6 +463,9 @@ class Test_SPS_Package_VolNumFpageLpage(unittest.TestCase):
             ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
+    def test_is_ahead_of_print_false(self):
+        self.assertFalse(self.sps_package.is_ahead_of_print)
+
 
 class Test_SPS_Package_VolFpageLpage(unittest.TestCase):
     def setUp(self):
@@ -555,6 +516,9 @@ class Test_SPS_Package_VolFpageLpage(unittest.TestCase):
             ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
+    def test_is_ahead_of_print_false(self):
+        self.assertFalse(self.sps_package.is_ahead_of_print)
+
 
 class Test_SPS_Package_NumFpageLpage(unittest.TestCase):
     def setUp(self):
@@ -604,6 +568,9 @@ class Test_SPS_Package_NumFpageLpage(unittest.TestCase):
             self.sps_package.order,
             ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
+
+    def test_is_ahead_of_print_false(self):
+        self.assertFalse(self.sps_package.is_ahead_of_print)
 
 
 class Test_SPS_Package_VolNumSpeFpageLpage(unittest.TestCase):
@@ -663,6 +630,9 @@ class Test_SPS_Package_VolNumSpeFpageLpage(unittest.TestCase):
             ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
+    def test_is_ahead_of_print_false(self):
+        self.assertFalse(self.sps_package.is_ahead_of_print)
+
 
 class Test_SPS_Package_VolSpeNumFpageLpage(unittest.TestCase):
     def setUp(self):
@@ -715,6 +685,9 @@ class Test_SPS_Package_VolSpeNumFpageLpage(unittest.TestCase):
             ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
+    def test_is_ahead_of_print_false(self):
+        self.assertFalse(self.sps_package.is_ahead_of_print)
+
 
 class Test_SPS_Package_VolSpeFpageLpage(unittest.TestCase):
     def setUp(self):
@@ -766,6 +739,9 @@ class Test_SPS_Package_VolSpeFpageLpage(unittest.TestCase):
             self.sps_package.order,
             ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
+
+    def test_is_ahead_of_print_false(self):
+        self.assertFalse(self.sps_package.is_ahead_of_print)
 
 
 class Test_SPS_Package_VolSuplFpageLpage(unittest.TestCase):
@@ -825,6 +801,9 @@ class Test_SPS_Package_VolSuplFpageLpage(unittest.TestCase):
             ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
+    def test_is_ahead_of_print_false(self):
+        self.assertFalse(self.sps_package.is_ahead_of_print)
+
 
 class Test_SPS_Package_VolSuplAFpageLpage(unittest.TestCase):
     def setUp(self):
@@ -882,6 +861,9 @@ class Test_SPS_Package_VolSuplAFpageLpage(unittest.TestCase):
             self.sps_package.order,
             ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
+
+    def test_is_ahead_of_print_false(self):
+        self.assertFalse(self.sps_package.is_ahead_of_print)
 
 
 class Test_SPS_Package_VolNumSuplFpageLpage(unittest.TestCase):
@@ -941,6 +923,9 @@ class Test_SPS_Package_VolNumSuplFpageLpage(unittest.TestCase):
             ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
+    def test_is_ahead_of_print_false(self):
+        self.assertFalse(self.sps_package.is_ahead_of_print)
+
 
 class Test_SPS_Package_Vol2SuplAFpageLpage(unittest.TestCase):
     def setUp(self):
@@ -998,6 +983,9 @@ class Test_SPS_Package_Vol2SuplAFpageLpage(unittest.TestCase):
             ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
         )
 
+    def test_is_ahead_of_print_false(self):
+        self.assertFalse(self.sps_package.is_ahead_of_print)
+
 
 class Test_SPS_Package_Vol5Elocation(unittest.TestCase):
     def setUp(self):
@@ -1046,6 +1034,9 @@ class Test_SPS_Package_Vol5Elocation(unittest.TestCase):
             self.sps_package.order,
             ("00006", "", "", ("2010", "", ""), ("", "", ""), "elocation"),
         )
+
+    def test_is_ahead_of_print_false(self):
+        self.assertFalse(self.sps_package.is_ahead_of_print)
 
 
 class Test_SPS_Package_VolElocation(unittest.TestCase):
@@ -1099,6 +1090,9 @@ class Test_SPS_Package_VolElocation(unittest.TestCase):
             ("00006", "", "", ("2010", "", ""), ("", "", ""), "elocation"),
         )
 
+    def test_is_ahead_of_print_false(self):
+        self.assertFalse(self.sps_package.is_ahead_of_print)
+
 
 class Test_SPS_Package_Aop_HTML(unittest.TestCase):
     def setUp(self):
@@ -1142,6 +1136,9 @@ class Test_SPS_Package_Aop_HTML(unittest.TestCase):
             self.sps_package.order,
             ("00006", "", "", ("2010", "", ""), ("", "", ""), ""),
         )
+
+    def test_is_ahead_of_print_true(self):
+        self.assertTrue(self.sps_package.is_ahead_of_print)
 
 
 class Test_SPS_Package_Aop_XML(unittest.TestCase):
@@ -1189,6 +1186,9 @@ class Test_SPS_Package_Aop_XML(unittest.TestCase):
             self.sps_package.order,
             ("00006", "", "", ("2010", "", ""), ("", "", ""), ""),
         )
+
+    def test_is_ahead_of_print_true(self):
+        self.assertTrue(self.sps_package.is_ahead_of_print)
 
 
 class Test_SPS_Package_Article_HTML(unittest.TestCase):
@@ -1244,6 +1244,9 @@ class Test_SPS_Package_Article_HTML(unittest.TestCase):
             ("00006", "", "", ("2010", "", ""), ("", "", ""), ""),
         )
 
+    def test_is_ahead_of_print_false(self):
+        self.assertFalse(self.sps_package.is_ahead_of_print)
+
 
 class Test_ArticleMetaCount(unittest.TestCase):
     def setUp(self):
@@ -1275,7 +1278,7 @@ class Test_ArticleMetaPublisherId(unittest.TestCase):
             <article-id pub-id-type="publisher-id">S0074-02761962000200006</article-id>
             <article-id pub-id-type="other">00006</article-id>
         """
-        xml = build_xml(article_meta_xml, "", article_ids=article_ids)
+        xml = utils.build_xml(article_meta_xml, "", article_ids=article_ids)
         xmltree = etree.fromstring(xml)
         self.sps_package = SPS_Package(xmltree)
 
@@ -1294,7 +1297,7 @@ class Test_ArticleMetaNoPublisherId(unittest.TestCase):
         article_ids = """
             <article-id pub-id-type="other">00006</article-id>
         """
-        xml = build_xml(article_meta_xml, "", article_ids=article_ids)
+        xml = utils.build_xml(article_meta_xml, "", article_ids=article_ids)
         xmltree = etree.fromstring(xml)
         self.sps_package = SPS_Package(xmltree)
 
@@ -1315,7 +1318,7 @@ class Test_ArticleMetaAOPPID(unittest.TestCase):
             <article-id pub-id-type="publisher-id" specific-use="previous-pid">S0074-02761962005000001</article-id>
             <article-id pub-id-type="other">00006</article-id>
         """
-        xml = build_xml(article_meta_xml, "", article_ids=article_ids)
+        xml = utils.build_xml(article_meta_xml, "", article_ids=article_ids)
         xmltree = etree.fromstring(xml)
         self.sps_package = SPS_Package(xmltree)
 
@@ -1335,7 +1338,7 @@ class Test_ArticleMetaNoAOPPID(unittest.TestCase):
             <article-id pub-id-type="publisher-id">S0074-02761962000200006</article-id>
             <article-id pub-id-type="other">00006</article-id>
         """
-        xml = build_xml(article_meta_xml, "", article_ids=article_ids)
+        xml = utils.build_xml(article_meta_xml, "", article_ids=article_ids)
         xmltree = etree.fromstring(xml)
         self.sps_package = SPS_Package(xmltree)
 

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -1285,10 +1285,6 @@ class Test_ArticleMetaPublisherId(unittest.TestCase):
     def test_publisher_id(self):
         self.assertEqual(self.sps_package.publisher_id, "S0074-02761962000200006")
 
-    def test_change_publisher_id(self):
-        self.sps_package.publisher_id = "S0074-02761962000200123"
-        self.assertEqual(self.sps_package.publisher_id, "S0074-02761962000200123")
-
 
 class Test_ArticleMetaNoPublisherId(unittest.TestCase):
     def setUp(self):
@@ -1303,10 +1299,6 @@ class Test_ArticleMetaNoPublisherId(unittest.TestCase):
 
     def test_publisher_id(self):
         self.assertIsNone(self.sps_package.publisher_id)
-
-    def test_set_publisher_id(self):
-        self.sps_package.publisher_id = "S0074-02761962000200123"
-        self.assertEqual(self.sps_package.publisher_id, "S0074-02761962000200123")
 
 
 class Test_ArticleMetaAOPPID(unittest.TestCase):
@@ -1348,6 +1340,117 @@ class Test_ArticleMetaNoAOPPID(unittest.TestCase):
     def test_set_aop_pid(self):
         self.sps_package.aop_pid = "S0074-02761962005000001"
         self.assertEqual(self.sps_package.aop_pid, "S0074-02761962005000001")
+
+
+class Test_ArticleMetaScieloPIDV1(unittest.TestCase):
+    def setUp(self):
+        article_meta_xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><article-meta>
+        </article-meta></article>"""
+        article_ids = """
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v1">12345(1995)</article-id>
+            <article-id pub-id-type="other">00006</article-id>
+        """
+        xml = utils.build_xml(article_meta_xml, "", article_ids=article_ids)
+        xmltree = etree.fromstring(xml)
+        self.sps_package = SPS_Package(xmltree)
+
+    def test_scielo_pid_v1(self):
+        self.assertIsNotNone(self.sps_package.scielo_pid_v1)
+        self.assertEqual(self.sps_package.scielo_pid_v1, "12345(1995)")
+
+    def test_set_scielo_pid_v1(self):
+        self.sps_package.scielo_pid_v1 = "1234-5678(1995)0001"
+        self.assertEqual(self.sps_package.scielo_pid_v1, "1234-5678(1995)0001")
+
+
+class Test_ArticleMetaNoPIDScieloV1(unittest.TestCase):
+    def setUp(self):
+        article_meta_xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><article-meta>
+        </article-meta></article>"""
+        article_ids = """
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0101-02022011009000001</article-id>
+            <article-id pub-id-type="other">00006</article-id>
+        """
+        xml = utils.build_xml(article_meta_xml, "", article_ids=article_ids)
+        xmltree = etree.fromstring(xml)
+        self.sps_package = SPS_Package(xmltree)
+
+    def test_scielo_pid_v1(self):
+        self.assertIsNone(self.sps_package.scielo_pid_v1)
+
+
+class Test_ArticleMetaPIDScieloV2(unittest.TestCase):
+    def setUp(self):
+        article_meta_xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><article-meta>
+        </article-meta></article>"""
+        article_ids = """
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0101-02022011009000001</article-id>
+            <article-id pub-id-type="other">00006</article-id>
+        """
+        xml = utils.build_xml(article_meta_xml, "", article_ids=article_ids)
+        xmltree = etree.fromstring(xml)
+        self.sps_package = SPS_Package(xmltree)
+
+    def test_scielo_pid_v2(self):
+        self.assertIsNotNone(self.sps_package.scielo_pid_v2)
+        self.assertEqual(self.sps_package.scielo_pid_v2, "S0101-02022011009000001")
+
+    def test_set_scielo_pid_v2(self):
+        self.sps_package.scielo_pid_v2 = "S0101-02022011009000001"
+        self.assertEqual(self.sps_package.scielo_pid_v2, "S0101-02022011009000001")
+
+
+class Test_ArticleMetaNoPIDScieloV2(unittest.TestCase):
+    def setUp(self):
+        article_meta_xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><article-meta>
+        </article-meta></article>"""
+        article_ids = """
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v1">12345(1995)</article-id>
+            <article-id pub-id-type="other">00006</article-id>
+        """
+        xml = utils.build_xml(article_meta_xml, "", article_ids=article_ids)
+        xmltree = etree.fromstring(xml)
+        self.sps_package = SPS_Package(xmltree)
+
+    def test_scielo_pid_v2(self):
+        self.assertIsNone(self.sps_package.scielo_pid_v2)
+
+
+class Test_ArticleMetaPIDScieloV3(unittest.TestCase):
+    def setUp(self):
+        article_meta_xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><article-meta>
+        </article-meta></article>"""
+        article_ids = """
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v3">cdmqrXxyd3DRjr88hpGQPLx</article-id>
+            <article-id pub-id-type="other">00006</article-id>
+        """
+        xml = utils.build_xml(article_meta_xml, "", article_ids=article_ids)
+        xmltree = etree.fromstring(xml)
+        self.sps_package = SPS_Package(xmltree)
+
+    def test_scielo_pid_v3(self):
+        self.assertIsNotNone(self.sps_package.scielo_pid_v3)
+        self.assertEqual(self.sps_package.scielo_pid_v3, "cdmqrXxyd3DRjr88hpGQPLx")
+
+    def test_set_scielo_pid_v3(self):
+        self.sps_package.scielo_pid_v3 = "cdmqrXxyd3DRjr88hpGQ123"
+        self.assertEqual(self.sps_package.scielo_pid_v3, "cdmqrXxyd3DRjr88hpGQ123")
+
+
+class Test_ArticleMetaNoPIDScieloV3(unittest.TestCase):
+    def setUp(self):
+        article_meta_xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><article-meta>
+        </article-meta></article>"""
+        article_ids = """
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0101-02022011009000001</article-id>
+            <article-id pub-id-type="other">00006</article-id>
+        """
+        xml = utils.build_xml(article_meta_xml, "", article_ids=article_ids)
+        xmltree = etree.fromstring(xml)
+        self.sps_package = SPS_Package(xmltree)
+
+    def test_scielo_pid_v3(self):
+        self.assertIsNone(self.sps_package.scielo_pid_v3)
 
 
 class Test_DocumentPubdateSPS1_9(unittest.TestCase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,3 +27,52 @@ def AnyType(cls):
             return isinstance(other, cls)
 
     return AnyType()
+
+
+def build_xml(
+    article_meta_children_xml,
+    doi,
+    journal_meta="",
+    article_ids="",
+    pub_date="",
+    sps_version="sps-1.9"
+):
+    default_journal_meta = """
+        <journal-id journal-id-type="publisher-id">acron</journal-id>
+                <issn pub-type="epub">1234-5678</issn>
+                <issn pub-type="ppub">0123-4567</issn>
+        """
+    default_article_ids = """
+        <article-id pub-id-type="publisher-id">S0074-02761962000200006</article-id>
+        <article-id pub-id-type="other">00006</article-id>
+    """
+    default_pubdate = """
+        <pub-date date-type="collection">
+                <year>2010</year>
+            </pub-date>
+    """
+    doi_elem = ""
+    if doi:
+        doi_elem = '<article-id pub-id-type="doi">{}</article-id>'.format(doi)
+    return """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" specific-use="{sps_version}">
+        <front>
+        <journal-meta>
+            {journal_meta}
+        </journal-meta>
+        <article-meta>
+            {article_meta_doi}
+            {article_ids}
+            {article_meta_children_xml}
+            {pub_date}
+        </article-meta>
+        </front>
+        </article>
+        """.format(
+        article_meta_children_xml=article_meta_children_xml,
+        article_meta_doi=doi_elem,
+        article_ids=article_ids or default_article_ids,
+        journal_meta=journal_meta or default_journal_meta,
+        pub_date=pub_date or default_pubdate,
+        sps_version=sps_version,
+    )


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona atualização de arquivos XMLs nativos com dados da base artigo, lidas de um arquivo CSV. Caso os XMLs não tenham um dos dados que estão no CSV, o conteúdo é atualizado no arquivo copiado do diretório informado.
Os seguintes dados são esperados no CSV:
 - PID
 - PID AOP
 - FILE
 - DATA (COLLECTION)
 - DATA PRIMEIRO PROCESSAMENTO
 - DATA DO ULTIMO PROCESSAMENTO
É importante salientar que os dados presentes no XML nativo não são sobrescritos.

#### Onde a revisão poderia começar?
É recomendado que a revisão do PR seja feita por commits.

#### Como este poderia ser testado manualmente?
1. Selecione um periódico com XMLs que tenham dados a serem complementados
2. Execute o comando `ds_migracao pack_from_site`, informando o acrônimo do periódico selecionado e a opção `-Article-csvfile` com o path para o arquivo CSV contendo os dados de artigos. Ex.:
`ds_migracao pack_from_site -a brjp -Xfolder data/xml -Ifolder data/img -Pfolder data/pdf -Ofolder xml/site_sps_packages -Article-csvfile articles_data.csv`
3. Ao final, verificar se arquivos XMLs do diretório `xml/site_sps_packages` foram completados com informações do CSV
4. Verifique também os XMLs que tem todas as informações e que deverão estar inalterados

#### Algum cenário de contexto que queira dar?
O arquivo CSV precisa ser gerado através das bases ISIS. É importante ressaltar que o campo DATA PRIMEIRO PROCESSAMENTO pode não existir neste arquivo e, nestas situações, a data utilizada é a do campo DATA DO ULTIMO PROCESSAMENTO.

### Screenshots
N/A

#### Quais são tickets relevantes?
#192

### Referências
 * https://jats.nlm.nih.gov/publishing/tag-library/1.3d1/element/article-meta.html
 * [articles_data_csv.zip](https://github.com/scieloorg/document-store-migracao/files/3718917/articles_data_csv.zip)

