### PR TITLE
Corrige a conversão de a[@href] que eram apagados ao invés de gerarem elementos <xref/>

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1676,8 +1676,8 @@ class ConvertElementsWhichHaveIdPipeline(object):
         Algumas NOTAS->TEXTO podem ser convertidas a "fn/label"
         """
 
-        def _classify_elem_a_by_id(self, xml):
-            items_by_id = {}
+        def _grouped_by_same_name_and_href(self, xml):
+            groups = {}
             for a in xml.findall(".//a"):
                 _id = a.attrib.get("name")
                 if not _id:
@@ -1685,9 +1685,9 @@ class ConvertElementsWhichHaveIdPipeline(object):
                     if href and href.startswith("#"):
                         _id = href[1:]
                 if _id:
-                    items_by_id[_id] = items_by_id.get(_id, [])
-                    items_by_id[_id].append(a)
-            return items_by_id
+                    groups[_id] = groups.get(_id, [])
+                    groups[_id].append(a)
+            return groups
 
         def _keep_only_one_a_name(self, items):
             # remove os a[@name] repetidos, se aplicável
@@ -1747,11 +1747,11 @@ class ConvertElementsWhichHaveIdPipeline(object):
         def transform(self, data):
             raw, xml = data
             logger.info("EvaluateElementAToDeleteOrCreateFnLabelPipe")
-            items_by_id = self._classify_elem_a_by_id(xml)
-            for _id, items in items_by_id.items():
-                self._keep_only_one_a_name(items)
-                self._exclude_invalid_a_name_and_identify_fn_label(items)
-                self._exclude_invalid_unique_a_href(items)
+            grouped_by_id = self._grouped_by_same_name_and_href(xml)
+            for _id, a_items in grouped_by_id.items():
+                self._keep_only_one_a_name(a_items)
+                self._exclude_invalid_a_name_and_identify_fn_label(a_items)
+                self._exclude_invalid_unique_a_href(a_items)
             etree.strip_tags(xml, "_EXCLUDE_REMOVETAG")
             logger.info("EvaluateElementAToDeleteOrCreateFnLabelPipe - fim")
             return data

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1689,6 +1689,15 @@ class ConvertElementsWhichHaveIdPipeline(object):
                     groups[_id].append(a)
             return groups
 
+        def _grouped_by_same_xml_text(self, xml):
+            groups = {}
+            for a in xml.findall(".//a[@xml_text]"):
+                xml_text = a.get("xml_text")
+                if xml_text:
+                    groups[xml_text] = groups.get(xml_text, [])
+                    groups[xml_text].append(a)
+            return groups
+
         def _keep_only_one_a_name(self, items):
             # remove os a[@name] repetidos, se aplicável
             a_names = [n for n in items if n.attrib.get("name")]
@@ -1696,7 +1705,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
                 items.remove(n)
                 _remove_tag(n)
 
-        def _exclude_invalid_a_name_and_identify_fn_label(self, items):
+        def _exclude_invalid_a_name_and_identify_fn_label(self, items, grouped_by_xml_text):
             if items[0].get("name"):
                 if len(items) > 1:
                     items[0].tag = "_EXCLUDE_REMOVETAG"
@@ -1748,9 +1757,10 @@ class ConvertElementsWhichHaveIdPipeline(object):
             raw, xml = data
             logger.info("EvaluateElementAToDeleteOrCreateFnLabelPipe")
             grouped_by_id = self._grouped_by_same_name_and_href(xml)
+            grouped_by_xml_text = self._grouped_by_same_xml_text(xml)
             for _id, a_items in grouped_by_id.items():
                 self._keep_only_one_a_name(a_items)
-                self._exclude_invalid_a_name_and_identify_fn_label(a_items)
+                self._exclude_invalid_a_name_and_identify_fn_label(a_items, grouped_by_xml_text)
                 self._exclude_invalid_unique_a_href(a_items)
             etree.strip_tags(xml, "_EXCLUDE_REMOVETAG")
             logger.info("EvaluateElementAToDeleteOrCreateFnLabelPipe - fim")

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1705,12 +1705,12 @@ class ConvertElementsWhichHaveIdPipeline(object):
                 items.remove(n)
                 _remove_tag(n)
 
-        def _exclude_invalid_a_name_and_identify_fn_label(self, items, grouped_by_xml_text):
-            if items[0].get("name"):
-                if len(items) > 1:
-                    items[0].tag = "_EXCLUDE_REMOVETAG"
-                root = items[0].getroottree()
-                for a_href in items[1:]:
+        def _exclude_invalid_a_name_and_identify_fn_label(self, a_items, grouped_by_xml_text):
+            if a_items[0].get("name"):
+                if len(a_items) > 1:
+                    a_items[0].tag = "_EXCLUDE_REMOVETAG"
+                root = a_items[0].getroottree()
+                for a_href in a_items[1:]:
                     found = None
                     if self._might_be_fn_label(a_href):
                         found = self._find_a_name_with_same_xml_text(root, a_href)


### PR DESCRIPTION
#### O que esse PR faz?
A conversão, antes da correção, considerava que os `a[@href]` que apareciam depois do seu correspondente `a[@name]` poderiam ser indicativos de ser "label" de nota de rodapé, mas ao comprovar que não eram labels, eram considerados como links inválidos e, por isso, eram apagados ao invés de gerarem `<xref/>`.
Com a correção, a ordem de apresentação de `a[@href]` e de seu correspondente `a[@name]` deixa de ser relevante. O que é usado para detectar se é ou não label de nota de rodapé é o conteúdo do `a/@xml_text`

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
`ds_migracao convert --file xml/source/S1519-70772013000300005.xml`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#227

### Referências
n/a
