### PR TITLE
Considera outros formatos de valor de `a[@href]` para gerar `ext-link`

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1014,6 +1014,10 @@ class HTML2SPSPipeline(object):
                 return self._create_email(node)
             if href.startswith("//") or ":" in href:
                 return self._create_ext_link(node)
+            if href.startswith("www"):
+                return self._create_ext_link(node)
+            if href.startswith("http//"):
+                return self._create_ext_link(node)
             href = href.split("/")[0]
             if href and href.count(".") and href.replace(".", ""):
                 return self._create_ext_link(node)


### PR DESCRIPTION
#### O que esse PR faz?
Converte `a[@href]`, cujo conteúdo contém uri com formato não esperado, para `<ext-link/>`.

```xml
<a href="http//sisifo.fpce.ul.pt" target="_blank" link-type="unknown" xml_text="http//sisifo.fpce.ul.pt">http//sisifo.fpce.ul.pt</a>
<a href="http//www.socerj.org.br/temas/21enfer.pdf" target="_blank" link-type="unknown" xml_text="http//www.socerj.org.br/temas/21 enfer.pdf">http//www.socerj.org.br/temas/21 enfer.pdf</a> - url incorreta
<a href="http//www.books.nap.edu/books/0309071836/html/287.html#pagetop" link-type="external" xml_text="http//www.books.nap.edu/books/0309071836/html/287.html#pagetop">http//www.books.nap.edu/books/0309071836/html/287.html#pagetop</a>
<a href="http//www.banet.com.br/propQstalABMR.htm" target="_blank" link-type="external" xml_text="http//www.banet.com.br/propqstalabmr.htm">http//www.banet.com.br/propQstalABMR.htm</a>
```

#### Onde a revisão poderia começar?
documentstore_migracao/utils/convert_html_body.py:L 1017

#### Como este poderia ser testado manualmente?
`python setup.py test -s tests.test_convert_html_body.TestAHrefPipe`

ou com 

`ds_migracao convert --file xml/source/<pid>.xml`

- S0034-71672011000300005 
- S0034-89101998000300005
- S1415-52732003000300005 
- S1984-29612009000300005

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
Ver detalhes em #205

### Referências
n/a