### PR TITLE
Remover as aspas de dentro de a[@href]

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1007,7 +1007,12 @@ class HTML2SPSPipeline(object):
                 node.set("{http://www.w3.org/1999/xlink}href", "mailto:" + href)
 
         def parser_node(self, node):
+
             href = node.get("href")
+            if href.count('"') == 2:
+                node.set("href", href.replace('"', ""))
+                href = node.get("href")
+
             if href[0] in ["#", "."] or href.startswith("/img/revistas/"):
                 return
             if "mailto" in href or "@" in href:
@@ -2876,8 +2881,12 @@ class Remote2LocalConversion:
 
         for a_href in self.xml.findall(".//*[@href]"):
             if not a_href.get("link-type"):
-
                 href = a_href.get("href")
+
+                if href.count('"') == 2:
+                    node.set("href", href.replace('"', ""))
+                    href = node.get("href")
+
                 if ":" in href:
                     a_href.set("link-type", "external")
                     logger.info("Added @link-type: %s" % etree.tostring(a_href))


### PR DESCRIPTION
#### O que esse PR faz?
Remove as aspas de dentro do conteúdo de a[@href]

```html
<a href="#&quot;fig06&quot;" link-type="internal"><bold>Figure 6A</bold></a>
```
se remover `&quot;` possivelmente fará match com o `<fig id="fig06"/>` então automaticamente será convertido para `<xref/>`

#### Onde a revisão poderia começar?
`documentstore_migracao/utils/convert_html_body.py
`
#### Como este poderia ser testado manualmente?
`ds_migracao convert --file xml/source/S1676-24442013000300005.xml`
`vi xml/conversion/S1676-24442013000300005.en.xml`
buscar por fig06.

#### Algum cenário de contexto que queira dar?
n/a
### Screenshots
n/a

#### Quais são tickets relevantes?
#213, parte de #205

### Referências
n/a
