### PR TITLE
Move app-group do body para o back durante a conversão

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -525,6 +525,24 @@ class SPS_Package:
 
         return self.xmltree
 
+    def _move_appendix_from_body_to_back(self, tbody, tback):
+        app_group_tags = tbody.findall(".//app-group")
+        if len(app_group_tags) > 0:
+            for app_group_tag in app_group_tags:
+                tback.append(app_group_tag)
+
+    def transform_content(self):
+        # CONVERTE PUB-DATE PARA SPS 1.9
+        self.transform_pubdate()
+
+        for body in self.xmltree.iterfind(".//body"):
+            back = body.getparent().find("./back")
+            if back is None:
+                body.getparent().append(etree.Element("back"))
+                back = body.getparent().find("./back")
+            # OUTROS AJUSTES NO XML PARA SPS 1.9
+            self._move_appendix_from_body_to_back(body, back)
+
     def transform_article_meta_count(self):
         count_tree = self.xmltree.find(".//counts")
         if count_tree is not None:

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -525,23 +525,23 @@ class SPS_Package:
 
         return self.xmltree
 
-    def _move_appendix_from_body_to_back(self, tbody, tback):
-        app_group_tags = tbody.findall(".//app-group")
-        if len(app_group_tags) > 0:
-            for app_group_tag in app_group_tags:
-                tback.append(app_group_tag)
+    def _move_appendix_from_body_to_back(self):
+        for body in self.xmltree.iterfind(".//body"):
+            app_group_tags = body.findall(".//app-group")
+            if len(app_group_tags) > 0:
+                back = body.getparent().find("./back")
+                if back is None:
+                    body.getparent().append(etree.Element("back"))
+                    back = body.getparent().find("./back")
+                for app_group_tag in app_group_tags:
+                    back.append(app_group_tag)
 
     def transform_content(self):
         # CONVERTE PUB-DATE PARA SPS 1.9
         self.transform_pubdate()
 
-        for body in self.xmltree.iterfind(".//body"):
-            back = body.getparent().find("./back")
-            if back is None:
-                body.getparent().append(etree.Element("back"))
-                back = body.getparent().find("./back")
-            # OUTROS AJUSTES NO XML PARA SPS 1.9
-            self._move_appendix_from_body_to_back(body, back)
+        # OUTROS AJUSTES NO XML PARA SPS 1.9
+        self._move_appendix_from_body_to_back()
 
     def transform_article_meta_count(self):
         count_tree = self.xmltree.find(".//counts")

--- a/documentstore_migracao/processing/conversion.py
+++ b/documentstore_migracao/processing/conversion.py
@@ -23,8 +23,8 @@ def convert_article_xml(file_xml_path):
     xml_sps = SPS_Package(obj_xmltree)
     # CONVERTE O BODY DO AM PARA SPS
     xml_sps.transform_body()
-    # CONVERTE PUB-DATE PARA SPS 1.9
-    xml_sps.transform_pubdate()
+    # Transforma XML em SPS 1.9
+    xml_sps.transform_content()
 
     # CONSTROI O SCIELO-id NO XML CONVERTIDO
     xml_sps.create_scielo_id()

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -80,7 +80,7 @@ class TestProcessingConversion(unittest.TestCase):
 
     @patch("documentstore_migracao.processing.conversion.SPS_Package")
     @patch("documentstore_migracao.processing.conversion.xml")
-    def test_convert_article_xml_calls_sps_package_transform_pubdate(
+    def test_convert_article_xml_calls_sps_package_transform_content(
         self, mk_utils_xml, MockSPS_Package
     ):
         mk_xml_sps = MagicMock()
@@ -88,7 +88,7 @@ class TestProcessingConversion(unittest.TestCase):
         conversion.convert_article_xml(
             os.path.join(SAMPLES_PATH, "S0036-36341997000100001.xml")
         )
-        mk_xml_sps.transform_pubdate.assert_called_once()
+        mk_xml_sps.transform_content.assert_called_once()
 
     def test_convert_article_xml(self):
 

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -1579,45 +1579,12 @@ class Test_DocumentsBundlePubdateSPS1_4(unittest.TestCase):
         self.assertEqual(self.sps_package.documents_bundle_pubdate, ("2012", "", ""))
 
 
-class TestMoveAppendixFromBodyToBack(unittest.TestCase):
-    def setUp(self):
-        self.xml = """<article specific-use="sps-1.9" xmlns:xlink="http://www.w3.org/1999/xlink">
-            <body>
-                <p>
-                    <app-group>
-                        <app id="anx01"><label>Anexo 1</label>
-                            <graphic xlink:href="/img/revistas/test/v2n3/a01anx01.jpg" />
-                        </app>
-                    </app-group>
-                </p>
-                <p />
-                <p>
-                    <app-group>
-                        <app id="anx02"><label>Anexo 2</label>
-                            <graphic xlink:href="/img/revistas/test/v2n3/a01anx02.jpg" />
-                        </app>
-                    </app-group>
-                </p>
-            </body>
-            <back></back>
-        </article>"""
-        xmltree = etree.fromstring(self.xml)
-        self.app_ids = [f"anx0{num}" for num in range(1, 3)]
-        self.sps_package = SPS_Package(xmltree, None)
-        self.body = self.sps_package.xmltree.find("./body")
-        self.back = self.sps_package.xmltree.find("./back")
-        self.sps_package._move_appendix_from_body_to_back(self.body, self.back)
-
-    def test_body_without_appedix(self):
-        self.assertEqual(len(self.sps_package.xmltree.findall("./body//app-group")), 0)
-
-    def test_back_with_appedix(self):
-        app_group_tags = self.sps_package.xmltree.findall(".//back//app-group")
-        self.assertEqual(len(app_group_tags), 2)
-        for app_group_tag in app_group_tags:
-            self.assertIn(app_group_tag.find("app").attrib["id"], self.app_ids)
-
-
+@mock.patch(
+    "documentstore_migracao.export.sps_package.SPS_Package._move_appendix_from_body_to_back"
+)
+@mock.patch(
+    "documentstore_migracao.export.sps_package.SPS_Package.transform_pubdate"
+)
 class TestTransformContent(unittest.TestCase):
     def setUp(self):
         self.xml = """<article specific-use="sps-1.9" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -1642,32 +1609,61 @@ class TestTransformContent(unittest.TestCase):
         </article>"""
         xmltree = etree.fromstring(self.xml)
         self.app_ids = [f"anx0{num}" for num in range(1, 3)]
-        self.mk_sps_package_move_appedix_patcher = mock.patch(
-            "documentstore_migracao.export.sps_package.SPS_Package._move_appendix_from_body_to_back"
-        )
-        self.mk_sps_package_move_appedix = (
-            self.mk_sps_package_move_appedix_patcher.start()
-        )
-        self.mk_sps_package_transform_pubdate_patcher = mock.patch(
-            "documentstore_migracao.export.sps_package.SPS_Package.transform_pubdate"
-        )
-        self.mk_sps_package_transform_pubdate = (
-            self.mk_sps_package_transform_pubdate_patcher.start()
-        )
         self.sps_package = SPS_Package(xmltree, None)
         self.body = self.sps_package.xmltree.find("./body")
         self.back = self.sps_package.xmltree.find("./back")
+
+    def test_calls_transform_pubdate(
+        self, mk_transform_pubdate, mk_sps_package_move_appedix
+    ):
         self.sps_package.transform_content()
+        mk_transform_pubdate.assert_called_once()
 
-    def tearDown(self):
-        self.mk_sps_package_move_appedix_patcher.stop()
-        self.mk_sps_package_transform_pubdate_patcher.stop()
+    def test_calls_moves_appendix_from_body_to_back(
+        self, mk_transform_pubdate, mk_sps_package_move_appedix
+    ):
+        self.sps_package.transform_content()
+        mk_sps_package_move_appedix.assert_called_once()
 
-    def test_moves_appendix_from_body_to_back(self):
-        self.mk_sps_package_move_appedix.assert_called_with(self.body, self.back)
+
+class TestMoveAppendixFromBodyToBack(unittest.TestCase):
+    def setUp(self):
+        self.xml = """<article specific-use="sps-1.9" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <body>
+                <p>
+                    <app-group>
+                        <app id="anx01"><label>Anexo 1</label>
+                            <graphic xlink:href="/img/revistas/test/v2n3/a01anx01.jpg" />
+                        </app>
+                    </app-group>
+                </p>
+                <p />
+                <p>
+                    <app-group>
+                        <app id="anx02"><label>Anexo 2</label>
+                            <graphic xlink:href="/img/revistas/test/v2n3/a01anx02.jpg" />
+                        </app>
+                    </app-group>
+                </p>
+            </body>
+        </article>"""
+        xmltree = etree.fromstring(self.xml)
+        self.app_ids = [f"anx0{num}" for num in range(1, 3)]
+        self.sps_package = SPS_Package(xmltree, None)
+
+    def test_body_without_appedix(self):
+        self.sps_package._move_appendix_from_body_to_back()
+        self.assertEqual(len(self.sps_package.xmltree.findall("./body//app-group")), 0)
+
+    def test_back_with_appedix(self):
+        self.sps_package._move_appendix_from_body_to_back()
+        app_group_tags = self.sps_package.xmltree.findall(".//back//app-group")
+        self.assertEqual(len(app_group_tags), 2)
+        for app_group_tag in app_group_tags:
+            self.assertIn(app_group_tag.find("app").attrib["id"], self.app_ids)
 
 
-class TestTransformContentWithSubArticle(unittest.TestCase):
+class TestMoveAppendixFromBodyToBackWithSubArticle(unittest.TestCase):
     def setUp(self):
         self.xml = """<article specific-use="sps-1.9" xmlns:xlink="http://www.w3.org/1999/xlink">
             <body>
@@ -1708,40 +1704,31 @@ class TestTransformContentWithSubArticle(unittest.TestCase):
             </sub-article>
         </article>"""
         xmltree = etree.fromstring(self.xml)
-        self.app_ids = [f"anx0{num}" for num in range(1, 3)]
-        self.mk_sps_package_move_appedix_patcher = mock.patch(
-            "documentstore_migracao.export.sps_package.SPS_Package._move_appendix_from_body_to_back"
-        )
-        self.mk_sps_package_move_appedix = (
-            self.mk_sps_package_move_appedix_patcher.start()
-        )
-        self.mk_sps_package_transform_pubdate_patcher = mock.patch(
-            "documentstore_migracao.export.sps_package.SPS_Package.transform_pubdate"
-        )
-        self.mk_sps_package_transform_pubdate = (
-            self.mk_sps_package_transform_pubdate_patcher.start()
-        )
+        self.app_ids = [f"anx0{num}" for num in range(1, 5)]
         self.sps_package = SPS_Package(xmltree, None)
-        self.sps_package.transform_content()
 
-    def tearDown(self):
-        self.mk_sps_package_move_appedix_patcher.stop()
-        self.mk_sps_package_transform_pubdate_patcher.stop()
+    def test_from_body_to_back_article_data(self):
+        self.sps_package._move_appendix_from_body_to_back()
+        self.assertEqual(len(self.sps_package.xmltree.findall("./body//app-group")), 0)
+        app_group_tags = self.sps_package.xmltree.findall("./back//app-group")
+        self.assertEqual(len(app_group_tags), 2)
+        for app_group_tag in app_group_tags:
+            self.assertIn(app_group_tag.find("app").attrib["id"], self.app_ids[:2])
 
-    def test_moves_appendix_from_body_to_back_article_data(self):
-        article_body = self.sps_package.xmltree.find("./body")
-        article_back = article_body.getparent().find("./back")
-        self.mk_sps_package_move_appedix.assert_any_call(article_body, article_back)
-
-    def test_moves_appendix_from_body_to_back_sub_article_data(self):
-        subarticle_body = self.sps_package.xmltree.find("./sub-article//body")
-        subarticle_back = self.sps_package.xmltree.find("./sub-article//back")
-        self.mk_sps_package_move_appedix.assert_any_call(
-            subarticle_body, subarticle_back
+    def test_from_body_to_back_sub_article_data(self):
+        self.sps_package._move_appendix_from_body_to_back()
+        self.assertEqual(
+            len(self.sps_package.xmltree.findall("./sub-article//body//app-group")), 0
         )
+        app_group_tags = self.sps_package.xmltree.findall(
+            "./sub-article//back//app-group"
+        )
+        self.assertEqual(len(app_group_tags), 2)
+        for app_group_tag in app_group_tags:
+            self.assertIn(app_group_tag.find("app").attrib["id"], self.app_ids[2:])
 
 
-class TestTransformContentWithSubArticleAndBacks(unittest.TestCase):
+class TestMoveAppendixFromBodyToBackWithSubArticleAndBacks(unittest.TestCase):
     def setUp(self):
         self.xml = """<article specific-use="sps-1.9" xmlns:xlink="http://www.w3.org/1999/xlink">
             <body>
@@ -1791,34 +1778,25 @@ class TestTransformContentWithSubArticleAndBacks(unittest.TestCase):
             </sub-article>
         </article>"""
         xmltree = etree.fromstring(self.xml)
-        self.app_ids = [f"anx0{num}" for num in range(1, 3)]
-        self.mk_sps_package_move_appedix_patcher = mock.patch(
-            "documentstore_migracao.export.sps_package.SPS_Package._move_appendix_from_body_to_back"
-        )
-        self.mk_sps_package_move_appedix = (
-            self.mk_sps_package_move_appedix_patcher.start()
-        )
-        self.mk_sps_package_transform_pubdate_patcher = mock.patch(
-            "documentstore_migracao.export.sps_package.SPS_Package.transform_pubdate"
-        )
-        self.mk_sps_package_transform_pubdate = (
-            self.mk_sps_package_transform_pubdate_patcher.start()
-        )
+        self.app_ids = [f"anx0{num}" for num in range(1, 5)]
         self.sps_package = SPS_Package(xmltree, None)
-        self.sps_package.transform_content()
 
-    def tearDown(self):
-        self.mk_sps_package_move_appedix_patcher.stop()
-        self.mk_sps_package_transform_pubdate_patcher.stop()
+    def test_from_body_to_back_article_data(self):
+        self.sps_package._move_appendix_from_body_to_back()
+        self.assertEqual(len(self.sps_package.xmltree.findall("./body//app-group")), 0)
+        app_group_tags = self.sps_package.xmltree.findall("./back//app-group")
+        self.assertEqual(len(app_group_tags), 2)
+        for app_group_tag in app_group_tags:
+            self.assertIn(app_group_tag.find("app").attrib["id"], self.app_ids[:2])
 
-    def test_moves_appendix_from_body_to_back_article_data(self):
-        article_body = self.sps_package.xmltree.find("./body")
-        article_back = article_body.getparent().find("./back")
-        self.mk_sps_package_move_appedix.assert_any_call(article_body, article_back)
-
-    def test_moves_appendix_from_body_to_back_sub_article_data(self):
-        subarticle_body = self.sps_package.xmltree.find("./sub-article//body")
-        subarticle_back = self.sps_package.xmltree.find("./sub-article//back")
-        self.mk_sps_package_move_appedix.assert_any_call(
-            subarticle_body, subarticle_back
+    def test_from_body_to_back_sub_article_data(self):
+        self.sps_package._move_appendix_from_body_to_back()
+        self.assertEqual(
+            len(self.sps_package.xmltree.findall("./sub-article//body//app-group")), 0
         )
+        app_group_tags = self.sps_package.xmltree.findall(
+            "./sub-article//back//app-group"
+        )
+        self.assertEqual(len(app_group_tags), 2)
+        for app_group_tag in app_group_tags:
+            self.assertIn(app_group_tag.find("app").attrib["id"], self.app_ids[2:])


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona mais um método ao SPS_Package para fazer transformações no conteúdo do XML não atendidas na transformação do conteúdo do `body`. Foi movida a chamada da transformação do pub-date para este método, além da inclusão do método que move os grupos de anexos/apêndices do `body` para o `back` e, assim, tornar o XML válido com relação a essas tags em específico.

#### Onde a revisão poderia começar?
Em `documentstore_migracao/export/sps_package.py`, L534.

#### Como este poderia ser testado manualmente?
Rodando os testes:
```python setup.py test```

OU

- Extraia algum artigo em HTML com o comando `ds_migracao extract`
- Perceba que o `body` tem tags `<app-group>`
- Converta o XML gravado na extração com o comando `ds_migracao convert`
- Verifique o XML gerado em `xml/conversion/`
- As tags `<app-group>` devem estar no `back` e não mais no `body`, após as referências.

Exemplo para o teste: `S2237-60892011000300005`

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#147

### Referências
N/A