### PR TITLE
[dsm][conversao] Corrige fig (e table-wrap) quando no HTML original usava "<table>" no layout

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1449,6 +1449,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
                 new_p.tag = "p"
                 new_a.append(new_p)
                 new_e = etree.Element("p")
+                new_e.set("content-type", "created-from-layout-side-by-side")
                 new_e.append(new_a)
                 table.addprevious(new_e)
                 parent = table.getparent()
@@ -1505,6 +1506,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
             new_a.append(deepcopy(img))
             new_a.append(deepcopy(p_label[-1]))
             new_elem.append(new_a)
+            new_elem.set("content-type", "created-from-layout-table-and-link-in-message")
             p.addnext(new_elem)
 
             for item in [p, previous, table]:
@@ -1578,6 +1580,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
             new_a.append(deepcopy(p_html_img))
             new_a.append(deepcopy(new_p))
             new_e = etree.Element("p")
+            new_e.set("content-type", "created-from-layout-table-link-in-thumbnail")
             new_e.append(new_a)
             table.addprevious(new_e)
             table_parent = table.getparent()
@@ -1657,7 +1660,11 @@ class ConvertElementsWhichHaveIdPipeline(object):
             new_a.append(new_p)
             new_a.append(deepcopy(p_html_img))
 
-            p.addnext(new_a)
+            new_e = etree.Element("p")
+            new_e.set("content-type", "created-from-layout-link-anchor-caption")
+            new_e.append(new_a)
+
+            p.addnext(new_e)
 
             # remove os elementos excedentes
             remove_items.append(p)

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -226,21 +226,21 @@ class HTML2SPSPipeline(object):
             self.StrongPipe(),
             self.RemoveInvalidBRPipe(),
             self.ConvertElementsWhichHaveIdPipe(),
-            self.RemoveInvalidBRPipe(),
-            self.BRPipe(),
-            self.BR2PPipe(),
-            self.TdCleanPipe(),
-            self.TableCleanPipe(),
-            self.BlockquotePipe(),
-            self.HrPipe(),
-            self.TagsHPipe(),
-            self.DispQuotePipe(),
-            self.GraphicChildrenPipe(),
-            self.FixBodyChildrenPipe(),
-            self.RemovePWhichIsParentOfPPipe(),
-            self.PPipe(),
-            self.RemoveRefIdPipe(),
-            self.FixIdAndRidPipe(super_obj=self),
+            # self.RemoveInvalidBRPipe(),
+            # self.BRPipe(),
+            # self.BR2PPipe(),
+            # self.TdCleanPipe(),
+            # self.TableCleanPipe(),
+            # self.BlockquotePipe(),
+            # self.HrPipe(),
+            # self.TagsHPipe(),
+            # self.DispQuotePipe(),
+            # self.GraphicChildrenPipe(),
+            # self.FixBodyChildrenPipe(),
+            # self.RemovePWhichIsParentOfPPipe(),
+            # self.PPipe(),
+            # self.RemoveRefIdPipe(),
+            # self.FixIdAndRidPipe(super_obj=self),
         )
 
     def deploy(self, raw):
@@ -1406,18 +1406,18 @@ class ConvertElementsWhichHaveIdPipeline(object):
             self.CreateDispFormulaPipe(),
             self.AssetElementAddContentPipe(),
             self.AssetElementIdentifyLabelAndCaptionPipe(),
-            self.AssetElementFixPipe(),
-            self.CreateInlineFormulaPipe(),
-            self.AppendixPipe(),
-            self.TablePipe(),
-            self.SupplementaryMaterialPipe(),
-            self.RemoveXMLAttributesPipe(),
-            self.ImgPipe(),
-            self.FnMovePipe(),
-            self.FnLabelOfPipe(),
-            self.FnAddContentPipe(),
-            self.FnIdentifyLabelAndPPipe(),
-            self.FnFixContentPipe(),
+            # self.AssetElementFixPipe(),
+            # self.CreateInlineFormulaPipe(),
+            # self.AppendixPipe(),
+            # self.TablePipe(),
+            # self.SupplementaryMaterialPipe(),
+            # self.RemoveXMLAttributesPipe(),
+            # self.ImgPipe(),
+            # self.FnMovePipe(),
+            # self.FnLabelOfPipe(),
+            # self.FnAddContentPipe(),
+            # self.FnIdentifyLabelAndPPipe(),
+            # self.FnFixContentPipe(),
         )
 
     def deploy(self, raw):
@@ -2423,8 +2423,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
                 return
             if n.find(".//img") is not None:
                 return
-            if get_node_text(n):
-                nodes_for_title.append(n)
+            nodes_for_title.append(n)
 
         def _infer_label_and_caption(self, label_parent, clue):
             label_text = None

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1408,6 +1408,14 @@ class ConvertElementsWhichHaveIdPipeline(object):
             return data, new_obj
 
     class ReplaceThumbnailTemplateTableAndMessageByImage(plumber.Pipe):
+        """
+        Converte o modelo de miniatura que fica dentro de uma tabela com duas
+        colunas e uma linha.
+        Sendo na primeira coluna a imagem em miniatura e na segunda a legenda.
+        Além disso na linha seguinte à tabela há a mensagem "View larger ..."
+        No parágrafo seguinte está o conteúdo que seria mostrado ao clicar em
+        "View larger..."
+        """
         def transform(self, data):
             raw, xml = data
             done = False
@@ -1460,6 +1468,14 @@ class ConvertElementsWhichHaveIdPipeline(object):
             return True
 
     class ConvertAssetThumbnailInTableIntoSimplerStructure(plumber.Pipe):
+        """
+        Converte o modelo de miniatura que fica dentro de uma tabela com duas
+        colunas e uma linha.
+        Sendo na primeira coluna a imagem em miniatura com link para a imagem
+        ampliada e na segunda a legenda.
+        Além disso na linha seguinte à tabela há a mensagem "View larger ..."
+        sem link.
+        """
         def transform(self, data):
             raw, xml = data
             thumbnail = False
@@ -1522,6 +1538,11 @@ class ConvertElementsWhichHaveIdPipeline(object):
             table_parent.remove(p)
 
     class ConvertAssetThumbnailInElementAIntoSimplerStructure(plumber.Pipe):
+        """
+        Converte o modelo de miniatura que fica dentro de um link.
+        No parágrafo seguinte, está a imagem ampliada + legenda.
+        No parágrafo seguinte, está a âncora e a legenda.
+        """
         def transform(self, data):
             raw, xml = data
             thumbnail = False

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -226,21 +226,21 @@ class HTML2SPSPipeline(object):
             self.StrongPipe(),
             self.RemoveInvalidBRPipe(),
             self.ConvertElementsWhichHaveIdPipe(),
-            # self.RemoveInvalidBRPipe(),
-            # self.BRPipe(),
-            # self.BR2PPipe(),
-            # self.TdCleanPipe(),
-            # self.TableCleanPipe(),
-            # self.BlockquotePipe(),
-            # self.HrPipe(),
-            # self.TagsHPipe(),
-            # self.DispQuotePipe(),
-            # self.GraphicChildrenPipe(),
-            # self.FixBodyChildrenPipe(),
-            # self.RemovePWhichIsParentOfPPipe(),
-            # self.PPipe(),
-            # self.RemoveRefIdPipe(),
-            # self.FixIdAndRidPipe(super_obj=self),
+            self.RemoveInvalidBRPipe(),
+            self.BRPipe(),
+            self.BR2PPipe(),
+            self.TdCleanPipe(),
+            self.TableCleanPipe(),
+            self.BlockquotePipe(),
+            self.HrPipe(),
+            self.TagsHPipe(),
+            self.DispQuotePipe(),
+            self.GraphicChildrenPipe(),
+            self.FixBodyChildrenPipe(),
+            self.RemovePWhichIsParentOfPPipe(),
+            self.PPipe(),
+            self.RemoveRefIdPipe(),
+            self.FixIdAndRidPipe(super_obj=self),
         )
 
     def deploy(self, raw):
@@ -1389,12 +1389,12 @@ class ConvertElementsWhichHaveIdPipeline(object):
     def __init__(self):
         self._ppl = plumber.Pipeline(
             self.SetupPipe(),
-            self.AssetThumbnailInLayoutImgAndCaptionAndMessage(),
             self.AssetThumbnailInLayoutTableAndLinkInMessage(),
             self.AssetThumbnailInLayoutTableAndLinkInThumbnail(),
-            self.AssetThumbnailInLinkAndAnchorAndCaption(),
             self.RemoveTableUsedToDisplayFigureAndLabelAndCaptionInTwoLines(),
             self.RemoveTableUsedToDisplayFigureAndLabelAndCaptionSideBySide(),
+            self.AssetThumbnailInLinkAndAnchorAndCaption(),
+            self.AssetThumbnailInLayoutImgAndCaptionAndMessage(),
             self.RemoveThumbImgPipe(),
             self.CompleteElementAWithNameAndIdPipe(),
             self.CompleteElementAWithXMLTextPipe(),
@@ -1406,18 +1406,18 @@ class ConvertElementsWhichHaveIdPipeline(object):
             self.CreateDispFormulaPipe(),
             self.AssetElementAddContentPipe(),
             self.AssetElementIdentifyLabelAndCaptionPipe(),
-            # self.AssetElementFixPipe(),
-            # self.CreateInlineFormulaPipe(),
-            # self.AppendixPipe(),
-            # self.TablePipe(),
-            # self.SupplementaryMaterialPipe(),
-            # self.RemoveXMLAttributesPipe(),
-            # self.ImgPipe(),
-            # self.FnMovePipe(),
-            # self.FnLabelOfPipe(),
-            # self.FnAddContentPipe(),
-            # self.FnIdentifyLabelAndPPipe(),
-            # self.FnFixContentPipe(),
+            self.AssetElementFixPipe(),
+            self.CreateInlineFormulaPipe(),
+            self.AppendixPipe(),
+            self.TablePipe(),
+            self.SupplementaryMaterialPipe(),
+            self.RemoveXMLAttributesPipe(),
+            self.ImgPipe(),
+            self.FnMovePipe(),
+            self.FnLabelOfPipe(),
+            self.FnAddContentPipe(),
+            self.FnIdentifyLabelAndPPipe(),
+            self.FnFixContentPipe(),
         )
 
     def deploy(self, raw):
@@ -1466,9 +1466,9 @@ class ConvertElementsWhichHaveIdPipeline(object):
                 return
 
             p_anchor = p_caption.getprevious()
-            
             src = img.get("src")
-            src = src.replace("http://www.scielo.br/img/fbpe", "/img/revistas")
+            for wrong in ["http:/img/fbpe", "http://www.scielo.br/img/fbpe"]:
+                src = src.replace(wrong, "/img/revistas")
             img.set("src", src)
 
             new_elem = etree.Element("p")
@@ -1588,7 +1588,8 @@ class ConvertElementsWhichHaveIdPipeline(object):
                 return
 
             src = img.get("src")
-            src = src.replace("http://www.scielo.br/img/fbpe", "/img/revistas")
+            for wrong in ["http:/img/fbpe", "http://www.scielo.br/img/fbpe"]:
+                src = src.replace(wrong, "/img/revistas")
             img.set("src", src)
 
             new_elem = etree.Element("p")

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1389,9 +1389,9 @@ class ConvertElementsWhichHaveIdPipeline(object):
     def __init__(self):
         self._ppl = plumber.Pipeline(
             self.SetupPipe(),
-            self.ReplaceThumbnailTemplateTableAndMessageByImage(),
-            self.ConvertAssetThumbnailInTableIntoSimplerStructure(),
-            self.ConvertAssetThumbnailInElementAIntoSimplerStructure(),
+            self.AssetThumbnailInLayoutTableAndLinkInMessage(),
+            self.AssetThumbnailInLayoutTableAndLinkInThumbnail(),
+            self.AssetThumbnailInLinkAndAnchorAndCaption(),
             self.RemoveTableUsedToDisplayFigureAndLabelAndCaptionSideBySide(),
             self.RemoveThumbImgPipe(),
             self.CompleteElementAWithNameAndIdPipe(),
@@ -1455,7 +1455,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
                 parent.remove(table)
             return data
 
-    class ReplaceThumbnailTemplateTableAndMessageByImage(plumber.Pipe):
+    class AssetThumbnailInLayoutTableAndLinkInMessage(plumber.Pipe):
         """
         Converte o modelo de miniatura que fica dentro de uma tabela com duas
         colunas e uma linha.
@@ -1512,7 +1512,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
                 parent.remove(item)
             return True
 
-    class ConvertAssetThumbnailInTableIntoSimplerStructure(plumber.Pipe):
+    class AssetThumbnailInLayoutTableAndLinkInThumbnail(plumber.Pipe):
         """
         Converte o modelo de miniatura que fica dentro de uma tabela com duas
         colunas e uma linha.
@@ -1588,7 +1588,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
             table_parent.remove(table)
             table_parent.remove(p)
 
-    class ConvertAssetThumbnailInElementAIntoSimplerStructure(plumber.Pipe):
+    class AssetThumbnailInLinkAndAnchorAndCaption(plumber.Pipe):
         """
         Converte o modelo de miniatura que fica dentro de um link.
         No parágrafo seguinte, está a imagem ampliada + legenda.

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1372,7 +1372,6 @@ class ConvertElementsWhichHaveIdPipeline(object):
             self.ReplaceThumbnailTemplateTableAndMessageByImage(),
             self.ConvertAssetThumbnailInTableIntoSimplerStructure(),
             self.ConvertAssetThumbnailInElementAIntoSimplerStructure(),
-            
             self.RemoveThumbImgPipe(),
             self.CompleteElementAWithNameAndIdPipe(),
             self.CompleteElementAWithXMLTextPipe(),
@@ -1493,16 +1492,23 @@ class ConvertElementsWhichHaveIdPipeline(object):
                 thumbnail_img = a.find("img")
                 if thumbnail_img is None:
                     continue
+                p_html_img = p.find(".//img")
+                if p_html_img is None:
+                    continue
+
                 thumbnail_img_src = thumbnail_img.get("src")
-                p_html_img = p.findall(".//img")
-                if len(p_html_img) == 1:
-                    p_html_img_src = p_html_img[0].get("src")
-                    name, ext = os.path.splitext(p_html_img_src)
-                    if thumbnail_img_src.startswith(name):
-                        a_name = previous.find(".//a[@name]")
-                        if a_name is not None:
-                            self._create_simpler_element(p, a_name, p_html_img)
-                            thumbnail = True
+                p_html_img_src = p_html_img.get("src")
+
+                thumbnail_name, ext = os.path.splitext(thumbnail_img_src)
+                name, ext = os.path.splitext(p_html_img_src)
+
+                if (thumbnail_img_src.startswith(name) or 
+                    thumbnail_name.endswith("table")):
+                    a_name = previous.find(".//a[@name]")
+                    print("x")
+                    if a_name is not None:
+                        self._create_simpler_element(p, a_name, p_html_img)
+                        thumbnail = True
             if thumbnail:
                 for p in xml.findall(".//p"):
                     if p.text and "View larger" in p.text:
@@ -1524,7 +1530,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
                 if _next is None:
                     break
                 new_p.append(deepcopy(_next))
-            new_a.append(deepcopy(p_html_img[0]))
+            new_a.append(deepcopy(p_html_img))
             new_a.append(deepcopy(new_p))
             new_e = etree.Element("p")
             new_e.append(new_a)

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2499,11 +2499,11 @@ class TestRemoveReferencesFromBody(unittest.TestCase):
         self.assertEqual(len(xml.findall(".//p")), 8)
 
 
-class TestDigitalAssetThumbnailTablePipe(unittest.TestCase):
+class TestAssetThumbnailInLayoutTableAndLinkInThumbnail(unittest.TestCase):
 
     def setUp(self):
         pipeline = ConvertElementsWhichHaveIdPipeline()
-        self.pipe = pipeline.ConvertAssetThumbnailInTableIntoSimplerStructure()
+        self.pipe = pipeline.AssetThumbnailInLayoutTableAndLinkInThumbnail()
 
     def test_transform_converts_thumbnail_table_into_simpler_structure(self):
         text = """<root xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -2598,11 +2598,11 @@ class TestDigitalAssetThumbnailTablePipe(unittest.TestCase):
                 ".//a[@name='Tab1']/img[@src='/img/revistas/bjmbr/v45n12/2406t01.jpg']"))
 
 
-class TestDigitalAssetThumbnailBlockPipe(unittest.TestCase):
+class TestAssetThumbnailInLinkAndAnchorAndCaption(unittest.TestCase):
 
     def setUp(self):
         pipeline = ConvertElementsWhichHaveIdPipeline()
-        self.pipe = pipeline.ConvertAssetThumbnailInElementAIntoSimplerStructure()
+        self.pipe = pipeline.AssetThumbnailInLinkAndAnchorAndCaption()
 
     def test_transform_converts_thumbnail_into_simpler_structure(self):
         text = """<root xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -2641,11 +2641,11 @@ class TestDigitalAssetThumbnailBlockPipe(unittest.TestCase):
         self.assertIsNotNone(xml.find(".//a[@name='Fig2']/img[@src='/img/revistas/bjmbr/v43n10/650i02.jpg']"))
 
 
-class TestReplaceThumbnailTemplateTableAndMessageByImage(unittest.TestCase):
+class TestAssetThumbnailInLayoutTableAndLinkInMessage(unittest.TestCase):
 
     def setUp(self):
         pipeline = ConvertElementsWhichHaveIdPipeline()
-        self.pipe = pipeline.ReplaceThumbnailTemplateTableAndMessageByImage()
+        self.pipe = pipeline.AssetThumbnailInLayoutTableAndLinkInMessage()
 
     def test_transform(self):
         text = """<root>
@@ -2721,7 +2721,7 @@ class TestRemoveTableUsedToDisplayFigureAndLabelAndCaptionSideBySide(unittest.Te
 
     def setUp(self):
         pipeline = ConvertElementsWhichHaveIdPipeline()
-        self.pipe = pipeline.RemoveTableUsedToDisplayImageAndLabelAndCaptionSideBySide()
+        self.pipe = pipeline.RemoveTableUsedToDisplayFigureAndLabelAndCaptionSideBySide()
 
     def test_transform(self):
         text = """<root>

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2750,6 +2750,53 @@ class TestRemoveTableUsedToDisplayFigureAndLabelAndCaptionSideBySide(unittest.Te
                 ".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v30n2/2635fig1.gif']"))
 
 
+class TestRemoveTableUsedToDisplayFigureAndLabelAndCaptionInTwoLines(unittest.TestCase):
+    def setUp(self):
+        pipeline = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pipeline.RemoveTableUsedToDisplayFigureAndLabelAndCaptionInTwoLines()
+
+    def test_transform(self):
+        text = """<root>
+        <p align="center">
+            <a name="Fig1" id="Fig1"/> <img src="/img/revistas/bjmbr/v30n1/2560fig1peq.gif"/>
+        </p>
+        <p>Figure 1 - Effect of dexamethasone pretreatment on ethanol-induced hypothermia in rats. Rats received dexamethasone (2.0 mg/kg,<italic> ip</italic>) or saline administered 15 min before ethanol 20% w/v (2.0, 3.0 or 4.0 g/kg, <italic>ip</italic>) or saline. Colon temperature was measured 30, 60 and 90 min after ethanol administration. The animals were divided into 4 groups: saline + saline (open circles); dexamethasone + saline (filled circles); saline + ethanol (open squares), and dexamethasone + ethanol (filled squares). Data are reported as the mean ± SEM of the fall in temperature in degrees Celsius obtained for 10 animals compared to basal values. *P&lt;0.05 compared to saline + saline group; <sup>+</sup>P&lt;0.05 compared to saline + ethanol group (ANOVA).</p>
+        <p>
+            <a href="#2560fig1" link-type="internal">[View larger version of this image (14 K GIF file)]</a>
+        </p>
+        <p content-type="html">
+            <a id="2560fig1" name="2560fig1"/>
+
+        <p align="center">
+          <img src="http://www.scielo.br/img/fbpe/bjmbr/v30n1/2560fig1.gif" 
+          imported="true" link-type="external"/> </p>
+
+        <p>Figure 1 - Effect of dexamethasone pretreatment on
+        ethanol-induced hypothermia in rats. Rats received dexamethasone
+        (2.0 mg/kg,<italic> ip</italic>) or saline administered 15 min before
+        ethanol 20% w/v (2.0, 3.0 or 4.0 g/kg, <italic>ip</italic>) or saline.
+        Colon temperature was measured 30, 60 and 90 min after ethanol
+        administration. The animals were divided into 4 groups: saline +
+        saline (open circles); dexamethasone + saline (filled circles);
+        saline + ethanol (open squares), and dexamethasone + ethanol
+        (filled squares). Data are reported as the mean ± SEM of the
+        fall in temperature in degrees Celsius obtained for 10 animals
+        compared to basal values. *P&lt;0.05 compared to saline + saline
+        group; <sup>+</sup>P&lt;0.05 compared to saline + ethanol group
+        (ANOVA).</p></p>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        print(etree.tostring(xml))
+        self.assertIsNotNone(xml.find(".//a[@name='Fig1']"))
+        p_text = xml.find(".//a[@name='Fig1']/p").text.strip()
+        self.assertTrue(
+            p_text.startswith(
+                "Figure 1 - Effect of dexamethasone pretreatment on"))
+        self.assertIsNotNone(
+            xml.find(
+                ".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v30n1/2560fig1.gif']"))
+
 class TestAssetThumbnailInLayoutImgAndCaptionAndMessage(unittest.TestCase):
 
     def setUp(self):
@@ -2797,3 +2844,33 @@ class TestAssetThumbnailInLayoutImgAndCaptionAndMessage(unittest.TestCase):
         self.assertIsNotNone(
             xml.find(
                 ".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v30n1/2560fig1.gif']"))
+
+
+class TestRemoveTableUsedToDisplayFigureAndLabelAndCaptionInTwoLines(unittest.TestCase):
+
+    def setUp(self):
+        pipeline = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pipeline.RemoveTableUsedToDisplayFigureAndLabelAndCaptionInTwoLines()
+
+    def test_transform(self):
+        text = """<root>
+        <table width="100%" cellpadding="2" cellspacing="0" border="0">
+            <tr>
+            <td width="38%" valign="TOP">
+            <p align="center">
+            <a name="Fig1" id="Fig1"/>
+          <img src="/img/revistas/bjmbr/v31n12/3156i01.gif" align="BOTTOM" border="2" vspace="0" hspace="0"/>
+        </p> <p>Figure 1 - Relationship between SHBG levels and 120-min proinsulin after a glucose load test in men.</p>
+        </td> </tr>
+        </table></root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        print(etree.tostring(xml))
+        self.assertIsNotNone(xml.find(".//a[@name='Fig1']"))
+        p_text = xml.find(".//a[@name='Fig1']/p").text.strip()
+        self.assertTrue(
+            p_text.startswith(
+                "Figure 1 - Relationship between SHBG levels"))
+        self.assertIsNotNone(
+            xml.find(
+                ".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v31n12/3156i01.gif']"))

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2544,6 +2544,59 @@ class TestDigitalAssetThumbnailTablePipe(unittest.TestCase):
         self.assertEqual(xml.find(".//a[@name='Fig1']/p").text, 'Figure 1. Concentration of IL-6 (pg/10')
         self.assertIsNotNone(xml.find(".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v43n10/472i01.jpg']"))
 
+    def test_transform_when_thumbnail_image_has_not_same_name_as_normal_image(self):
+        text = """<root xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <table width="100%" border="0">
+                <tr align="left" valign="top">
+                <td width="16%">
+                <a href="#2406t01" link-type="internal">
+                <img src="/img/revistas/bjmbr/v45n12/table.jpg" width="100" height="65" border="2"/>
+            </a>
+            </td> <td width="84%"> <p align="LEFT">
+                <a name="Tab1" id="Tab1"/>Table 1. Distribution of serum hs-CRP concentration (mg/L) according to gender.</p> </td> </tr>
+            </table>
+            <p content-type="html">
+                <a id="2406t01" name="2406t01"/>&#13;
+            &#13;
+             &#13;
+            &#13;
+               High sensitivity C-reactive protein distribution in the elderly: the Bambuí Cohort Study, Brazil. L.G.S. Assunção, S.M. Eloi-Santos, S.V. Peixoto, M.F. Lima-Costa and P.G. Vidigal. Braz J Med Biol Res 2012; 45: 1284-1286 &#13;
+            &#13;
+               <hr align="LEFT" width="100%" size="2"/>&#13;
+            &#13;
+               <p>
+                <ext-link ext-link-type="uri" xlink:href="javascript:history.back()">
+                <img src="/img/revistas/bjmbr/v45n12/2406t01.jpg" align="BOTTOM" border="0" vspace="0" hspace="0" width="600" height="303" imported="true"/>
+             </ext-link>
+             </p>&#13;
+            &#13;
+               &#13;
+            &#13;
+                 &#13;
+            &#13;
+               &#13;
+            &#13;
+             &#13;
+            &#13;
+             &#13;
+            &#13;
+            </p>
+        <p>[View larger version of this table (57 K JPG file)]</p> <hr align="LEFT" width="100%" size="2"/>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertIsNotNone(xml.find(".//a[@name='Tab1']"))
+        p_text = xml.find(".//a[@name='Tab1']/p").text.strip()
+        self.assertTrue(
+            p_text.startswith(
+                "Table 1. Distribution of serum hs-CRP concentration (mg/L) according to gender."))
+        self.assertTrue(
+            p_text.endswith(
+                "Table 1. Distribution of serum hs-CRP concentration (mg/L) according to gender."))
+        self.assertIsNotNone(
+            xml.find(
+                ".//a[@name='Tab1']/img[@src='/img/revistas/bjmbr/v45n12/2406t01.jpg']"))
+
 
 class TestDigitalAssetThumbnailBlockPipe(unittest.TestCase):
 
@@ -2662,4 +2715,5 @@ class TestReplaceThumbnailTemplateTableAndMessageByImage(unittest.TestCase):
         self.assertIsNotNone(
             xml.find(
                 ".//a[@name='Fig3']/img[@src='/img/revistas/bjmbr/v30n6/2677fig1.gif']"))
+
 

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2497,3 +2497,74 @@ class TestRemoveReferencesFromBody(unittest.TestCase):
             (text, xml)
         )
         self.assertEqual(len(xml.findall(".//p")), 8)
+
+
+class TestDigitalAssetThumbnailBlockPipe(unittest.TestCase):
+
+    def setUp(self):
+        pipeline = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pipeline.ConvertAssetThumbnailInTableIntoSimplerStructure()
+
+    def test_transform_converts_thumbnail_table_into_simpler_structure(self):
+        text = """<root xmlns:xlink="http://www.w3.org/1999/xlink">
+        <table border="0">
+            <tr align="left" valign="top">
+            <td>
+            <a href="#472i01" link-type="internal">
+            <img src="/img/revistas/bjmbr/v43n10/472i01peq.jpg" border="2"/>
+        </a>
+        </td> <td> <p align="left">
+          <a name="Fig1" id="Fig1"/>Figure 1. Concentration of IL-6 (pg/10<sup>6 </sup>cells) produced by the suspension of plasmacytoid dendritic cells (pDC). Concentration (Conc.) 1: 20 IU/mL penicillin, 5 µg/mL vancomycin, 5 µg/mL amoxicillin, 75 ng/mL anti-FcεRI/mL, and 100 nM CpG. Concentration 2: 200 IU/mL penicillin, 50 µg/mL vancomycin, and 50 µg/mL amoxicillin. Concentration 3: 1000 IU/mL penicillin, 250 µg/mL vancomycin, and 250 µg/mL amoxicillin.</p> </td> </tr>
+        </table>
+          <p content-type="html">
+            <a id="472i01" name="472i01"/>&#13;
+         <p align="left">C.M.F. Lima, J.T. Schroeder, C.E.S. Galvão, F.M. Castro, J. Kalil and N.F. Adkinson Jr. Functional changes of dendritic cells in hypersensitivity reactions to amoxicillin. Braz J Med Biol Res 2010; 43: 964-968. &#13;
+         </p>&#13;
+           <p>
+            <ext-link ext-link-type="uri" xlink:href="javascript:history.back()">
+            <img src="/img/revistas/bjmbr/v43n10/472i01.jpg" align="BOTTOM" border="0" vspace="0" hspace="0" width="800" height="403" imported="true"/>
+         </ext-link>
+         </p>&#13;
+           <p>&#13;
+             <p align="left">Figure 1. Concentration of IL-6 (pg/10<sup>6 </sup>cells) produced by the suspension of plasmacytoid dendritic cells (pDC). Concentration (Conc.) 1: 20 IU/mL penicillin, 5 µg/mL vancomycin, 5 µg/mL amoxicillin, 75 ng/mL anti-FcεRI/mL, and 100 nM CpG. Concentration 2: 200 IU/mL penicillin, 50 µg/mL vancomycin, and 50 µg/mL amoxicillin. Concentration 3: 1000 IU/mL penicillin, 250 µg/mL vancomycin, and 250 µg/mL amoxicillin.</p>&#13;
+           </p>&#13;
+         &#13;
+         &#13;
+        </p>
+        <p>[View larger version of this image (90 K JPG file)]</p> <hr align="LEFT" size="2"/>
+        </root>"""
+        expected = b"""<root xmlns:xlink="http://www.w3.org/1999/xlink">
+        <p><a name="Fig1" id="Fig1"><img src="/img/revistas/bjmbr/v43n10/472i01.jpg" align="BOTTOM" border="0" vspace="0" hspace="0" width="800" height="403" imported="true"/>
+        <p>Figure 1. Concentration of IL-6 (pg/10<sup>6 </sup>cells) produced by the suspension of plasmacytoid dendritic cells (pDC). Concentration (Conc.) 1: 20 IU/mL penicillin, 5 &#181;g/mL vancomycin, 5 &#181;g/mL amoxicillin, 75 ng/mL anti-Fc&#949;RI/mL, and 100 nM CpG. Concentration 2: 200 IU/mL penicillin, 50 &#181;g/mL vancomycin, and 50 &#181;g/mL amoxicillin. Concentration 3: 1000 IU/mL penicillin, 250 &#181;g/mL vancomycin, and 250 &#181;g/mL amoxicillin.</p></a></p><hr align="LEFT" size="2"/>
+        </root>"""
+
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertIsNotNone(xml.find(".//a[@name='Fig1']"))
+        self.assertEqual(xml.find(".//a[@name='Fig1']/p").text, 'Figure 1. Concentration of IL-6 (pg/10')
+        self.assertIsNotNone(xml.find(".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v43n10/472i01.jpg']"))
+
+
+"""
+<a href="#650i02" link-type="internal">
+  <img src="/img/revistas/bjmbr/v43n10/650i02peq.jpg" border="2"/>
+</a>
+<p content-type="html">
+  <a id="650i02" name="650i02"/>&#13;
+ <p align="left">C. Raineki, A. Pickenhagen, T.L. Roth, D.M. Babstock, J.H. McLean, C.W. Harley, A.B. Lucion and R.M. Sullivan. The neurobiology of infant maternal odor learning. Braz J Med Biol Res 2010; 43: 914-919. &#13;
+ </p>&#13;
+   <p>
+    <ext-link ext-link-type="uri" xlink:href="javascript:history.back()">
+    <img src="/img/revistas/bjmbr/v43n10/650i02.jpg" align="BOTTOM" border="0" vspace="0" hspace="0" width="800" height="349" imported="true"/>
+ </ext-link>
+ </p>&#13;
+   <p>&#13;
+     <p align="LEFT">Figure 2. During early life (postnatal day 8), pairing an odor with a 0.5-mA shock does not produce a change in pCREB expression (top) or <italic>2</italic>-<italic>deoxy-d-glucose</italic> (2-DG) uptake (bottom) in the lateral (LA) and basolateral (BLA) amygdala. The expression of phosphorylated cAMP response element binding protein (pCREB) in the cortical amygdala (CoA), a component of the olfactory cortex, appears to be heightened by odor exposure.</p>&#13;
+   </p>&#13;
+ &#13;
+ &#13;
+</p>
+<a name="Fig2" id="Fig2"/>
+Figure 2. During early life (postnatal day 8), pairing an odor with a 0.5-mA shock does not produce a change in pCREB expression (top) or <italic>2</italic>-<italic>deoxy-d-glucose</italic> (2-DG) uptake (bottom) in the lateral (LA) and basolateral (BLA) amygdala. The expression of phosphorylated cAMP response element binding protein (pCREB) in the cortical amygdala (CoA), a component of the olfactory cortex, appears to be heightened by odor exposure. <p>[View larger version of this image (340 K JPG file)]</p>  
+<hr align="LEFT" size="2"/>
+"""

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2717,3 +2717,35 @@ class TestReplaceThumbnailTemplateTableAndMessageByImage(unittest.TestCase):
                 ".//a[@name='Fig3']/img[@src='/img/revistas/bjmbr/v30n6/2677fig1.gif']"))
 
 
+class TestRemoveTableUsedToDisplayFigureAndLabelAndCaptionSideBySide(unittest.TestCase):
+
+    def setUp(self):
+        pipeline = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pipeline.RemoveTableUsedToDisplayFigureAndLabelAndCaptionSideBySide()
+
+    def test_transform(self):
+        text = """<root>
+        <table border="0" cellpadding="2" cellspacing="0" width="100%">
+          <tr>
+            <td>
+              <a name="Fig1" id="Fig1"/>
+            <img src="/img/revistas/bjmbr/v30n2/2635fig1.gif"/>
+          </td> 
+          <td>Figure 1 - Effects of peripheral <sub>post-trial</sub> administration of</td>
+          </tr>
+        </table>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertIsNotNone(xml.find(".//a[@name='Fig1']"))
+        p_text = xml.find(".//a[@name='Fig1']/p").text.strip()
+        self.assertTrue(
+            p_text.startswith(
+                "Figure 1 - Effects of peripheral"))
+        self.assertTrue(
+            p_text.endswith(
+                "Figure 1 - Effects of peripheral"))
+        self.assertIsNotNone(
+            xml.find(
+                ".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v30n2/2635fig1.gif']"))
+

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2586,3 +2586,80 @@ class TestDigitalAssetThumbnailBlockPipe(unittest.TestCase):
         self.assertIsNotNone(xml.find(".//a[@name='Fig2']"))
         self.assertEqual(xml.find(".//a[@name='Fig2']/p").text.strip(), 'Figure 2. During early life (postnatal day 8), pairing an odor with a 0.5-mA shock does not produce a change in pCREB expression (top) or')
         self.assertIsNotNone(xml.find(".//a[@name='Fig2']/img[@src='/img/revistas/bjmbr/v43n10/650i02.jpg']"))
+
+
+class TestReplaceThumbnailTemplateTableAndMessageByImage(unittest.TestCase):
+
+    def setUp(self):
+        pipeline = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pipeline.ReplaceThumbnailTemplateTableAndMessageByImage()
+
+    def test_transform(self):
+        text = """<root>
+        <table border="0" cellpadding="2" cellspacing="0" width="100%">
+        <tr>
+        <td>
+            <a name="Fig3" id="Fig3"/>
+            <img src="/img/revistas/bjmbr/v30n6/2677fig1peq.gif"/>
+        </td> 
+        <td>Figure 3 - Gastric retention (%) 15 min after the infusion of test meals containing 2.5% glucose + 2.5% galactose (5% glu + gal), 5% lactose, 5% glucose + 5% galactose (10% glu + gal) or 10% lactose. The rats were fed normal chow (control) or chow with 20% (w/w) lactose (experimental) for four weeks after which time the gastric retention was measured (N = 12 per subgroup). The data are presented as box plots, where the intermediate, lower and upper horizontal lines indicate the median, first and third quartiles of the gastric retention values, respectively, and error bars indicate the maximum and minimum gastric retention values observed. Significant differences between subgroups tested by the Kruskal-Wallis test (P&lt;0.10) followed by the multiple comparisons test (P&lt;0.02) are indicated in the figure.</td> </tr>
+        </table>
+        <p>
+            <a href="#2677fig1" link-type="internal">[View larger version of this image (28 K GIF file)]</a>
+        </p>
+        <p content-type="html">
+            <a id="2677fig1" name="2677fig1"/>
+
+            <p align="center">
+                <img src="http://www.scielo.br/img/fbpe/bjmbr/v30n6/2677fig1.gif" imported="true" link-type="external"/> </p>
+
+            <p>Figure 3 - Gastric retention (%) 15 min after the infusion of
+            test meals containing 2.5% glucose + 2.5% galactose (5% glu +
+            gal), 5% lactose, 5% glucose + 5% galactose (10% glu + gal) or
+            10% lactose. The rats were fed normal chow (control) or chow with
+            20% (w/w) lactose (experimental) for four weeks after which time
+            the gastric retention was measured (N = 12 per subgroup). The
+            data are presented as box plots, where the intermediate, lower
+            and upper horizontal lines indicate the median, first and third
+            quartiles of the gastric retention values, respectively, and
+            error bars indicate the maximum and minimum gastric retention
+            values observed. Significant differences between subgroups tested
+            by the Kruskal-Wallis test (P&lt;0.10) followed by the multiple
+            comparisons test (P&lt;0.02) are indicated in the figure.</p>
+        </p>
+        </root>"""
+        expected = b"""<root xmlns:xlink="http://www.w3.org/1999/xlink">
+            <p>
+            <a name="Fig3" id="Fig3">
+            <img src="/img/revistas/bjmbr/v30n6/2677fig1.gif" align="BOTTOM" border="0" vspace="0" hspace="0" width="800" height="403" imported="true"/>
+            <p>Figure 3 - Gastric retention (%) 15 min after the infusion of
+            test meals containing 2.5% glucose + 2.5% galactose (5% glu +
+            gal), 5% lactose, 5% glucose + 5% galactose (10% glu + gal) or
+            10% lactose. The rats were fed normal chow (control) or chow with
+            20% (w/w) lactose (experimental) for four weeks after which time
+            the gastric retention was measured (N = 12 per subgroup). The
+            data are presented as box plots, where the intermediate, lower
+            and upper horizontal lines indicate the median, first and third
+            quartiles of the gastric retention values, respectively, and
+            error bars indicate the maximum and minimum gastric retention
+            values observed. Significant differences between subgroups tested
+            by the Kruskal-Wallis test (P&lt;0.10) followed by the multiple
+            comparisons test (P&lt;0.02) are indicated in the figure.</p>
+            </a>
+            <hr align="LEFT" size="2"/>
+            </root>"""
+
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertIsNotNone(xml.find(".//a[@name='Fig3']"))
+        p_text = xml.find(".//a[@name='Fig3']/p").text.strip()
+        self.assertTrue(
+            p_text.startswith(
+                "Figure 3 - Gastric retention (%) 15 min after the infusion"))
+        self.assertTrue(
+            p_text.endswith(
+                "are indicated in the figure."))
+        self.assertIsNotNone(
+            xml.find(
+                ".//a[@name='Fig3']/img[@src='/img/revistas/bjmbr/v30n6/2677fig1.gif']"))
+

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2748,3 +2748,52 @@ class TestRemoveTableUsedToDisplayFigureAndLabelAndCaptionSideBySide(unittest.Te
         self.assertIsNotNone(
             xml.find(
                 ".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v30n2/2635fig1.gif']"))
+
+
+class TestAssetThumbnailInLayoutImgAndCaptionAndMessage(unittest.TestCase):
+
+    def setUp(self):
+        pipeline = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pipeline.AssetThumbnailInLayoutImgAndCaptionAndMessage()
+
+    def test_transform(self):
+        text = """<root>
+        <p align="center">
+            <a name="Fig1" id="Fig1"/> <img src="/img/revistas/bjmbr/v30n1/2560fig1peq.gif"/>
+        </p>
+        <p>Figure 1 - Effect of dexamethasone pretreatment on ethanol-induced hypothermia in rats. Rats received dexamethasone (2.0 mg/kg,<italic> ip</italic>) or saline administered 15 min before ethanol 20% w/v (2.0, 3.0 or 4.0 g/kg, <italic>ip</italic>) or saline. Colon temperature was measured 30, 60 and 90 min after ethanol administration. The animals were divided into 4 groups: saline + saline (open circles); dexamethasone + saline (filled circles); saline + ethanol (open squares), and dexamethasone + ethanol (filled squares). Data are reported as the mean ± SEM of the fall in temperature in degrees Celsius obtained for 10 animals compared to basal values. *P&lt;0.05 compared to saline + saline group; <sup>+</sup>P&lt;0.05 compared to saline + ethanol group (ANOVA).</p>
+        <p>
+            <a href="#2560fig1" link-type="internal">[View larger version of this image (14 K GIF file)]</a>
+        </p>
+        <p content-type="html">
+            <a id="2560fig1" name="2560fig1"/>
+
+        <p align="center">
+          <img src="http://www.scielo.br/img/fbpe/bjmbr/v30n1/2560fig1.gif" 
+          imported="true" link-type="external"/> </p>
+
+        <p>Figure 1 - Effect of dexamethasone pretreatment on
+        ethanol-induced hypothermia in rats. Rats received dexamethasone
+        (2.0 mg/kg,<italic> ip</italic>) or saline administered 15 min before
+        ethanol 20% w/v (2.0, 3.0 or 4.0 g/kg, <italic>ip</italic>) or saline.
+        Colon temperature was measured 30, 60 and 90 min after ethanol
+        administration. The animals were divided into 4 groups: saline +
+        saline (open circles); dexamethasone + saline (filled circles);
+        saline + ethanol (open squares), and dexamethasone + ethanol
+        (filled squares). Data are reported as the mean ± SEM of the
+        fall in temperature in degrees Celsius obtained for 10 animals
+        compared to basal values. *P&lt;0.05 compared to saline + saline
+        group; <sup>+</sup>P&lt;0.05 compared to saline + ethanol group
+        (ANOVA).</p></p>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        print(etree.tostring(xml))
+        self.assertIsNotNone(xml.find(".//a[@name='Fig1']"))
+        p_text = xml.find(".//a[@name='Fig1']/p").text.strip()
+        self.assertTrue(
+            p_text.startswith(
+                "Figure 1 - Effect of dexamethasone pretreatment on"))
+        self.assertIsNotNone(
+            xml.find(
+                ".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v30n1/2560fig1.gif']"))

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -1930,8 +1930,7 @@ class TestConvertRemote2LocalPipe(unittest.TestCase):
             new=stub_get_html_body,
         ):
             text, xml = pipeline.ConvertRemote2LocalPipe().transform((text, xml))
-            print(etree.tostring(xml))
-
+            
             a_name_items = xml.findall(".//a[@name]")
             self.assertEqual(len(a_name_items), 2)
             self.assertEqual(a_name_items[0].get("name"), "a05tab01")
@@ -2542,6 +2541,9 @@ class TestAssetThumbnailInLayoutTableAndLinkInThumbnail(unittest.TestCase):
         text, xml = self.pipe.transform((text, xml))
         self.assertIsNotNone(xml.find(".//a[@name='Fig1']"))
         self.assertEqual(xml.find(".//a[@name='Fig1']/p").text, 'Figure 1. Concentration of IL-6 (pg/10')
+        self.assertTrue(
+            xml.find(".//a[@name]/p").getchildren()[-1].tail.endswith(
+                "amoxicillin."))
         self.assertIsNotNone(xml.find(".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v43n10/472i01.jpg']"))
 
     def test_transform_when_thumbnail_image_has_not_same_name_as_normal_image(self):
@@ -2553,7 +2555,7 @@ class TestAssetThumbnailInLayoutTableAndLinkInThumbnail(unittest.TestCase):
                 <img src="/img/revistas/bjmbr/v45n12/table.jpg" width="100" height="65" border="2"/>
             </a>
             </td> <td width="84%"> <p align="LEFT">
-                <a name="Tab1" id="Tab1"/>Table 1. Distribution of serum hs-CRP concentration (mg/L) according to gender.</p> </td> </tr>
+                <a name="Tab1" id="Tab1"/>Table 1. Distribution of serum hs-CRP concentration (<sup>mg/L</sup>) according to gender.</p> </td> </tr>
             </table>
             <p content-type="html">
                 <a id="2406t01" name="2406t01"/>&#13;
@@ -2589,10 +2591,10 @@ class TestAssetThumbnailInLayoutTableAndLinkInThumbnail(unittest.TestCase):
         p_text = xml.find(".//a[@name='Tab1']/p").text.strip()
         self.assertTrue(
             p_text.startswith(
-                "Table 1. Distribution of serum hs-CRP concentration (mg/L) according to gender."))
+                "Table 1. Distribution of serum hs-CRP concentration ("))
         self.assertTrue(
-            p_text.endswith(
-                "Table 1. Distribution of serum hs-CRP concentration (mg/L) according to gender."))
+            xml.find(".//a[@name]/p").getchildren()[-1].tail.endswith(
+                ") according to gender."))
         self.assertIsNotNone(
             xml.find(
                 ".//a[@name='Tab1']/img[@src='/img/revistas/bjmbr/v45n12/2406t01.jpg']"))
@@ -2638,6 +2640,10 @@ class TestAssetThumbnailInLinkAndAnchorAndCaption(unittest.TestCase):
         text, xml = self.pipe.transform((text, xml))
         self.assertIsNotNone(xml.find(".//a[@name='Fig2']"))
         self.assertEqual(xml.find(".//a[@name='Fig2']/p").text.strip(), 'Figure 2. During early life (postnatal day 8), pairing an odor with a 0.5-mA shock does not produce a change in pCREB expression (top) or')
+        
+        self.assertTrue(
+            xml.find(".//a[@name='Fig2']/p").getchildren()[-1].tail.endswith(
+                "appears to be heightened by odor exposure. "))
         self.assertIsNotNone(xml.find(".//a[@name='Fig2']/img[@src='/img/revistas/bjmbr/v43n10/650i02.jpg']"))
 
 
@@ -2743,8 +2749,8 @@ class TestRemoveTableUsedToDisplayFigureAndLabelAndCaptionSideBySide(unittest.Te
             p_text.startswith(
                 "Figure 1 - Effects of peripheral"))
         self.assertTrue(
-            p_text.endswith(
-                "Figure 1 - Effects of peripheral"))
+            xml.find(".//a[@name='Fig1']/p").getchildren()[-1].tail.startswith(
+                " administration of"))
         self.assertIsNotNone(
             xml.find(
                 ".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v30n2/2635fig1.gif']"))
@@ -2793,6 +2799,9 @@ class TestRemoveTableUsedToDisplayFigureAndLabelAndCaptionInTwoLines(unittest.Te
         self.assertTrue(
             p_text.startswith(
                 "Figure 1 - Effect of dexamethasone pretreatment on"))
+        self.assertTrue(
+            xml.find(".//a[@name='Fig1']/p").getchildren()[-1].tail.startswith(
+                "P&lt;0.05 compared to saline + ethanol group"))
         self.assertIsNotNone(
             xml.find(
                 ".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v30n1/2560fig1.gif']"))
@@ -2835,12 +2844,14 @@ class TestAssetThumbnailInLayoutImgAndCaptionAndMessage(unittest.TestCase):
         </root>"""
         xml = etree.fromstring(text)
         text, xml = self.pipe.transform((text, xml))
-        print(etree.tostring(xml))
         self.assertIsNotNone(xml.find(".//a[@name='Fig1']"))
         p_text = xml.find(".//a[@name='Fig1']/p").text.strip()
         self.assertTrue(
             p_text.startswith(
                 "Figure 1 - Effect of dexamethasone pretreatment on"))
+        self.assertTrue(
+            xml.find(".//a[@name='Fig1']/p").getchildren()[-1].tail.endswith(
+                "(ANOVA)."))
         self.assertIsNotNone(
             xml.find(
                 ".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v30n1/2560fig1.gif']"))
@@ -2865,12 +2876,15 @@ class TestRemoveTableUsedToDisplayFigureAndLabelAndCaptionInTwoLines(unittest.Te
         </table></root>"""
         xml = etree.fromstring(text)
         text, xml = self.pipe.transform((text, xml))
-        print(etree.tostring(xml))
+        
         self.assertIsNotNone(xml.find(".//a[@name='Fig1']"))
         p_text = xml.find(".//a[@name='Fig1']/p").text.strip()
         self.assertTrue(
             p_text.startswith(
                 "Figure 1 - Relationship between SHBG levels"))
+        self.assertTrue(
+            p_text.endswith(
+                "load test in men."))
         self.assertIsNotNone(
             xml.find(
                 ".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v31n12/3156i01.gif']"))

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2499,7 +2499,7 @@ class TestRemoveReferencesFromBody(unittest.TestCase):
         self.assertEqual(len(xml.findall(".//p")), 8)
 
 
-class TestDigitalAssetThumbnailBlockPipe(unittest.TestCase):
+class TestDigitalAssetThumbnailTablePipe(unittest.TestCase):
 
     def setUp(self):
         pipeline = ConvertElementsWhichHaveIdPipeline()
@@ -2545,26 +2545,44 @@ class TestDigitalAssetThumbnailBlockPipe(unittest.TestCase):
         self.assertIsNotNone(xml.find(".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v43n10/472i01.jpg']"))
 
 
-"""
-<a href="#650i02" link-type="internal">
-  <img src="/img/revistas/bjmbr/v43n10/650i02peq.jpg" border="2"/>
-</a>
-<p content-type="html">
-  <a id="650i02" name="650i02"/>&#13;
- <p align="left">C. Raineki, A. Pickenhagen, T.L. Roth, D.M. Babstock, J.H. McLean, C.W. Harley, A.B. Lucion and R.M. Sullivan. The neurobiology of infant maternal odor learning. Braz J Med Biol Res 2010; 43: 914-919. &#13;
- </p>&#13;
-   <p>
-    <ext-link ext-link-type="uri" xlink:href="javascript:history.back()">
-    <img src="/img/revistas/bjmbr/v43n10/650i02.jpg" align="BOTTOM" border="0" vspace="0" hspace="0" width="800" height="349" imported="true"/>
- </ext-link>
- </p>&#13;
-   <p>&#13;
-     <p align="LEFT">Figure 2. During early life (postnatal day 8), pairing an odor with a 0.5-mA shock does not produce a change in pCREB expression (top) or <italic>2</italic>-<italic>deoxy-d-glucose</italic> (2-DG) uptake (bottom) in the lateral (LA) and basolateral (BLA) amygdala. The expression of phosphorylated cAMP response element binding protein (pCREB) in the cortical amygdala (CoA), a component of the olfactory cortex, appears to be heightened by odor exposure.</p>&#13;
-   </p>&#13;
- &#13;
- &#13;
-</p>
-<a name="Fig2" id="Fig2"/>
-Figure 2. During early life (postnatal day 8), pairing an odor with a 0.5-mA shock does not produce a change in pCREB expression (top) or <italic>2</italic>-<italic>deoxy-d-glucose</italic> (2-DG) uptake (bottom) in the lateral (LA) and basolateral (BLA) amygdala. The expression of phosphorylated cAMP response element binding protein (pCREB) in the cortical amygdala (CoA), a component of the olfactory cortex, appears to be heightened by odor exposure. <p>[View larger version of this image (340 K JPG file)]</p>  
-<hr align="LEFT" size="2"/>
-"""
+class TestDigitalAssetThumbnailBlockPipe(unittest.TestCase):
+
+    def setUp(self):
+        pipeline = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pipeline.ConvertAssetThumbnailInElementAIntoSimplerStructure()
+
+    def test_transform_converts_thumbnail_into_simpler_structure(self):
+        text = """<root xmlns:xlink="http://www.w3.org/1999/xlink">
+        <a href="#650i02" link-type="internal">
+          <img src="/img/revistas/bjmbr/v43n10/650i02peq.jpg" border="2"/>
+        </a>
+        <p content-type="html">
+          <a id="650i02" name="650i02"/>&#13;
+         <p align="left">C. Raineki, A. Pickenhagen, T.L. Roth, D.M. Babstock, J.H. McLean, C.W. Harley, A.B. Lucion and R.M. Sullivan. The neurobiology of infant maternal odor learning. Braz J Med Biol Res 2010; 43: 914-919. &#13;
+         </p>&#13;
+           <p>
+            <ext-link ext-link-type="uri" xlink:href="javascript:history.back()">
+            <img src="/img/revistas/bjmbr/v43n10/650i02.jpg" align="BOTTOM" border="0" vspace="0" hspace="0" width="800" height="349" imported="true"/>
+         </ext-link>
+         </p>&#13;
+           <p>&#13;
+             <p align="LEFT">Figure 2. During early life (postnatal day 8), pairing an odor with a 0.5-mA shock does not produce a change in pCREB expression (top) or <italic>2</italic>-<italic>deoxy-d-glucose</italic> (2-DG) uptake (bottom) in the lateral (LA) and basolateral (BLA) amygdala. The expression of phosphorylated cAMP response element binding protein (pCREB) in the cortical amygdala (CoA), a component of the olfactory cortex, appears to be heightened by odor exposure.</p>&#13;
+           </p>&#13;
+         &#13;
+         &#13;
+        </p>
+        <a name="Fig2" id="Fig2"/>
+        Figure 2. During early life (postnatal day 8), pairing an odor with a 0.5-mA shock does not produce a change in pCREB expression (top) or <italic>2</italic>-<italic>deoxy-d-glucose</italic> (2-DG) uptake (bottom) in the lateral (LA) and basolateral (BLA) amygdala. The expression of phosphorylated cAMP response element binding protein (pCREB) in the cortical amygdala (CoA), a component of the olfactory cortex, appears to be heightened by odor exposure. <p>[View larger version of this image (340 K JPG file)]</p>  
+        <hr align="LEFT" size="2"/>
+        </root>"""
+        expected = b"""<root xmlns:xlink="http://www.w3.org/1999/xlink">
+        <p><a name="Fig2" id="Fig2"><img src="/img/revistas/bjmbr/v43n10/650i02.jpg" align="BOTTOM" border="0" vspace="0" hspace="0" width="800" height="403" imported="true"/>
+        <p>Figure 2. During early life (postnatal day 8), pairing an odor with a 0.5-mA shock does not produce a change in pCREB expression (top) or <italic>2</italic>-<italic>deoxy-d-glucose</italic> (2-DG) uptake (bottom) in the lateral (LA) and basolateral (BLA) amygdala. The expression of phosphorylated cAMP response element binding protein (pCREB) in the cortical amygdala (CoA), a component of the olfactory cortex, appears to be heightened by odor exposure. </p></a></p>
+        <hr align="LEFT" size="2"/>
+        </root>"""
+
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertIsNotNone(xml.find(".//a[@name='Fig2']"))
+        self.assertEqual(xml.find(".//a[@name='Fig2']/p").text.strip(), 'Figure 2. During early life (postnatal day 8), pairing an odor with a 0.5-mA shock does not produce a change in pCREB expression (top) or')
+        self.assertIsNotNone(xml.find(".//a[@name='Fig2']/img[@src='/img/revistas/bjmbr/v43n10/650i02.jpg']"))

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2721,7 +2721,7 @@ class TestRemoveTableUsedToDisplayFigureAndLabelAndCaptionSideBySide(unittest.Te
 
     def setUp(self):
         pipeline = ConvertElementsWhichHaveIdPipeline()
-        self.pipe = pipeline.RemoveTableUsedToDisplayFigureAndLabelAndCaptionSideBySide()
+        self.pipe = pipeline.RemoveTableUsedToDisplayImageAndLabelAndCaptionSideBySide()
 
     def test_transform(self):
         text = """<root>
@@ -2748,4 +2748,3 @@ class TestRemoveTableUsedToDisplayFigureAndLabelAndCaptionSideBySide(unittest.Te
         self.assertIsNotNone(
             xml.find(
                 ".//a[@name='Fig1']/img[@src='/img/revistas/bjmbr/v30n2/2635fig1.gif']"))
-


### PR DESCRIPTION
#### O que esse PR faz?
A conversão de fig ou table-wrap estava errada quando as imagens (thumbnail) estavam no HTML original dentro de table de HTML para estabelecer um layout em particular.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando `ds_migracao convert`

Em anexo estão os PIDs, classificados pelo tipo de layout no html.

[created-from-layout.zip](https://github.com/scieloorg/document-store-migracao/files/4042392/created-from-layout.zip)

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#238

### Referências
n/a
