### PR TITLE
Armazena o conteúdo modificado junto do registro de mudança

### DIFF
--- a/documentstore_migracao/processing/inserting.py
+++ b/documentstore_migracao/processing/inserting.py
@@ -1,23 +1,22 @@
 """ module to processing to inserting methods """
-
 import os
 import re
 import logging
 import json
 from typing import List, Tuple
 from mimetypes import MimeTypes
+from urllib.parse import urlparse
+
 import lxml
 from xylose.scielodocument import Journal
-from urllib.parse import urlparse
+from documentstore.domain import utcnow, DocumentsBundle, get_static_assets
+from documentstore.exceptions import AlreadyExists, DoesNotExist
+from documentstore.interfaces import Session
 
 from documentstore_migracao.utils import files, xml, manifest, scielo_ids_generator
 from documentstore_migracao import config, exceptions
 from documentstore_migracao.export.sps_package import DocumentsSorter, SPS_Package
 from documentstore_migracao.processing import reading
-
-from documentstore.domain import utcnow, DocumentsBundle, get_static_assets
-from documentstore.exceptions import AlreadyExists, DoesNotExist
-from documentstore.interfaces import Session
 from documentstore_migracao.tools import constructor
 
 

--- a/documentstore_migracao/processing/inserting.py
+++ b/documentstore_migracao/processing/inserting.py
@@ -34,22 +34,6 @@ from documentstore_migracao.tools import constructor
 logger = logging.getLogger(__name__)
 
 
-class ManifestDomainAdapter:
-    """Complementa o manifesto produzido na fase de transformação
-    para o formato exigido pelos adapters do Kernel para
-    realizar a inserção no MongoDB"""
-
-    def __init__(self, manifest):
-        self._manifest = manifest
-
-    def id(self) -> str:
-        return self.manifest["id"]
-
-    @property
-    def manifest(self) -> dict:
-        return self._manifest
-
-
 def get_document_renditions(
     folder: str, renditions: List[str], file_prefix: str, storage: object
 ) -> List[dict]:

--- a/documentstore_migracao/processing/inserting.py
+++ b/documentstore_migracao/processing/inserting.py
@@ -34,6 +34,9 @@ from documentstore_migracao.tools import constructor
 logger = logging.getLogger(__name__)
 
 
+__all__ = ["import_documents_to_kernel", "register_documents_in_documents_bundle"]
+
+
 def get_document_renditions(
     folder: str, renditions: List[str], file_prefix: str, storage: object
 ) -> List[dict]:
@@ -282,9 +285,7 @@ def register_documents(session_db, storage, documents_sorter, folder) -> None:
 
 
 def link_documents_bundles_with_documents(
-    documents_bundle: DocumentsBundle,
-    documents: List[str],
-    session: Session,
+    documents_bundle: DocumentsBundle, documents: List[str], session: Session
 ):
     """Função responsável por atualizar o relacionamento entre
     documents bundles e documents no nível de banco de dados"""

--- a/documentstore_migracao/processing/pipeline.py
+++ b/documentstore_migracao/processing/pipeline.py
@@ -2,6 +2,7 @@ import logging
 import sys
 import os
 import json
+
 from documentstore_migracao import exceptions, config
 from documentstore_migracao.utils import extract_isis
 from documentstore_migracao.processing import reading, conversion

--- a/documentstore_migracao/processing/pipeline.py
+++ b/documentstore_migracao/processing/pipeline.py
@@ -4,12 +4,13 @@ import os
 import json
 import gzip
 
-from documentstore_migracao import exceptions, config
-from documentstore_migracao.utils import extract_isis
-from documentstore_migracao.processing import reading, conversion
 from documentstore.interfaces import Session
 from documentstore.domain import utcnow, Journal, DocumentsBundle
 from documentstore.exceptions import AlreadyExists, DoesNotExist
+
+from documentstore_migracao import exceptions, config
+from documentstore_migracao.utils import extract_isis
+from documentstore_migracao.processing import reading, conversion
 from documentstore_migracao.utils.xylose_converter import (
     issue_to_kernel,
     parse_date,

--- a/documentstore_migracao/processing/pipeline.py
+++ b/documentstore_migracao/processing/pipeline.py
@@ -9,7 +9,14 @@ from documentstore.domain import utcnow, Journal, DocumentsBundle
 from documentstore.exceptions import AlreadyExists, DoesNotExist
 
 from documentstore_migracao import exceptions, config
-from documentstore_migracao.utils import extract_isis
+from documentstore_migracao.utils import (
+    extract_isis,
+    add_document,
+    add_journal,
+    update_journal,
+    add_bundle,
+    update_bundle,
+)
 from documentstore_migracao.processing import reading, conversion
 from documentstore_migracao.utils.xylose_converter import (
     issue_to_kernel,
@@ -43,33 +50,6 @@ def filter_issues(issues: list) -> list:
         issues = list(filter(f, issues))
 
     return issues
-
-
-def add_change(session, instance, entity):
-    session.changes.add(
-        {
-            "timestamp": utcnow(),
-            "entity": entity,
-            "id": instance.id(),
-            "content_gz": gzip.compress(instance.data_bytes()),
-            "content_type": instance.data_type,
-        }
-    )
-
-
-def add_journal(session, journal):
-    session.journals.add(journal)
-    add_change(session, journal, "Journal")
-
-
-def update_journal(session, journal):
-    session.journals.update(journal)
-    add_change(session, journal, "Journal")
-
-
-def add_bundle(session, bundle):
-    session.documents_bundles.add(bundle)
-    add_change(session, bundle, "DocumentsBundle")
 
 
 def import_journals(json_file: str, session: Session):

--- a/documentstore_migracao/processing/pipeline.py
+++ b/documentstore_migracao/processing/pipeline.py
@@ -19,22 +19,6 @@ from documentstore_migracao.utils.xylose_converter import (
 logger = logging.getLogger(__name__)
 
 
-class ManifestDomainAdapter:
-    """Complementa o manifesto produzido na fase de transformação
-    para o formato exigido pelos adapters do Kernel para
-    realizar a inserção no MongoDB"""
-
-    def __init__(self, manifest):
-        self._manifest = manifest
-
-    def id(self) -> str:
-        return self.manifest["id"]
-
-    @property
-    def manifest(self) -> dict:
-        return self._manifest
-
-
 def filter_issues(issues: list) -> list:
     """Filtra as issues em formato xylose sempre removendo
     os press releases e possibilitando a aplicação do filtro

--- a/documentstore_migracao/utils/__init__.py
+++ b/documentstore_migracao/utils/__init__.py
@@ -1,0 +1,49 @@
+import gzip
+
+from documentstore.domain import utcnow
+
+
+def _add_change(session, instance, entity):
+    session.changes.add(
+        {
+            "timestamp": utcnow(),
+            "entity": entity,
+            "id": instance.id(),
+            "content_gz": gzip.compress(instance.data_bytes()),
+            "content_type": instance.data_type,
+        }
+    )
+
+
+def add_document(session, document):
+    session.documents.add(document)
+    _add_change(session, document, "Document")
+
+
+def add_journal(session, journal):
+    session.journals.add(journal)
+    _add_change(session, journal, "Journal")
+
+
+def update_journal(session, journal):
+    session.journals.update(journal)
+    _add_change(session, journal, "Journal")
+
+
+def add_bundle(session, bundle):
+    session.documents_bundles.add(bundle)
+    _add_change(session, bundle, "DocumentsBundle")
+
+
+def update_bundle(session, bundle):
+    session.documents_bundles.update(bundle)
+    _add_change(session, bundle, "DocumentsBundle")
+
+
+__all__ = [
+    "add_document",
+    "add_journal",
+    "update_journal",
+    "add_bundle",
+    "update_bundle",
+]

--- a/tests/test_inserting.py
+++ b/tests/test_inserting.py
@@ -202,7 +202,9 @@ class TestProcessingInserting(unittest.TestCase):
         session.journals.add(journal)
 
         inserting.create_aop_bundle(session, journal.id())
-        self.assertEqual(session.journals.fetch(journal.id()).ahead_of_print_bundle, "0001-3714-aop")
+        self.assertEqual(
+            session.journals.fetch(journal.id()).ahead_of_print_bundle, "0001-3714-aop"
+        )
 
     def test_create_aop_bundle_returns_bundle(self):
         session_db = Session()
@@ -258,7 +260,11 @@ class TestProcessingInserting(unittest.TestCase):
     @patch("documentstore_migracao.processing.inserting.reading.read_json_file")
     @patch("documentstore_migracao.processing.inserting.scielo_ids_generator")
     def test_register_documents_in_documents_bundle_scielo_ids_generator(
-        self, mk_scielo_ids_generator, mk_read_json_file, mk_get_documents_bundle, mk_gzip
+        self,
+        mk_scielo_ids_generator,
+        mk_read_json_file,
+        mk_get_documents_bundle,
+        mk_gzip,
     ):
         documents = {
             "JwqGdMDrdcV3Z7MFHgtKvVk": {
@@ -291,7 +297,7 @@ class TestProcessingInserting(unittest.TestCase):
 
         session_db = Session()
         inserting.register_documents_in_documents_bundle(
-                session_db, "/tmp/documents.json", "/tmp/journals.json"
+            session_db, "/tmp/documents.json", "/tmp/journals.json"
         )
         mk_scielo_ids_generator.issue_id.assert_any_call(
             "0036-3634", "2009", "45", "04", None
@@ -333,7 +339,7 @@ class TestProcessingInserting(unittest.TestCase):
         mk_gzip.compress.return_value = "bla".encode("ascii")
         session_db = Session()
         inserting.register_documents_in_documents_bundle(
-                session_db, "/tmp/documents.json", "/tmp/journals.json"
+            session_db, "/tmp/documents.json", "/tmp/journals.json"
         )
         mk_get_documents_bundle.assert_any_call(
             session_db, "0036-3634-2009-v45-n4", True, "0036-3634"

--- a/tests/test_inserting.py
+++ b/tests/test_inserting.py
@@ -29,9 +29,11 @@ from . import (
 class TestLinkDocumentsBundleWithDocuments(unittest.TestCase):
     def setUp(self):
         self.session = Session()
-        manifest = inserting.ManifestDomainAdapter(SAMPLE_ISSUES_KERNEL[0])
-        self.session.documents_bundles.add(manifest)
-        self.documents_bundle = self.session.documents_bundles.fetch(manifest.id())
+        self.documents_bundle = DocumentsBundle(SAMPLE_ISSUES_KERNEL[0])
+        self.session.documents_bundles.add(self.documents_bundle)
+
+    def fetch_documents_bundle(self):
+        return self.session.documents_bundles.fetch(self.documents_bundle.id())
 
     def test_should_link_documents_bundle_with_documents(self):
         inserting.link_documents_bundles_with_documents(
@@ -42,7 +44,7 @@ class TestLinkDocumentsBundleWithDocuments(unittest.TestCase):
 
         self.assertEqual(
             [{"id": "doc-1", "order": "0001"}, {"id": "doc-2", "order": "0002"}],
-            self.documents_bundle.documents,
+            self.fetch_documents_bundle().documents,
         )
 
     def test_should_not_insert_duplicated_documents(self):
@@ -53,7 +55,7 @@ class TestLinkDocumentsBundleWithDocuments(unittest.TestCase):
         )
 
         self.assertEqual(
-            [{"id": "doc-1", "order": "0001"}], self.documents_bundle.documents
+            [{"id": "doc-1", "order": "0001"}], self.fetch_documents_bundle().documents
         )
 
     def test_should_register_changes(self):

--- a/tests/test_inserting.py
+++ b/tests/test_inserting.py
@@ -1,6 +1,21 @@
 import unittest
 from unittest.mock import patch, Mock, MagicMock, ANY, call
 from copy import deepcopy
+import os
+import shutil
+import json
+
+from documentstore.domain import DocumentsBundle, Journal
+from documentstore.exceptions import DoesNotExist
+
+from documentstore_migracao.utils.xml import loadToXML
+from documentstore_migracao.utils import manifest
+from documentstore_migracao.processing import inserting
+from documentstore_migracao import config
+from documentstore_migracao.processing.inserting import (
+    get_document_assets_path,
+    put_static_assets_into_storage,
+)
 from .apptesting import Session
 from . import (
     SAMPLE_ISSUES_KERNEL,
@@ -9,21 +24,6 @@ from . import (
     SAMPLES_PATH,
     SAMPLES_JOURNAL,
 )
-
-import os
-import shutil
-import json
-
-from documentstore_migracao.processing import inserting
-from documentstore_migracao.utils import manifest
-from documentstore_migracao import config
-from documentstore.domain import DocumentsBundle, Journal
-from documentstore.exceptions import DoesNotExist
-from documentstore_migracao.processing.inserting import (
-    get_document_assets_path,
-    put_static_assets_into_storage,
-)
-from documentstore_migracao.utils.xml import loadToXML
 
 
 class TestLinkDocumentsBundleWithDocuments(unittest.TestCase):

--- a/tests/test_migrate_isis.py
+++ b/tests/test_migrate_isis.py
@@ -2,6 +2,10 @@ import os
 import subprocess
 import unittest
 from unittest import mock
+
+from documentstore.exceptions import AlreadyExists
+from documentstore.domain import Journal
+
 from documentstore_migracao.utils import extract_isis
 from documentstore_migracao.processing import pipeline, conversion
 from documentstore_migracao import exceptions, config
@@ -14,8 +18,6 @@ from . import (
     SAMPLE_ISSUES_KERNEL,
     SAMPLE_JOURNALS_JSON,
 )
-from documentstore.exceptions import AlreadyExists
-from documentstore.domain import Journal
 
 
 class ExtractIsisTests(unittest.TestCase):

--- a/tests/test_migrate_isis.py
+++ b/tests/test_migrate_isis.py
@@ -15,6 +15,7 @@ from . import (
     SAMPLE_JOURNALS_JSON,
 )
 from documentstore.exceptions import AlreadyExists
+from documentstore.domain import Journal
 
 
 class ExtractIsisTests(unittest.TestCase):
@@ -343,9 +344,7 @@ class TestLinkDocumentsBundlesWithJournals(unittest.TestCase):
 class TestImportDocumentsBundlesLink(unittest.TestCase):
     def setUp(self):
         self.session = Session()
-        self.session.journals.add(
-            pipeline.ManifestDomainAdapter(manifest=SAMPLE_KERNEL_JOURNAL)
-        )
+        self.session.journals.add(Journal(manifest=SAMPLE_KERNEL_JOURNAL))
 
     @mock.patch("documentstore_migracao.processing.pipeline.reading.read_json_file")
     def test_read_journal_bundle_file(self, read_json_file_mock):

--- a/tests/test_migrate_isis.py
+++ b/tests/test_migrate_isis.py
@@ -499,7 +499,7 @@ class TestImportDocumentsBundlesLink(unittest.TestCase):
                 "~/json/output.json", self.session
             )
             self.assertIn(
-                "Bundle issue-1 already exists in journal 0001-3714", log[-1][-1]
+                'Bundle "issue-1" already exists in journal "0001-3714"', log[-1][-1]
             )
 
         with self.assertLogs(level="DEBUG") as log:
@@ -507,6 +507,6 @@ class TestImportDocumentsBundlesLink(unittest.TestCase):
                 "~/json/output.json", self.session
             )
             self.assertIn(
-                "Journal missing-journal does not exists, cannot link bundles.",
+                'Journal "missing-journal" does not exists, cannot link bundles.',
                 log[-1][-1],
             )


### PR DESCRIPTION
Este PR compatibiliza o utilitário de migração com a mudança https://github.com/scieloorg/kernel/pull/191, do Kernel.

Além da compatibilização também foram feitas mudanças com o objetivo de melhorar o código, como refatoração, reorganização dos imports, renomeação de variáveis e aplicação de formatação automática com [black](https://pypi.org/project/black/). Deixei cada passo em _commits_ separados para que seja possível seguir a sequência de atividades que foram realizadas.

#### Onde a revisão poderia começar?

As alterações se concentram nos módulos `processing.pipeline` e `processing.inserting`. Sugiro seguir os _commits_ em ordem crescente.

#### Como este poderia ser testado manualmente?

Você terá que de fato migrar e importar bases de dados ISIS e documentos para uma instância do Kernel.

Para migrar bases ISIS (assumindo um MongoDB rodando em localhost:27017):
1. `migrate_isis extract /Users/gustavofonseca/title.mst --output /tmp/title.iso`
2. `migrate_isis extract /Users/gustavofonseca/issue.mst --output /tmp/issues.json`
3. `migrate_isis link /tmp/issues.json --output /tmp/link.json`
4. `migrate_isis import --uri mongodb://localhost:27017 --db document-store --type journal /tmp/title.iso && migrate_isis import --uri mongodb://localhost:27017 --db document-store --type issue /tmp/issues.json && migrate_isis import --uri mongodb://localhost:27017 --db document-store --type documents-bundles-link /tmp/link.json`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#216

### Referências
n/a

