### PR TITLE
Remove do body os parágrafos correspondentes às referências

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -500,13 +500,23 @@ class SPS_Package:
 
         return f"{self.issn}/{self.scielo_pid_v3}"
 
+    def _get_ref_items(self, body):
+        ref_items = []
+        back = body.getnext()
+        if back is not None:
+            ref_items = back.findall(".//ref")
+        return ref_items
+
     def transform_body(self):
 
         for index, body in enumerate(self.xmltree.xpath("//body"), start=1):
             logger.info("Processando body numero: %s" % index)
 
             txt_body = body.findtext("./p") or ""
-            convert = HTML2SPSPipeline(pid=self.scielo_pid_v2, index_body=index)
+            convert = HTML2SPSPipeline(
+                ref_items=self._get_ref_items(body),
+                pid=self.scielo_pid_v2,
+                index_body=index)
             _, obj_html_body = convert.deploy(txt_body)
 
             # sobrecreve o html escapado anterior pelo novo xml tratado

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -505,6 +505,8 @@ class SPS_Package:
         back = body.getnext()
         if back is not None:
             ref_items = back.findall(".//ref")
+        if not ref_items:
+            ref_items = body.getroottree().findall(".//ref")
         return ref_items
 
     def transform_body(self):

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -514,8 +514,8 @@ class SPS_Package:
 
             txt_body = body.findtext("./p") or ""
             convert = HTML2SPSPipeline(
-                ref_items=self._get_ref_items(body),
                 pid=self.scielo_pid_v2,
+                ref_items=self._get_ref_items(body),
                 index_body=index)
             _, obj_html_body = convert.deploy(txt_body)
 

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -968,13 +968,13 @@ class HTML2SPSPipeline(object):
             for comment in comments:
                 name = comment.text.strip()
                 if name == "end-ref":
-                    p = comment.getparent()
-                    if p.tag == "p":
-                        p.set("content-type", "ref-to-delete")
+                    parents = [comment.getparent(), comment.getparent().getparent()]
+                    for parent in parents:
+                        if parent.tag == "p":
+                            parent.set("content-type", "ref-to-delete")
+                            break
                 elif header is None and name == "ref":
                     header = comment.getprevious()
-
-            p = xml.findall(".//p[@content-type='ref-to-delete']")
             return header, xml.findall(".//p[@content-type='ref-to-delete']")
 
         def _delete_references_header(self, references_header):

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -160,7 +160,7 @@ class CustomPipe(plumber.Pipe):
 
 
 class HTML2SPSPipeline(object):
-    def __init__(self, pid, index_body=1):
+    def __init__(self, ref_items=[], pid="", index_body=1):
         self.pid = pid
         self.index_body = index_body
         self.document = Document(None)

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2325,14 +2325,11 @@ class TestRemoveReferencesFromBody(unittest.TestCase):
     def test_remove_references_from_body_removes_references_from_body(self):
         text = """
         <body>
-        <p>In conclusion, revascularization of above-knee amputation stump, 
-        based on DFA or hypogastric revascularization, is the best therapeutic 
-        alternative and should be attempted even in frail patients. We believe 
-        that our small series reinforces the idea that stump revascularization is 
-        possible and can save both: stump and life.</p>     <p> </p>     
+        <p></p>     
+        <p></p>     
         <p><b>REFERENCES</b></p>      
         <!-- ref --><p>7. Endean ED, Schwarcz TH, Barker DE, Munfakh NA, Wilson-Neely R, Hyde GL. Hip disarticulation: factors affecting outcome. J Vasc Surg.1991:398-404.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004773&amp;pid=S1646-706X201900020000200007&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>     
-        <!-- ref --><p>8. Remes L, Isoaho R, Vahlberg T, Viitanen M, Rautava P. Predictors for institutionalization and prosthetic ambulation after major lower extremity amputation during an eight-year follow-up. Aging Clin Exp Res.2009:129-135.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004775&amp;pid=S1646-706X201900020000200008&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>     <p>9. Fletcher DD, Andrews KL, Butters MA, Jacobsen SJ, Rowland CM, Hallett JW Jr. Rehabilitation of the geriatric vascular amputee patient: a population-based study. Arch Phys Med Rehabil. 2001:776-779.</p>     
+        <!-- ref --><p>8. Remes L, Isoaho R, Vahlberg T, Viitanen M, Rautava P. Predictors for institutionalization and prosthetic ambulation after major lower extremity amputation during an eight-year follow-up. Aging Clin Exp Res.2009:129-135.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004775&amp;pid=S1646-706X201900020000200008&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>    
         <!-- ref --><p>10. Moura D, Garruço A. Desarticulação da anca - Análise de uma série e revisão da literatura. Rev Bras Ortop, 2016: 1-5.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004778&amp;pid=S1646-706X201900020000200010&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>     
         <!-- ref --><p>11. Dénes Z, Till A. Rehabilitation of patients after hipdisarticulation. Arch Orthop Trauma Surg. 1997:498-499.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004780&amp;pid=S1646-706X201900020000200011&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>     
         <!-- ref --><p>12. Fenelon GC, Von Foerster G, Engelbrecht E. Disarticulation ofthe hip as a result of failed arthroplasty. A series of 11 cases. J Bone Joint Surg Br 1980:441-446.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004782&amp;pid=S1646-706X201900020000200012&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>     
@@ -2347,7 +2344,6 @@ class TestRemoveReferencesFromBody(unittest.TestCase):
             <back>
                 <ref>7</ref>
                 <ref>8</ref>
-                <ref>9</ref>
                 <ref>10</ref>
                 <ref>11</ref>
                 <ref>12</ref>
@@ -2366,3 +2362,55 @@ class TestRemoveReferencesFromBody(unittest.TestCase):
         text, xml = pipeline.RemoveReferencesFromBodyPipe(pipeline
             ).transform((text, xml))
         self.assertEqual(len(xml.findall(".//p")), 2)
+
+    def test_remove_references_from_body_does_not_remove_any_paragraph(self):
+        text = """
+        <body>
+        <p><b>REFERENCES</b></p>      
+        
+        <!-- ref -->
+        <p align="LEFT"><font color="000000">1. Vengrenovitch, R.D. <i>Acta Metall.</i>, v. 30, p. 1079-1086, 1982. </font>         
+        <!-- end-ref -->
+        <!-- ref --></p>
+        <p align="LEFT"><font color="000000">2. Lameiras, F.S. <i>Scripta Metall.</i>, v. 28, p. 1435-1440, 1993. </font>         
+        <!-- end-ref -->
+        <!-- ref --></p>
+        <p align="LEFT"><font color="000000">3. Rivier, N.; Lissowski, A. <i>J. Phys. A: Math. Gen.</i>, n. 15, p. L143-L148, 1982. </font>         
+        <!-- end-ref -->
+        <!-- ref --></p>
+        <p align="LEFT"><font color="000000">4. Rivier, N. <i>Phil. Mag. B</i>, n. 52, p. 795, 1985. </font>         
+        <!-- end-ref -->
+        <!-- ref --></p>
+        <p align="LEFT"><font color="000000">5. Hunderi, O.; Ryum, N. <i>Acta Metall.</i>, v. 29, p. 1737-1745, 1981. </font>         
+        <!-- end-ref -->
+        <!-- ref --></p>
+        <p align="LEFT"><font color="000000">6. Barnsley, M. <i>Fractals Everywhere</i>, Academic Press, Inc., San Diego, Ca-USA, 1988. </font>         
+        <!-- end-ref -->
+        <!-- ref --></p>
+        <p align="LEFT"><font color="000000">7. Rhines, F.N.; K.R. Craig. <i>Metallurgical Trans.</i>, v. 5, p. 413-425, 1974. </font>         
+        <!-- end-ref --> </p></body>
+        """
+        article_text = """
+        <article>
+            <back>
+                <ref>1</ref>
+                <ref>2</ref>
+                <ref>3</ref>
+                <ref>40</ref>
+                <ref>5</ref>
+                <ref>6</ref>
+                <ref>7</ref>
+                <ref>8</ref>
+            </back>
+        </article>
+        """
+        article = etree.fromstring(article_text)
+        ref_items = article.findall(".//ref")
+
+        xml = etree.fromstring(text)
+        pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011", ref_items=ref_items)
+        text, xml = pipeline.RemoveReferencesFromBodyPipe(pipeline
+            ).transform((text, xml))
+        self.assertEqual(len(xml.findall(".//p")), 8)
+
+

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2319,3 +2319,50 @@ class TestSupplementaryMaterial(unittest.TestCase):
             inline_supplement_material.text,
             "Supplementary material")
         self.assertIsNone(inline_supplement_material.find(".//a"))
+
+
+class TestRemoveReferencesFromBody(unittest.TestCase):
+    def test_remove_references_from_body_removes_references_from_body(self):
+        text = """
+        <body>
+        <p>In conclusion, revascularization of above-knee amputation stump, 
+        based on DFA or hypogastric revascularization, is the best therapeutic 
+        alternative and should be attempted even in frail patients. We believe 
+        that our small series reinforces the idea that stump revascularization is 
+        possible and can save both: stump and life.</p>     <p> </p>     
+        <p><b>REFERENCES</b></p>      
+        <!-- ref --><p>7. Endean ED, Schwarcz TH, Barker DE, Munfakh NA, Wilson-Neely R, Hyde GL. Hip disarticulation: factors affecting outcome. J Vasc Surg.1991:398-404.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004773&amp;pid=S1646-706X201900020000200007&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>     
+        <!-- ref --><p>8. Remes L, Isoaho R, Vahlberg T, Viitanen M, Rautava P. Predictors for institutionalization and prosthetic ambulation after major lower extremity amputation during an eight-year follow-up. Aging Clin Exp Res.2009:129-135.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004775&amp;pid=S1646-706X201900020000200008&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>     <p>9. Fletcher DD, Andrews KL, Butters MA, Jacobsen SJ, Rowland CM, Hallett JW Jr. Rehabilitation of the geriatric vascular amputee patient: a population-based study. Arch Phys Med Rehabil. 2001:776-779.</p>     
+        <!-- ref --><p>10. Moura D, Garruço A. Desarticulação da anca - Análise de uma série e revisão da literatura. Rev Bras Ortop, 2016: 1-5.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004778&amp;pid=S1646-706X201900020000200010&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>     
+        <!-- ref --><p>11. Dénes Z, Till A. Rehabilitation of patients after hipdisarticulation. Arch Orthop Trauma Surg. 1997:498-499.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004780&amp;pid=S1646-706X201900020000200011&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>     
+        <!-- ref --><p>12. Fenelon GC, Von Foerster G, Engelbrecht E. Disarticulation ofthe hip as a result of failed arthroplasty. A series of 11 cases. J Bone Joint Surg Br 1980:441-446.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004782&amp;pid=S1646-706X201900020000200012&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>     
+        <!-- ref --><p>13. Jain R, Grimer RJ, Carter SR, Tillman RM, Abudu AA. Outcome after disarticulation of the hip for sarcomas. Eur J Surg Oncol. 2005:1025-1028.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004784&amp;pid=S1646-706X201900020000200013&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>     
+        <!-- ref --><p>14. Daigeler A, Lehnhardt M, Khadra A, Hauser J, Steinstraesser L,Langer S, et al. Proximal major limb amputations - a retrospective analysis of 45 oncological cases. World J Surg Oncol. 2009:1-10.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004786&amp;pid=S1646-706X201900020000200014&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>     
+        <!-- ref --><p>15. Ebrahimzadeh MH, Kachooei AR, Soroush MR, HasankhaniEG, Razi S, Birjandinejad A. Long-term clinical outcomes ofwar-related hip disarticulation and transpelvic amputation. J Bone Joint Surg Am. 2013:1-6.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004788&amp;pid=S1646-706X201900020000200015&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>     
+        <!-- ref --><p>16. Zalavras CG, Rigopoulos N, Ahlmann E, Patzakis MJ. Hipdisarticulation for severe lower extremity infections. Clin Orthop Relat Res. 2009:1721-1726.            [&#160;<a href="javascript:void(0);" onclick="javascript: window.open('/scielo.php?script=sci_nlinks&amp;ref=004790&amp;pid=S1646-706X201900020000200016&amp;lng=en','','width=640,height=500,resizable=yes,scrollbars=1,menubar=yes,');">Links</a>&#160;]<!-- end-ref --></p>     
+        </body>
+        """
+        article_text = """
+        <article>
+            <back>
+                <ref>7</ref>
+                <ref>8</ref>
+                <ref>9</ref>
+                <ref>10</ref>
+                <ref>11</ref>
+                <ref>12</ref>
+                <ref>13</ref>
+                <ref>14</ref>
+                <ref>15</ref>
+                <ref>16</ref>
+            </back>
+        </article>
+        """
+        article = etree.fromstring(article_text)
+        ref_items = article.findall(".//ref")
+
+        xml = etree.fromstring(text)
+        pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011", ref_items=ref_items)
+        text, xml = pipeline.RemoveReferencesFromBodyPipe(pipeline
+            ).transform((text, xml))
+        self.assertEqual(len(xml.findall(".//p")), 2)

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -1882,3 +1882,53 @@ class TestUpdateMixedCitations(unittest.TestCase):
             etree.tostring(self.package.xmltree),
         )
         self.assertNotIn(b"<label>1</label>", etree.tostring(self.package.xmltree))
+
+
+class TestGetRefItems(unittest.TestCase):
+    def _get_sps_package(self, text):
+        return SPS_Package(etree.fromstring(text), None)
+
+    def test__get_ref_items_returns_ref_list_three_ref_items(self):
+        text = """
+        <article>
+            <body></body>
+            <back>
+                <ref-list>
+                    <ref>1</ref>
+                    <ref>2</ref>
+                    <ref>3</ref>
+                </ref-list>
+            </back>
+        </article>
+        """
+        xml = etree.fromstring(text)
+        body = xml.find(".//body")
+        _sps_package = self._get_sps_package(text)
+        ref_items = _sps_package._get_ref_items(body)
+        self.assertEqual(ref_items[0].text, "1")
+        self.assertEqual(ref_items[1].text, "2")
+        self.assertEqual(ref_items[2].text, "3")
+
+    def test__get_ref_items_returns_subarticle_ref_list_ref_items(self):
+        text = """
+        <article>
+            <body></body>
+            <back>
+                <ref-list>
+                    <ref>1</ref>
+                    <ref>2</ref>
+                    <ref>3</ref>
+                </ref-list>
+            </back>
+            <sub-article>
+                <body></body>
+                <back>
+                </back>
+            </sub-article>
+        </article>
+        """
+        xml = etree.fromstring(text)
+        body = xml.find(".//sub-article/body")
+        _sps_package = self._get_sps_package(text)
+        ref_items = _sps_package._get_ref_items(body)
+        self.assertEqual(len(ref_items), 0)

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -1931,4 +1931,4 @@ class TestGetRefItems(unittest.TestCase):
         body = xml.find(".//sub-article/body")
         _sps_package = self._get_sps_package(text)
         ref_items = _sps_package._get_ref_items(body)
-        self.assertEqual(len(ref_items), 0)
+        self.assertEqual(len(ref_items), 3)


### PR DESCRIPTION
#### O que esse PR faz?
Remove do body os parágrafos correspondentes às referências

#### Onde a revisão poderia começar?
Revisar pelos commits

#### Como este poderia ser testado manualmente?

`ds_migracao convert --file xml/source/S1516-14391999000300005.xml`
referências são removidas

`ds_migracao convert --file xml/source/S1516-31802007000300005.xml`
referências são mantidas


#### Algum cenário de contexto que queira dar?
Para carregar na base de dados os artigos (HTML), eram usados dois arquivos: body e markup. O body continha apenas HTML e o markup continha HTML+SGML. O Converter usava o arquivo markup com as referências marcadas para localizar o parágrafo correspondente à referência no arquivo body. As referências localizadas no body são indicadas com `<!-- ref -->`. Mas nem todas as referências marcadas são necessariamente localizadas no body.

### Screenshots
n/a

#### Quais são tickets relevantes?
#231

### Referências
n/a
