### PR TITLE
Migra os dados de "publisher" do isis para kernel

### DIFF
--- a/documentstore_migracao/utils/xylose_converter.py
+++ b/documentstore_migracao/utils/xylose_converter.py
@@ -139,21 +139,25 @@ def journal_to_kernel(journal):
     _contact = {}
     if journal.editor_email:
         _contact["email"] = journal.editor_email
-
     if journal.editor_address:
         _contact["address"] = journal.editor_address
-
-    if journal.publisher_city:
-        _contact["city"] = journal.publisher_city
-    if journal.publisher_state:
-        _contact["state"] = journal.publisher_state
-    if journal.publisher_country:
-        country_code, country_name = journal.publisher_country
-        _contact["country_code"] = country_code
-        _contact["country"] = country_name
-
     if _contact:
         _metadata["contact"] = set_metadata(_creation_date, _contact)
+
+    if journal.publisher_name:
+        institution_responsible_for = {"name": journal.publisher_name}
+        if journal.publisher_city:
+            institution_responsible_for["city"] = journal.publisher_city
+        if journal.publisher_state:
+            institution_responsible_for["state"] = journal.publisher_state
+        if journal.publisher_country:
+            country_code, country_name = journal.publisher_country
+            institution_responsible_for["country_code"] = country_code
+            institution_responsible_for["country"] = country_name
+
+        _metadata["institution_responsible_for"] = [
+            institution_responsible_for
+        ]
 
     return _bundle
 

--- a/documentstore_migracao/utils/xylose_converter.py
+++ b/documentstore_migracao/utils/xylose_converter.py
@@ -145,20 +145,21 @@ def journal_to_kernel(journal):
         _metadata["contact"] = set_metadata(_creation_date, _contact)
 
     if journal.publisher_name:
-        institution_responsible_for = {"name": journal.publisher_name}
-        if journal.publisher_city:
-            institution_responsible_for["city"] = journal.publisher_city
-        if journal.publisher_state:
-            institution_responsible_for["state"] = journal.publisher_state
-        if journal.publisher_country:
-            country_code, country_name = journal.publisher_country
-            institution_responsible_for["country_code"] = country_code
-            institution_responsible_for["country"] = country_name
+        institutions = []
+        for name in journal.publisher_name:
+            item = {"name": name}
+            if journal.publisher_city:
+                item["city"] = journal.publisher_city
+            if journal.publisher_state:
+                item["state"] = journal.publisher_state
+            if journal.publisher_country:
+                country_code, country_name = journal.publisher_country
+                item["country_code"] = country_code
+                item["country"] = country_name
+            institutions.append(item)
 
-        _metadata["institution_responsible_for"] = [
-            institution_responsible_for
-        ]
-
+        _metadata["institution_responsible_for"] = set_metadata(
+            _creation_date, tuple(institutions))
     return _bundle
 
 

--- a/tests/test_xylose_converter.py
+++ b/tests/test_xylose_converter.py
@@ -64,6 +64,10 @@ class TestXyloseJournalConverter(unittest.TestCase):
             "v610": [{"_": "previous journal"}],
             "v64": [{"_": "editor@email.com"}],
             "v63": [{"_": "Rua de exemplo, 1, São Paulo, SP, Brasil"}],
+            "v480": [{"_": "Sociedade Brasileira de Medicina Tropical - SBMT"}],
+            "v310": [{"_": "BR"}],
+            "v320": [{"_": "MG"}],
+            "v490": [{"_": "Uberaba"}],
         }
 
         self._journal = Journal(self.json_journal)
@@ -175,6 +179,22 @@ class TestXyloseJournalConverter(unittest.TestCase):
             get_metadata_item(journal, "contact")["address"],
         )
 
+    def test_journal_has_institution_responsible_for(self):
+        journal = journal_to_kernel(self._journal)
+        expected = tuple(
+            [
+                {
+                    "name": "Sociedade Brasileira de Medicina Tropical - SBMT",
+                    "country_code": "BR",
+                    "country": "Brazil",
+                    "state": "MG",
+                    "city": "Uberaba",
+                }
+            ]
+        )
+        self.assertEqual(
+            expected,
+            get_metadata_item(journal, "institution_responsible_for"))
 
 class TestXyloseIssueConverter(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
#### O que esse PR faz?
Migra os dados de "publisher" (responsável pelo periódico) da base title (isis) para o kernel no campo "institution_responsible_for"
Os dados são: nome, endereço, cidade, estado e país

#### Onde a revisão poderia começar?
documentstore_migracao/utils/xylose_converter.py

#### Como este poderia ser testado manualmente?
n/a

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/1453

### Referências
n/a
