### PR TITLE
[dsm][conversao] Garante que o conteúdo de arquivos mencionados (html e imagens) esteja presente apenas 1 vez

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -2831,7 +2831,6 @@ class Remote2LocalConversion:
         self.xml = xml
         self.body = self.xml.find(".//body")
         self._digital_assets_path = None
-        self.names = []
         self.imported_files = []
 
     def find_digital_assets_path(self):
@@ -3070,29 +3069,11 @@ class Remote2LocalConversion:
         a_href.set("link-type", "internal")
         logger.info("Atualiza a[@href]: %s" % etree.tostring(a_href))
 
-    def exist_in_body(self, a_href, new_href, delete_tag="REMOVETAG"):
-        """
-        Verifica se o elemento já foi importado ou se já existe no body
-        """
-        if new_href in self.names:
-            logger.info("Será criado")
-            return True
-        a_name = a_href.getroottree().find(".//a[@name='{}']".format(new_href))
-        if a_name is not None:
-            if a_name.getchildren():
-                logger.info("Já importado")
-                return True
-            else:
-                # existe um a[@name] mas é inválido porque está sem conteúdo
-                a_name.tag = delete_tag
-                return True
-
     def _create_new_p(self, new_href, node_content, content_type, delete_tag):
         """
         Cria o elemento p para inserir o(s) ativo(s) digital(is) proveniente(s)
         de arquivo de imagem ou arquivo HTML mencionado.
         """
-        self.names.append(new_href)
         a_name = etree.Element("a")
         a_name.set("id", new_href)
         a_name.set("name", new_href)

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -3001,9 +3001,11 @@ class Remote2LocalConversion:
             delete_tag = "REMOVE_" + content_type
             node_content = self._create_new_element_for_imported_html_file(
                 new_href, html_body, delete_tag)
-            return self._create_new_p(
-                new_href, node_content, content_type, delete_tag
+            new_p = self._create_new_p(
+                new_href, node_content, content_type
             )
+            etree.strip_tags(new_p, delete_tag)
+            return new_p
 
     def _get_html_body(self, href):
         """
@@ -3054,13 +3056,11 @@ class Remote2LocalConversion:
         self.imported_files.append(href)
 
         content_type = "asset"
-        delete_tag = "REMOVE_" + content_type
-
         node_content = self._create_new_element_for_imported_img_file(
             node_a, href, new_href)
         if node_content is not None:
             new_p = self._create_new_p(
-                new_href, node_content, content_type, delete_tag
+                new_href, node_content, content_type
             )
             return new_p
 
@@ -3069,7 +3069,7 @@ class Remote2LocalConversion:
         a_href.set("link-type", "internal")
         logger.info("Atualiza a[@href]: %s" % etree.tostring(a_href))
 
-    def _create_new_p(self, new_href, node_content, content_type, delete_tag):
+    def _create_new_p(self, new_href, node_content, content_type):
         """
         Cria o elemento p para inserir o(s) ativo(s) digital(is) proveniente(s)
         de arquivo de imagem ou arquivo HTML mencionado.
@@ -3077,12 +3077,18 @@ class Remote2LocalConversion:
         a_name = etree.Element("a")
         a_name.set("id", new_href)
         a_name.set("name", new_href)
-        a_name.append(node_content)
+
+        if content_type == "asset":
+            a_name.append(node_content)
+        else:
+            if len(node_content.findall(".//*[@src]")) == 1:
+                a_name.append(node_content)
+            else:
+                a_name.addnext(node_content)
 
         new_p = etree.Element("p")
         new_p.set("content-type", content_type)
         new_p.append(a_name)
-        etree.strip_tags(new_p, delete_tag)
         logger.info("Cria novo p: %s" % etree.tostring(new_p))
 
         return new_p

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -2964,9 +2964,7 @@ class Remote2LocalConversion:
         for bodychild in self.body_children:
             for a_link_type in bodychild.findall(".//a[@link-type='html']"):
                 new_p = self._imported_html_file(a_link_type)
-                if new_p is None:
-                    a_link_type.set("link-type", "external")
-                else:
+                if new_p is not None:
                     new_p_items.append((bodychild, new_p))
         for bodychild, new_p in new_p_items[::-1]:
             logger.info(
@@ -3114,15 +3112,6 @@ class Remote2LocalConversion:
         if a_name is not None:
             a_name.tag = delete_tag
         return body
-
-    def wrap_asset_with_a_name(self, asset, new_href):
-        a = etree.Element("a")
-        a.set("name", new_href)
-        a.set("id", new_href)
-        asset.addprevious(a)
-        a.append(deepcopy(asset))
-        parent = asset.getparent()
-        parent.remove(asset)
 
     def _create_new_element_for_imported_img_file(self, node_a, location):
         """

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -2973,8 +2973,17 @@ class Remote2LocalConversion:
                 html_body = self._get_html_body(href)
                 new_p = None
                 if html_body is not None:
-                    new_p = self._convert_a_href(a_link_type, new_href, html_body)
 
+                    self._update_a_href(a_link_type, new_href)
+
+                    found_a_name = self.find_a_name(a_link_type, new_href, delete_tag)
+                    if not found_a_name:
+                        content_type = "html"
+                        delete_tag = "REMOVE_" + content_type
+                        node_content = self._create_new_element_for_imported_html_file(new_href, html_body, delete_tag)
+                        new_p = self._create_new_p(
+                            new_href, node_content, content_type, delete_tag
+                        )
                 if new_p is None:
                     a_link_type.set("link-type", "external")
                 else:

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -2832,6 +2832,7 @@ class Remote2LocalConversion:
         self.body = self.xml.find(".//body")
         self._digital_assets_path = None
         self.names = []
+        self.imported_files = []
 
     def find_digital_assets_path(self):
         for node in self.xml.xpath(".//*[@src]|.//*[@href]"):
@@ -2985,22 +2986,25 @@ class Remote2LocalConversion:
         if "#" in href:
             href, anchor = href.split("#")
 
+        f, ext = os.path.splitext(href)
+        new_href = os.path.basename(f)
+
+        self._update_a_href(a_link_type, new_href)
+
+        if href in self.imported_files:
+            return
+
+        self.imported_files.append(href)
+
         html_body = self._get_html_body(href)
         if html_body is not None:
-            f, ext = os.path.splitext(href)
-            new_href = os.path.basename(f)
-
-            self._update_a_href(a_link_type, new_href)
-
             content_type = "html"
             delete_tag = "REMOVE_" + content_type
-            exist = self.exist_in_body(a_link_type, new_href, delete_tag)
-            if not exist:
-                node_content = self._create_new_element_for_imported_html_file(
-                    new_href, html_body, delete_tag)
-                return self._create_new_p(
-                    new_href, node_content, content_type, delete_tag
-                )
+            node_content = self._create_new_element_for_imported_html_file(
+                new_href, html_body, delete_tag)
+            return self._create_new_p(
+                new_href, node_content, content_type, delete_tag
+            )
 
     def _get_html_body(self, href):
         """

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -2976,6 +2976,10 @@ class Remote2LocalConversion:
         return len(new_p_items)
 
     def _imported_html_file(self, a_link_type):
+        """
+        Retorna novo elemento que representa o conteúdo do html importado,
+        se aplicável
+        """
         logger.info("Importar HTML de %s" % etree.tostring(a_link_type))
         href = a_link_type.get("href")
         if "#" in href:
@@ -3021,18 +3025,25 @@ class Remote2LocalConversion:
         new_p_items = []
         for child in self.body_children:
             for node_a in child.findall(".//a[@link-type='asset']"):
-                logger.info("Converter %s" % etree.tostring(node_a))
-                href = node_a.get("href")
-                f, ext = os.path.splitext(href)
-                new_href = os.path.basename(f)
-                if ext:
-                    new_p = self._convert_a_href(node_a, new_href)
-                    if new_p is not None:
-                        new_p_items.append((child, new_p))
+                new_p = self._imported_img_file(node_a)
+                if new_p is not None:
+                    new_p_items.append((child, new_p))
         for bodychild, new_p in new_p_items[::-1]:
             logger.info("Insere novo p: %s" % etree.tostring(new_p))
             bodychild.addnext(new_p)
         return len(new_p_items)
+
+    def _imported_img_file(self, node_a):
+        """
+        Retorna novo elemento que representa a imagem importada,
+        se aplicável
+        """
+        logger.info("Converter %s" % etree.tostring(node_a))
+        href = node_a.get("href")
+        f, ext = os.path.splitext(href)
+        new_href = os.path.basename(f)
+        if ext:
+            return self._convert_a_href(node_a, new_href)
 
     def _convert_a_href(self, node_a, new_href, html_body=None):
         """

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -3057,7 +3057,7 @@ class Remote2LocalConversion:
 
         content_type = "asset"
         node_content = self._create_new_element_for_imported_img_file(
-            node_a, href, new_href)
+            node_a, href)
         if node_content is not None:
             new_p = self._create_new_p(
                 new_href, node_content, content_type
@@ -3078,6 +3078,10 @@ class Remote2LocalConversion:
         a_name.set("id", new_href)
         a_name.set("name", new_href)
 
+        new_p = etree.Element("p")
+        new_p.set("content-type", content_type)
+        new_p.append(a_name)
+
         if content_type == "asset":
             a_name.append(node_content)
         else:
@@ -3086,9 +3090,6 @@ class Remote2LocalConversion:
             else:
                 a_name.addnext(node_content)
 
-        new_p = etree.Element("p")
-        new_p.set("content-type", content_type)
-        new_p.append(a_name)
         logger.info("Cria novo p: %s" % etree.tostring(new_p))
 
         return new_p

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -3043,32 +3043,20 @@ class Remote2LocalConversion:
         f, ext = os.path.splitext(href)
         new_href = os.path.basename(f)
         if ext:
-            return self._convert_a_href(node_a, new_href)
+            self._update_a_href(node_a, new_href)
 
-    def _convert_a_href(self, node_a, new_href, html_body=None):
-        """
-        Converte em a/@href em "link interno" para o a/@name
-        Criar o novo elemento a/@name associado ao a/@href
-        """
-        location = node_a.get("href")
+            content_type = "asset"
+            delete_tag = "REMOVE_" + content_type
 
-        self._update_a_href(node_a, new_href)
-        content_type = "asset"
-        if html_body is not None:
-            content_type = "html"
-        delete_tag = "REMOVE_" + content_type
-
-        found_a_name = self.exist_in_body(node_a, new_href, delete_tag)
-        if not found_a_name:
-            if html_body is not None:
-                node_content = self._create_new_element_for_imported_html_file(new_href, html_body, delete_tag)
-            else:
-                node_content = self._create_new_element_for_imported_img_file(node_a, location, new_href)
-            if node_content is not None:
-                new_p = self._create_new_p(
-                    new_href, node_content, content_type, delete_tag
-                )
-                return new_p
+            found_a_name = self.exist_in_body(node_a, new_href, delete_tag)
+            if not found_a_name:
+                node_content = self._create_new_element_for_imported_img_file(
+                    node_a, href, new_href)
+                if node_content is not None:
+                    new_p = self._create_new_p(
+                        new_href, node_content, content_type, delete_tag
+                    )
+                    return new_p
 
     def _update_a_href(self, a_href, new_href):
         a_href.set("href", "#" + new_href)


### PR DESCRIPTION
#### O que esse PR faz?
Garante que o conteúdo de arquivos mencionados (html e imagens) esteja presente apenas 1 vez e que seja a primeira menção.
O problema que ocorria é que uma imagem estava contida em um html mencionado e também havia uma menção diretamente ao arquivo de imagem.

http://www.scielo.br/img/revistas/dados/v52n3/05t08.gif

Está contida em:
http://www.scielo.br/img/revistas/dados/v52n3/html/05t08.htm

```html
<body>
<p>
<font>
<b>c) Percepção    sobre deveres e direitos relativos ao exercício da cidadania</b></font></p>
<p>
<font size="2" face="Verdana, Arial, Helvetica, sans-serif">
Quando analisamos    as opiniões em torno dos deveres relacionados ao bom exercício
da cidadania, podemos perceber a tendência de os brasileiros valorizarem,    
pelo menos no plano discursivo, práticas comumente relacionadas aos deveres   
 associados ao exercício da cidadania, envolvendo o dever de votar nas    eleições, 
pagar impostos,
 obedecer às leis, ajudar as pessoas    e prestar serviço militar, entre outras questões 
(<a href="/img/revistas/dados/v52n3/05t08.gif">Tabela    8</a>).
</font></p>
</body>
```

```html
<p>
<a href="/img/revistas/dados/v52n3/html/05t08.htm">16</a>.    
A pergunta do questionário era a seguinte: "Há muitas opiniões    diferentes sobre o que se deve fazer para ser um bom cidadão. Em uma    escala de 1 a 7, em que 1 significa nada importante e 7 muito importante, que    importância o(a) senhor(a) atribui, pessoalmente, a cada um dos seguintes    aspectos: (i) votar sempre nas eleições; (ii) nunca sonegar impostos;    (iii) obedecer sempre às leis e aos regulamentos; (iv) manter-se informado    sobre as atividades do governo; (v) participar em associações,    sindicatos e partidos; (vi) tentar compreender a maneira de pensar das pessoas    com opiniões diferentes das suas; (vii) escolher produtos por questões    políticas, éticas ou ambientais, mesmo que eles custem mais caro;    (viii) ajudar as pessoas que, no Brasil, vivem pior do que o(a) senhor(a); (ix)    ajudar as pessoas que, no resto do mundo, vivem pior do que o(a) senhor(a);    e (x) estar disposto a prestar serviço militar quando for preciso".
</p>
```
Gerando incorretamente:

<img width="945" alt="Captura de Tela 2019-12-11 às 17 33 12" src="https://user-images.githubusercontent.com/505143/70658496-df686e00-1c3c-11ea-90e1-ee5b4630944e.png">

<img width="971" alt="Captura de Tela 2019-12-11 às 17 33 41" src="https://user-images.githubusercontent.com/505143/70658512-e4c5b880-1c3c-11ea-92e4-c9cb4cbb7f11.png">

Após a correção:

<img width="1292" alt="Captura de Tela 2019-12-11 às 17 15 51" src="https://user-images.githubusercontent.com/505143/70659129-3458b400-1c3e-11ea-9858-6d5480e2f316.png">
<img width="898" alt="Captura de Tela 2019-12-11 às 17 16 36" src="https://user-images.githubusercontent.com/505143/70659134-37ec3b00-1c3e-11ea-8ff7-6b4b07ac0a27.png">

#### Onde a revisão poderia começar?
Por commits. 

#### Como este poderia ser testado manualmente?
`python setup.py test -s python setup.py test -s tests.test_convert_html_body.TestConvertRemote2LocalPipe`

ou executando:
`ds_migracao convert --file xml/source/S0011-52582009000300005.xml`

#### Algum cenário de contexto que queira dar?
Este PR está indiretamente relacionado com o issue que já estava trabalhando (#227), pois também está relacionado como tabelas.

### Screenshots
n/a

#### Quais são tickets relevantes?
#233

### Referências
n/a
