### PR TITLE
Registra mudança para os renditions importados

### DIFF
--- a/documentstore_migracao/processing/inserting.py
+++ b/documentstore_migracao/processing/inserting.py
@@ -24,6 +24,7 @@ from documentstore_migracao.utils import (
     update_journal,
     add_bundle,
     update_bundle,
+    add_renditions,
 )
 from documentstore_migracao import config, exceptions
 from documentstore_migracao.export.sps_package import DocumentsSorter, SPS_Package
@@ -204,6 +205,10 @@ def register_document(folder: str, session, storage) -> None:
 
         try:
             add_document(session, document)
+
+            if renditions:
+                add_renditions(session, document)
+
             logger.info("Document-store save: %s", document.id())
         except AlreadyExists as exc:
             logger.exception(exc)

--- a/documentstore_migracao/utils/__init__.py
+++ b/documentstore_migracao/utils/__init__.py
@@ -1,14 +1,15 @@
 import gzip
 
 from documentstore.domain import utcnow
+from documentstore.services import DocumentRenditions
 
 
-def _add_change(session, instance, entity):
+def _add_change(session, instance, entity, id=None):
     session.changes.add(
         {
             "timestamp": utcnow(),
             "entity": entity,
-            "id": instance.id(),
+            "id": id or instance.id(),
             "content_gz": gzip.compress(instance.data_bytes()),
             "content_type": instance.data_type,
         }
@@ -40,10 +41,17 @@ def update_bundle(session, bundle):
     _add_change(session, bundle, "DocumentsBundle")
 
 
+def add_renditions(session, document):
+    _add_change(
+        session, DocumentRenditions(document), "DocumentRendition", document.id()
+    )
+
+
 __all__ = [
     "add_document",
     "add_journal",
     "update_journal",
     "add_bundle",
     "update_bundle",
+    "add_renditions",
 ]


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request adiciona o registro de mudanças para os renditions importados durante a migração. 

#### Onde a revisão poderia começar?
- `documentstore_migracao/utils/__init__.py` L:`4`

#### Como este poderia ser testado manualmente?

Para testar este pr manualmente, deve-se:
- Realizar as etapas de extração, conversão e importação de um pacote SPS;
- Verificar a API de mudanças do `kernel` se foi adicionado o registro de mudanças para os renditions do pacote.

#### Algum cenário de contexto que queira dar?

Este pr faz uso da [interface de domínio criada](https://github.com/scieloorg/kernel/blob/master/documentstore/services.py#L480) no `kernel` para serializar corretamente os dados da manifestação que está associada ao documento, sendo assim é preciso atualizar a versão do `scielo-kernel` para utilizar este código.

### Screenshots
N/A

#### Quais são tickets relevantes?
closes #237

### Referências
N/A

