### PR TITLE
Corrige os caminhos das imagens relacionadas como /img/revistas

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -2792,19 +2792,22 @@ class FileLocation:
 def fix_img_revistas_path(node):
     attr = "src" if node.get("src") else "href"
     location = node.get(attr)
-    old_location = location
-    if location.startswith("img/"):
-        location = "/" + location
-    if "/img" in location:
-        location = location[location.find("/img") :]
-    if " " in location:
-        location = "".join(location.split())
-    location = location.replace("/img/fbpe", "/img/revistas")
-    if old_location != location:
-        logger.info(
-            "fix_img_revistas_path: de {} para {}".format(old_location, location)
-        )
-        node.set(attr, location)
+    if "fbpe" in location or "revistas" in location or "img" in location:
+        if ":" in location or location[0] == "#":
+            return
+        old_location = location
+        if location.startswith("img"):
+            location = "/" + location
+        if " " in location:
+            location = "".join(location.split())
+        location = location.replace("/img/fbpe", "/img/revistas")
+        location = location[location.find("/img/revistas"):]
+        if old_location != location:
+            logger.info(
+                "fix_img_revistas_path: de {} para {}".format(
+                    old_location, location)
+            )
+            node.set(attr, location)
 
 
 class Remote2LocalConversion:
@@ -2822,10 +2825,12 @@ class Remote2LocalConversion:
     def __init__(self, xml):
         self.xml = xml
         self.body = self.xml.find(".//body")
-        self._digital_assets_path = self.find_digital_assets_path()
+        self._digital_assets_path = None
         self.names = []
 
     def find_digital_assets_path(self):
+        for node in self.xml.xpath(".//*[@src]|.//*[@href]"):
+            fix_img_revistas_path(node)
         for node in self.xml.xpath(".//*[@src]|.//*[@href]"):
             location = node.get("src", node.get("href"))
             if location.startswith("/img/"):
@@ -2834,9 +2839,9 @@ class Remote2LocalConversion:
 
     @property
     def digital_assets_path(self):
-        if self._digital_assets_path:
-            return self._digital_assets_path
-        self._digital_assets_path = self.find_digital_assets_path()
+        if self._digital_assets_path is None:
+            self._digital_assets_path = self.find_digital_assets_path()
+        return self._digital_assets_path
 
     @property
     def body_children(self):
@@ -2852,6 +2857,7 @@ class Remote2LocalConversion:
         if self.digital_assets_path is None:
             return
         for node in self.xml.findall(".//*[@src]"):
+            fix_img_revistas_path(node)
             src = node.get("src")
             if ":" in src:
                 node.set("link-type", "external")
@@ -2876,7 +2882,7 @@ class Remote2LocalConversion:
 
         for a_href in self.xml.findall(".//*[@href]"):
             if not a_href.get("link-type"):
-
+                fix_img_revistas_path(a_href)
                 href = a_href.get("href")
                 if ":" in href:
                     a_href.set("link-type", "external")


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o caminho das imagens

```html
<a href="../img/revistas/pd/v31n3/a05tab01.jpg">Table 1</a>
<a href="../img/revistas/si/v19n3/a05fig01.jpg">Figura 1</a>
<a href="..img/a05tab04.jpg" link-type="external"/>
```

#### Onde a revisão poderia começar?
`documentstore_migracao/utils/convert_html_body.py`

#### Como este poderia ser testado manualmente?
`ds_migracao convert --file xml/source/S0104-92242014000300005.xml`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#212

### Referências
n/a
