### PR TITLE
Remove `body` que faz referência ao texto completo em PDF

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -560,29 +560,25 @@ class SPS_Package:
         """Remove o corpo do documento quando o texto completo está disponível
         apenas em pdf."""
 
-        def find_pdf_links(body: etree.Element) -> list:
+        def body_has_full_text_reference(body: etree.Element) -> bool:
             TEXT_LINK_FOR_PDF = [
-                "texto completo disponível apenas em pdf.",
-                "full text available only in pdf format.",
-                "texto completo solamente en formato pdf.",
+                "texto completo disponível apenas em pdf",
+                "full text available only in pdf format",
+                "texto completo solamente en formato pdf",
             ]
-            renditions = []
 
-            for node in body.findall(".//a"):
-                if not node.get("href", "").endswith(".pdf"):
-                    continue
+            body_str = (etree.tostring(body) or b"").decode().lower()
 
-                if node.text is not None and node.text.lower() in TEXT_LINK_FOR_PDF:
-                    renditions.append(node)
+            for text in TEXT_LINK_FOR_PDF:
+                if text in body_str:
+                    return True
 
-            return renditions
+            return False
 
         has_self_uri_tags = len(self.xmltree.findall(".//self-uri")) > 0
 
         for body in self.xmltree.iterfind(".//body"):
-            full_text_available_in_pdf = len(find_pdf_links(body)) > 0
-
-            if has_self_uri_tags and full_text_available_in_pdf:
+            if has_self_uri_tags and body_has_full_text_reference(body):
                 parent = body.getparent()
                 parent.remove(body)
 

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -556,6 +556,36 @@ class SPS_Package:
 
         return self.xmltree
 
+    def remove_article_body_when_text_is_available_only_in_pdf(self) -> None:
+        """Remove o corpo do documento quando o texto completo está disponível
+        apenas em pdf."""
+
+        def find_pdf_links(body: etree.Element) -> list:
+            TEXT_LINK_FOR_PDF = [
+                "texto completo disponível apenas em pdf.",
+                "full text available only in pdf format.",
+                "texto completo solamente en formato pdf.",
+            ]
+            renditions = []
+
+            for node in body.findall(".//a"):
+                if not node.get("href", "").endswith(".pdf"):
+                    continue
+
+                if node.text is not None and node.text.lower() in TEXT_LINK_FOR_PDF:
+                    renditions.append(node)
+
+            return renditions
+
+        has_self_uri_tags = len(self.xmltree.findall(".//self-uri")) > 0
+
+        for body in self.xmltree.iterfind(".//body"):
+            full_text_available_in_pdf = len(find_pdf_links(body)) > 0
+
+            if has_self_uri_tags and full_text_available_in_pdf:
+                parent = body.getparent()
+                parent.remove(body)
+
     def create_scielo_id(self):
         PATHS = [".//article-meta"]
 

--- a/documentstore_migracao/processing/conversion.py
+++ b/documentstore_migracao/processing/conversion.py
@@ -32,6 +32,9 @@ def convert_article_xml(file_xml_path):
     # Remove a TAG <counts> do XML
     xml_sps.transform_article_meta_count()
 
+    # Remove body when text is available only in PDF
+    xml_sps.remove_article_body_when_text_is_available_only_in_pdf()
+
     languages = "-".join(xml_sps.languages)
     _, fname = os.path.split(file_xml_path)
     fname, fext = fname.rsplit(".", 1)

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -1932,3 +1932,48 @@ class TestGetRefItems(unittest.TestCase):
         _sps_package = self._get_sps_package(text)
         ref_items = _sps_package._get_ref_items(body)
         self.assertEqual(len(ref_items), 3)
+
+
+class TestRemoveBodyWhenFulltextIsOnlyAvailableInPDF(unittest.TestCase):
+    def setUp(self):
+        xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><article-meta>
+            <self-uri xlink:href="url/arquivo.pdf" xml:lang="fr">Full text available only in PDF format (FR)</self-uri>
+            <self-uri xlink:href="ufl/arquivo.pdf" xml:lang="pt">Texto completo somente em PDF (PT)</self-uri>
+            <body>
+             <p content-type="title">Título!</p>
+             <p><a href="/pdf/mioc/v80n1/vol80(f1)_002-010.pdf">Texto completo disponível apenas em PDF.</a></p>
+             <p><a href="/pdf/mioc/v80n1/vol80(f1)_002-010.pdf">Full text available only in PDF format.</a></p>
+             <p></p>
+            </body>
+        </article-meta></article>"""
+        xmltree = etree.fromstring(xml)
+        self.sps_package = SPS_Package(xmltree, None)
+
+    def test_remove_body_when_self_uri_are_available_and_text_points_to_full_text_in_pdf(
+        self,
+    ):
+        self.sps_package.remove_article_body_when_text_is_available_only_in_pdf()
+        self.assertIsNone(self.sps_package.xmltree.find(".//body"))
+
+    def test_do_not_remove_body_wyen_self_uri_tag_is_not_present(self):
+        article_meta = self.sps_package.xmltree.find(".//article-meta")
+        tags = self.sps_package.xmltree.findall(".//self-uri")
+
+        for tag in tags:
+            article_meta.remove(tag)
+
+        self.sps_package.remove_article_body_when_text_is_available_only_in_pdf()
+        self.assertIsNotNone(self.sps_package.xmltree.find(".//body"))
+
+    def test_do_not_remove_body_if_it_does_not_point_to_full_text(self):
+        xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><article-meta>
+            <self-uri xlink:href="fr_tomo14(f1)_104-116.pdf" xml:lang="fr">Full text available only in PDF format (FR)</self-uri>
+            <self-uri xlink:href="/tomo14(f1)_104-116.pdf" xml:lang="pt">Texto completo somente em PDF (PT)</self-uri>
+            <body>
+             <p content-type="title">Título!</p>
+            </body>
+        </article-meta></article>"""
+        xmltree = etree.fromstring(xml)
+        sps_package = SPS_Package(xmltree, None)
+        sps_package.remove_article_body_when_text_is_available_only_in_pdf()
+        self.assertIsNotNone(self.sps_package.xmltree.find(".//body"))

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -1955,7 +1955,7 @@ class TestRemoveBodyWhenFulltextIsOnlyAvailableInPDF(unittest.TestCase):
         self.sps_package.remove_article_body_when_text_is_available_only_in_pdf()
         self.assertIsNone(self.sps_package.xmltree.find(".//body"))
 
-    def test_do_not_remove_body_wyen_self_uri_tag_is_not_present(self):
+    def test_do_not_remove_body_when_self_uri_tag_is_not_present(self):
         article_meta = self.sps_package.xmltree.find(".//article-meta")
         tags = self.sps_package.xmltree.findall(".//self-uri")
 


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request adiciona a capacidade de remover o corpo do documento quando:
1) O documento possuir ao menos uma tag `self-uri` apontando para a versão em `pdf`;
2) O `body` do documento existir apenas para referenciar as versões do texto completo em `pdf`.

#### Onde a revisão poderia começar?
- `documentstore_migracao/export/sps_package.py` L: `559`

#### Como este poderia ser testado manualmente?
Para testar este pull request manualmente, deve-se:
- Extrair documentos que possuem o corpo apenas para referenciar o texto completo em PDF (ou usar o anexo [1]);
- Converter os arquivos (`ds_migracao convert`)
- Verificar que o corpo dos documentos com tags `self-uri` foi removido;
- Verificar que o corpo de documentos sem tags `self-uri` foi mentido;

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#206 

### Referências
N/A


### Anexos
[[1] - Pasta source com documentos com e sem self-uri](https://drive.google.com/open?id=1O1Gwannoq36_2SPsXp-vEs41p89hFgEI)