### PR TITLE
Adiciona processo para inclusão das mixed-citations

### DIFF
--- a/documentstore_migracao/main/migrate_articlemeta.py
+++ b/documentstore_migracao/main/migrate_articlemeta.py
@@ -165,8 +165,42 @@ def migrate_articlemeta_parser(sargs):
         help="JSON file de documentos importados, e.g: ~/json/collection-issues.json",
     )
     link_documents_issues.add_argument(
-        "journals",
-        help="JSON file de journals result, e.g: ~/json/journal.json",
+        "journals", help="JSON file de journals result, e.g: ~/json/journal.json"
+    )
+
+    # Referências
+    example_text = """example:
+
+    # Use multiple MST files with a fixed directory structure inferred
+    # by articles' PID, e.g /bases/xml.000/bases/article/p/issn/year/order_in_year/order_in_issue.mst
+    ds_migracao mixed-citations xml/conversion /bases/xml.000/bases/article/p/
+
+    # Use a single MST file to update all articles' mixed citations.
+    ds_migracao mixed-citations xml/conversion /bases/extracted_paragraphs_file.mst
+
+    # Output updated XMLs in a different directory.
+    ds_migracao mixed-citations xml/conversion /bases/extracted_paragraphs_file.mst --output=/home/xmls
+
+    # Process a single XML, then save the result in the source file. NOTE: If the
+    # output directory path isn't used, the source file will be modified.
+    ds_migracao mixed-citations xml/conversion/file.xml /bases/extracted_paragraphs_file.mst
+    """
+
+    references = subparsers.add_parser(
+        "mixed-citations",
+        help="Update mixed citations",
+        epilog=example_text,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    references.add_argument("source", help="XML source or directory path")
+    references.add_argument(
+        "mst", help="Directory root or MST file where paragraphs are located"
+    )
+    references.add_argument("--output", metavar="dir", help="Output directory path")
+    references.add_argument(
+        "--override",
+        action="store_true",
+        help="Override old mixed citations in XML file",
     )
 
     ################################################################################################
@@ -233,6 +267,15 @@ def migrate_articlemeta_parser(sargs):
 
         inserting.register_documents_in_documents_bundle(
             session_db=DB_Session(), file_documents=args.documents, file_journals=args.journals
+        )
+    elif args.command == "mixed-citations":
+        from documentstore_migracao.processing import pipeline
+
+        pipeline.update_articles_mixed_citations(
+            source=args.source,
+            mst_source=args.mst,
+            output_folder=args.output,
+            override=args.override,
         )
 
     else:

--- a/documentstore_migracao/processing/pipeline.py
+++ b/documentstore_migracao/processing/pipeline.py
@@ -3,6 +3,14 @@ import sys
 import os
 import json
 import gzip
+import re
+from typing import List, Generator
+
+from lxml import etree
+
+from documentstore_migracao.export.sps_package import SPS_Package
+from documentstore_migracao.utils.extract_isis import run as run_isis2json
+from documentstore_migracao.utils import xml as XMLUtils
 
 from documentstore.interfaces import Session
 from documentstore.domain import utcnow, Journal, DocumentsBundle
@@ -187,3 +195,146 @@ def link_documents_bundles_with_journals(issue_path: str, output_path: str):
 
     with open(output_path, "w") as output:
         output.write(json.dumps(journals_bundles, indent=4, sort_keys=True))
+
+
+def update_articles_mixed_citations(
+    source: str, mst_source: str, output_folder: str = None, override: bool = False
+):
+    """Atualiza os elementos de ``mixed-citations`` em um ou mais XMLs.
+
+    É possível atualizar um ou mais XML a partir de um path `source`. A fonte
+    de parágrafos pode ser um arquivo MST ou um diretório no padrão SciELO Brasil.
+
+    Se a fonte MST for um diretório no padrão SciELO os arquivos MST serão
+    localizados a partir do PID do XML processado
+    (PID: S0301-80591999000100002 -> 0301-8059/1999/0001/00002.mst).
+
+    O resultado da atualização pode ser salvo no próprio arquivo XML ou em
+    outro arquivo XML em um diretório diferente utilizando o parâmetro
+    ``output_folder``."""
+    if not os.path.exists(source):
+        raise FileNotFoundError("Source path '%s' does not exists" % source)
+    elif not os.path.exists(mst_source):
+        raise FileNotFoundError("MST path '%s' does not exists" % mst_source)
+    elif output_folder is not None and not os.path.exists(output_folder):
+        raise FileNotFoundError("Output folder '%s' does not exists" % output_folder)
+
+    def get_nested(node, *path, default=""):
+        try:
+            for p in path:
+                node = node[p]
+        except (IndexError, KeyError):
+            return default
+        return node
+
+    def get_xml_files_path(path: str) -> List[str]:
+        """Retorna uma lista com os XMLs encontrados em um determinado path"""
+        if os.path.isfile(path):
+            return [path]
+
+        xmls = []
+        for root, _, files in os.walk(path):
+            xmls.extend(
+                [
+                    os.path.realpath(os.path.join(root, file))
+                    for file in files
+                    if ".xml" in file
+                ]
+            )
+
+        return xmls
+
+    def translate_pid_to_mst_path(pid: str) -> str:
+        """Converte o PID de um artigo na estrutura de diretório de parágrafos
+        utilizada pela SciELO BR.
+
+        Exemplo:
+        PID: S0301-80591999000100002 -> 0301-8059/1999/0001/00002.mst"""
+        result = re.split(r"S?([\w-]{9})(.{4})(.{4})(.{5})", pid)
+        result = "/".join(result[1:-1]) + ".mst"
+        return result
+
+    def get_paragraphs_from_mst(mst_source: str, pid: str = None) -> dict:
+        """Ler um arquivo MST e retorna seu conteúdo em formato JSON.
+
+        Se o parâmetro `mst_source` for um arquivo MST, o seu conteúdo será lido
+        e transformado em JSON. O parâmetro `pid` será utilizado para inferir
+        o path da base MST se o `mst_source` for um diretório.
+
+        O caminho inferido a partir do `pid` segue a regra utilizada pela SciELO
+        para segmentar a base Artigo e seus parágrafos (issn/year/order/order_in_issue).
+        """
+        if os.path.isdir(mst_source) and pid is None:
+            raise ValueError("PID param is required if mst source is a directory")
+        elif os.path.isdir(mst_source):
+            mst_source = os.path.join(mst_source, translate_pid_to_mst_path(pid))
+
+        if not os.path.exists(mst_source):
+            raise FileNotFoundError("File '%s' does not exists" % mst_source)
+
+        return json.loads(run_isis2json(mst_source).stdout.decode())
+
+    def get_references_text_from_paragraphs(paragraphs: list, pid: str) -> dict:
+        """Filtra as referências a partir dos paragráfos.
+
+        As referências possuem a mesma estrutura dos parágrafos na base MST
+        exceto pelo índice (v888). Considera-se uma referência os registros que
+        possuem o índice/order (v888) e a chave de `PID` para o artigo (v880).
+
+        Params:
+            paragraphs (List[dict]): Lista de parágrafos extraídos da base MST
+            pid (str): Identificador do documento no formato `scielo-v2`
+
+        Returns:
+            references (Dict[str, str]): Dicionário com referências filtradas,
+            e.g: {"order": "text"}
+        """
+        references = {}
+
+        for paragraph in paragraphs:
+            article_pid = get_nested(paragraph, "v880", 0, "_", default=None)
+            index = get_nested(paragraph, "v888", 0, "_", default=-1)
+
+            if index != -1 and article_pid == pid:
+                references[index] = XMLUtils.cleanup_mixed_citation_text(
+                    get_nested(paragraph, "v704", 0, "_")
+                )
+
+        return references
+
+    def get_output_file_path(original_file, output_folder=None):
+        """Retorna o path completo para um arquivo de saída"""
+        if output_folder is None:
+            return original_file
+
+        return os.path.join(output_folder, os.path.basename(xml))
+
+    if os.path.isfile(mst_source):
+        paragraphs = get_paragraphs_from_mst(mst_source)
+
+    for xml in get_xml_files_path(source):
+        try:
+            package = SPS_Package(etree.parse(xml))
+
+            if os.path.isdir(mst_source):
+                paragraphs = get_paragraphs_from_mst(
+                    mst_source, pid=package.publisher_id
+                )
+
+            references = get_references_text_from_paragraphs(
+                paragraphs, pid=package.publisher_id
+            )
+            updated = package.update_mixed_citations(references, override=override)
+            output_file = get_output_file_path(xml, output_folder)
+            XMLUtils.objXML2file(output_file, package.xmltree, pretty=True)
+
+            if len(updated) > 0:
+                logger.debug(
+                    "Updated %0.3d references from '%s' file.", len(updated), xml
+                )
+        except etree.XMLSyntaxError as e:
+            logger.error(e)
+        except FileNotFoundError as e:
+            logger.error(
+                "Could not update file '%s' " "the exception '%s' occurred.", xml, e
+            )

--- a/documentstore_migracao/utils/extract_isis.py
+++ b/documentstore_migracao/utils/extract_isis.py
@@ -20,28 +20,34 @@ def create_output_dir(path):
         os.makedirs(output_dir)
 
 
-def run(path: str, output_file: str):
+def run(path: str, output_file: str = "") -> dict:
     """Roda um subprocesso com o isis2json de target para extrair dados
     de uma base ISIS em formato MST. O resultado da extração
     é armazenado em formato JSON em arquivo determinado pelo
-    parâmetro output_file.
+    parâmetro ``output_file``.
+
+    Se o parâmetro ``output_file`` não for utilizado o resultado da extração
+    não será gravado em disco.
     """
 
-    command = "java -cp %s org.python.util.jython %s -t 3 -p 'v' -o %s %s" % (
+    if not os.path.exists(path):
+        raise FileNotFoundError("File '%s' does not exist.")
+
+    if output_file:
+        output_command = "-o %s" % output_file
+    else:
+        output_command = ""
+
+    command = "java -cp %s org.python.util.jython %s -t 3 -p 'v' %s %s" % (
         config.get("CLASSPATH"),
         ISIS2JSON_PATH,
-        output_file,
+        output_command,
         path,
     )
 
-    try:
-        logger.debug("Extracting database file: %s" % path)
-        subprocess.run(
-            shlex.split(command),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=True,
-        )
-        logger.debug("Writing extracted result as JSON file in: %s" % output_file)
-    except Exception as exc:
-        raise exceptions.ExtractError(str(exc)) from None
+    return subprocess.run(
+        shlex.split(command),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )

--- a/documentstore_migracao/utils/xml.py
+++ b/documentstore_migracao/utils/xml.py
@@ -167,3 +167,17 @@ def extract_reference_order(text: str) -> str:
         if match:
             return match.group(1)
     return ""
+
+
+def remove_element(root: etree.Element, query: str) -> bool:
+    """Encontra um elemento a partir de uma string de consulta (LXML) e o
+    remove. A busca e a remoção são feitas no elemento ``root``."""
+    if root is None or root.find(query) is None:
+        return False
+
+    el = root.find(query)
+
+    if root.remove(el) is None and el.getparent() is None:
+        return True
+
+    return False

--- a/documentstore_migracao/utils/xml.py
+++ b/documentstore_migracao/utils/xml.py
@@ -142,3 +142,28 @@ def create_mixed_citation_element(citation_text: str) -> etree.Element:
     new_mixed_citation.tag = "mixed-citation"
 
     return new_mixed_citation
+
+
+NUMBER_REGEXS = [
+    re.compile(r"^(?P<number>\d+)\.?\s?.*"),
+    re.compile(r".*>(?P<number>\d+)<?.*", re.MULTILINE),
+]
+
+
+def extract_reference_order(text: str) -> str:
+    """Retorna o número indicativo de ordem a partir do texto da
+    referência.
+
+    Exemplo:
+
+    >>> text = "2. Referência X"
+    >>> number = extract_reference_order(text)
+    >>> number
+    >>> 2
+    """
+    for regex in NUMBER_REGEXS:
+        match = regex.match(text)
+
+        if match:
+            return match.group(1)
+    return ""

--- a/tests/test_migrate_isis.py
+++ b/tests/test_migrate_isis.py
@@ -21,28 +21,9 @@ from . import (
 
 
 class ExtractIsisTests(unittest.TestCase):
-    @mock.patch("documentstore_migracao.utils.extract_isis.subprocess")
-    def test_should_raise_file_not_found_exception(self, subprocess_mock):
-        subprocess_mock.run.side_effect = FileNotFoundError
 
-        with self.assertRaises(exceptions.ExtractError):
-            extract_isis.run("file.mst", "file.json")
-
-    @mock.patch("documentstore_migracao.utils.extract_isis.subprocess")
-    def test_extract_isis_should_log_steps(self, subprocess_mock):
-        with self.assertLogs(level="DEBUG") as log:
-            extract_isis.run("file.mst", "file.json")
-            self.assertEqual(2, len(log.output))
-            self.assertIn("Extracting database file: file.mst", log.output[0])
-            self.assertIn(
-                "Writing extracted result as JSON file in: file.json", log.output[1]
-            )
-
-    @mock.patch("documentstore_migracao.utils.extract_isis.subprocess")
-    def teste_should_raise_called_process_erro(self, subprocess_mock):
-        subprocess_mock.run.side_effect = subprocess.CalledProcessError(1, 2)
-
-        with self.assertRaises(exceptions.ExtractError):
+    def test_should_raise_file_not_found_exception(self):
+        with self.assertRaises(FileNotFoundError):
             extract_isis.run("file.mst", "file.json")
 
     @mock.patch("documentstore_migracao.utils.extract_isis.os.makedirs")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -189,3 +189,15 @@ class TestReferencesNumberExtract(unittest.TestCase):
 
     def test_should_return_an_empty_string_when_the_number_is_an_parameter_value(self):
         self.assertEqual("", xml.extract_reference_order("<font size='2'>ref</font>"))
+
+
+class TestXMLUtilsRemoveElements(unittest.TestCase):
+    def setUp(self):
+        self.xmltree = etree.fromstring(
+            "<article><meta><body><p>text</p><p>second text</p></body></meta></article>"
+        )
+
+    def test_should_remove_only_first_p_element_from_body(self):
+        xml.remove_element(self.xmltree.find(".//body"), ".//p")
+        self.assertNotIn(b"<p>text</p>", etree.tostring(self.xmltree))
+        self.assertIn(b"<p>second text</p>", etree.tostring(self.xmltree))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -170,3 +170,22 @@ class TestUtilsDicts(unittest.TestCase):
     def test_grouper(self):
         result = dicts.grouper(3, "abcdefg", "x")
         self.assertEqual(list(result)[0], ("a", "b", "c"))
+
+
+class TestReferencesNumberExtract(unittest.TestCase):
+    def test_extract_2_from_reference_text(self):
+        self.assertEqual("2", xml.extract_reference_order("2. ref"))
+
+    def test_should_extract_2_when_are_spaces_between_number_and_text(self):
+        self.assertEqual("2", xml.extract_reference_order("2   ref"))
+
+    def test_should_extract_2_when_the_number_is_inner_a_html_tag(self):
+        self.assertEqual("2", xml.extract_reference_order("<span>2<span>"))
+
+    def test_should_return_an_empty_string_when_does_not_extract_the_reference_order(
+        self
+    ):
+        self.assertEqual("", xml.extract_reference_order("ref ref ref ref"))
+
+    def test_should_return_an_empty_string_when_the_number_is_an_parameter_value(self):
+        self.assertEqual("", xml.extract_reference_order("<font size='2'>ref</font>"))


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona o comando para atualizar as `mixed-citations` de um ou mais arquivos `xml` utilizando uma ou mais bases `mst`.

#### Onde a revisão poderia começar?
- `documentstore_migracao/main/migrate_articlemeta.py` L: `271`

#### Como este poderia ser testado manualmente?
Para testar este pull request manualmente deve-se:
- Extrair documentos (lista de exemplo em [1]);
- Obter a base MST necessária para extrair os parágrafos dos documentos (exemplo em [2]);
- Executar o comando para atualização das citações (ajuda em: `ds_migracao mixed-citations -h`)

#### Algum cenário de contexto que queira dar?
O código atual trabalha de forma linear, os xmls serão processados um a um. Para a atualização do XML é necessário executar o processo de `isis2json` com o `jysthon` (por enquanto). Se a atualização utilizar os parágrafos no estilo SciELO BR (`bases/artigo/p/*`) teremos uma lentidão visível uma vez que para cada base `mst` lida será necessário fazer `um` bootstrap da `jvm`.

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
https://github.com/scieloorg/document-store-migracao/issues/134

# Anexos
[[1] - pids.txt](https://github.com/scieloorg/document-store-migracao/files/3847108/pids.txt)
[[2] - parágrafos](https://drive.google.com/open?id=1c_BrvB2IRUa2wW9gbtsQPF9YXuG8ShXt)