### PR TITLE
Completa datas de publicação dos documentos provenientes de HTML

### DIFF
--- a/documentstore_migracao/export/article.py
+++ b/documentstore_migracao/export/article.py
@@ -43,9 +43,9 @@ def ext_article(code, **ext_params):
 
 
 def ext_article_json(code, **ext_params):
-    article = ext_article(code, **ext_params)
+    article = ext_article(code, format="json", **ext_params)
     if article:
-        return article.json()
+        return article.text
 
 
 def ext_article_txt(code, **ext_params):

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -476,13 +476,22 @@ class SPS_Package:
 
     @documents_bundle_pubdate.setter
     def documents_bundle_pubdate(self, value):
-        xpaths_attrs_to_set = {
-            "sps-1.9": (
-                ("publication-format", "electronic"), ("date-type", "collection"),),
-            "sps-1.8": (("pub-type", "collection"),),
-            "other": (("pub-type", "epub-ppub"),),
-        }
-        self._set_pub_date(xpaths_attrs_to_set, value)
+        if value is None:
+            xpaths = (
+                'pub-date[@pub-type="epub-ppub"]',
+                'pub-date[@pub-type="collection"]',
+                'pub-date[@date-type="collection"]',
+            )
+            pubdate_node = self._match_pubdate(xpaths)
+            self.article_meta.remove(pubdate_node)
+        else:
+            xpaths_attrs_to_set = {
+                "sps-1.9": (
+                    ("publication-format", "electronic"), ("date-type", "collection"),),
+                "sps-1.8": (("pub-type", "collection"),),
+                "other": (("pub-type", "epub-ppub"),),
+            }
+            self._set_pub_date(xpaths_attrs_to_set, value)
 
     @property
     def languages(self):

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -433,7 +433,7 @@ class SPS_Package:
         pubdate_node = etree.Element("pub-date")
         for attr in attrs:
             pubdate_node.set(*attr)
-        for tag, val in zip(["year", "month", "day"], value):
+        for tag, val in zip(["day", "month", "year"], value[::-1]):
             if len(val) > 0:
                 new_node = etree.Element(tag)
                 new_node.text = val

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -493,6 +493,28 @@ class SPS_Package:
             }
             self._set_pub_date(xpaths_attrs_to_set, value)
 
+    def complete_pub_date(self, document_pubdate, issue_pubdate):
+        # Verificar data de publicação e da coleção
+        if len("".join(self.document_pubdate)) == 0 and document_pubdate is not None:
+            logger.debug(
+                'Updating document with document pub date "%s"', document_pubdate,
+            )
+            self.document_pubdate = document_pubdate
+
+        if self.is_ahead_of_print:
+            if len("".join(self.documents_bundle_pubdate)) > 0:
+                logger.debug("Removing collection date from ahead of print document")
+                self.documents_bundle_pubdate = None
+        else:
+            if (
+                len("".join(self.documents_bundle_pubdate)) == 0
+                and issue_pubdate is not None
+            ):
+                logger.debug(
+                    'Updating document with collection date "%s"', issue_pubdate
+                )
+                self.documents_bundle_pubdate = issue_pubdate
+
     @property
     def languages(self):
         """The language of the main document plus all translations.

--- a/documentstore_migracao/processing/extracted.py
+++ b/documentstore_migracao/processing/extracted.py
@@ -20,6 +20,12 @@ class PoisonPill:
 
 
 def get_and_write(pid, stage_path, poison_pill):
+
+    def save_file(stage_path, file_path, documents_pid, article_content):
+        logger.debug("\t Salvando arquivo '%s'", file_path)
+        files.write_file(file_path, article_content)
+        files.register_latest_stage(stage_path, documents_pid)
+
     if poison_pill.poisoned:
         return
 
@@ -27,12 +33,22 @@ def get_and_write(pid, stage_path, poison_pill):
 
     logger.debug("\t coletando dados do Documento '%s'", documents_pid)
     xml_article = article.ext_article_txt(documents_pid)
-
     if xml_article:
-        file_path = os.path.join(config.get("SOURCE_PATH"), "%s.xml" % documents_pid)
-        logger.debug("\t Salvando arquivo '%s'", file_path)
-        files.write_file(file_path, xml_article)
-        files.register_latest_stage(stage_path, documents_pid)
+        save_file(
+            stage_path,
+            os.path.join(config.get("SOURCE_PATH"), "%s.xml" % documents_pid),
+            documents_pid,
+            xml_article,
+        )
+
+    json_article = article.ext_article_json(documents_pid)
+    if json_article:
+        save_file(
+            stage_path,
+            os.path.join(config.get("SOURCE_PATH"), "%s.json" % documents_pid),
+            documents_pid,
+            json_article,
+        )
 
 
 def extract_all_data(list_documents_pids: List[str]):

--- a/documentstore_migracao/utils/xylose_converter.py
+++ b/documentstore_migracao/utils/xylose_converter.py
@@ -1,8 +1,9 @@
 import logging
+import json
 from typing import List
 from datetime import datetime
 from documentstore_migracao.utils import scielo_ids_generator
-from xylose.scielodocument import Journal, Issue
+from xylose.scielodocument import Journal, Issue, Article
 
 logger = logging.getLogger(__name__)
 
@@ -261,3 +262,8 @@ def find_documents_bundles(journal: dict, issues: List[Issue]):
             issues_ids.append(issue_to_kernel(issue).get("id"))
 
     return issues_ids
+
+
+def json_file_to_xylose_article(json_file_path):
+    with open(json_file_path) as json_file:
+        return Article(json.load(json_file))

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ venusian==1.2.0
 waitress==1.2.1
 WebOb==1.8.5
 WebTest==2.0.33
-xylose==1.35.1
+-e git+https://github.com/scieloorg/xylose.git@1.35.8#egg=xylose
 zope.deprecation==4.4.0
 zope.interface==4.6.0
 fs==2.4.5

--- a/tests/samples/S0036-36341997000100001.json
+++ b/tests/samples/S0036-36341997000100001.json
@@ -1,0 +1,847 @@
+{
+    "article": {
+        "v709": [
+            {
+                "_": "text"
+            }
+        ],
+        "v882": [
+            {
+                "_": "",
+                "n": "1",
+                "v": "39"
+            }
+        ],
+        "v1": [
+            {
+                "_": "br1.1"
+            }
+        ],
+        "v992": [
+            {
+                "_": "spa"
+            }
+        ],
+        "v121": [
+            {
+                "_": "01"
+            }
+        ],
+        "v10": [
+            {
+                "s": "Sep\u00falveda",
+                "1": "A01",
+                "_": "",
+                "n": "Jaime",
+                "r": "ND"
+            }
+        ],
+        "v705": [
+            {
+                "_": "S"
+            }
+        ],
+        "v91": [
+            {
+                "_": "20010808"
+            }
+        ],
+        "v30": [
+            {
+                "_": "Salud p\u00fablica M\u00e9x"
+            }
+        ],
+        "v936": [
+            {
+                "i": "0036-3634",
+                "o": "1",
+                "y": "1997",
+                "_": ""
+            }
+        ],
+        "v120": [
+            {
+                "_": "3.0"
+            }
+        ],
+        "v14": [
+            {
+                "l": "1",
+                "_": "",
+                "f": "1"
+            }
+        ],
+        "v31": [
+            {
+                "_": "39"
+            }
+        ],
+        "v4": [
+            {
+                "_": "v39n1"
+            }
+        ],
+        "v700": [
+            {
+                "_": "2"
+            }
+        ],
+        "v702": [
+            {
+                "_": "C:\\SciELO\\Serial\\spm\\v39n1\\markup\\edit.htm"
+            }
+        ],
+        "v706": [
+            {
+                "_": "h"
+            }
+        ],
+        "v35": [
+            {
+                "_": "0036-3634"
+            }
+        ],
+        "v65": [
+            {
+                "_": "19970100"
+            }
+        ],
+        "v12": [
+            {
+                "l": "es",
+                "_": "EDITORIAL"
+            }
+        ],
+        "v49": [
+            {
+                "_": "SPM070"
+            }
+        ],
+        "v70": [
+            {
+                "i": "A01",
+                "p": "Mexico",
+                "_": "Instituto Nacional de Salud P\u00fablica"
+            }
+        ],
+        "v32": [
+            {
+                "_": "1"
+            }
+        ],
+        "v2": [
+            {
+                "_": "S0036-3634(97)03900101"
+            }
+        ],
+        "v40": [
+            {
+                "_": "es"
+            }
+        ],
+        "v977": [
+            {
+                "l": "es",
+                "_": "EDITORIAL"
+            }
+        ],
+        "v708": [
+            {
+                "_": "1"
+            }
+        ],
+        "v123": [
+            {
+                "_": "2"
+            }
+        ],
+        "v158": [
+            {
+                "_": "nd"
+            }
+        ],
+        "v38": [
+            {
+                "_": "ND"
+            }
+        ],
+        "v880": [
+            {
+                "_": "S0036-36341997000100001"
+            }
+        ],
+        "v701": [
+            {
+                "_": "1"
+            }
+        ],
+        "v71": [
+            {
+                "_": "ed"
+            }
+        ],
+        "v42": [
+            {
+                "_": "1"
+            }
+        ]
+    },
+    "title": {
+        "v950": [
+            {
+                "_": "sonia.reis"
+            }
+        ],
+        "v943": [
+            {
+                "_": "20170620"
+            }
+        ],
+        "v951": [
+            {
+                "_": "sonia.reis"
+            }
+        ],
+        "v540": [
+            {
+                "l": "en",
+                "_": "",
+                "t": "<a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/4.0/\"><img alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by-nc-sa/4.0/80x15.png\" /></a><br />This work is licensed under a <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/4.0/\">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>."
+            },
+            {
+                "l": "es",
+                "_": "",
+                "t": "<a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/4.0/\"><img alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by-nc-sa/4.0/80x15.png\" /></a><br />This work is licensed under a <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/4.0/\">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>."
+            },
+            {
+                "l": "pt",
+                "_": "",
+                "t": "<a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/4.0/\"><img alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by-nc-sa/4.0/80x15.png\" /></a><br />This work is licensed under a <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/4.0/\">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>."
+            }
+        ],
+        "v10": [
+            {
+                "_": "br1.1"
+            }
+        ],
+        "v930": [
+            {
+                "_": "spm"
+            }
+        ],
+        "v69": [
+            {
+                "_": "http://saludpublica.mx/insp/index.php/spm"
+            }
+        ],
+        "v940": [
+            {
+                "_": "19990608"
+            }
+        ],
+        "v330": [
+            {
+                "_": "CT"
+            }
+        ],
+        "v441": [
+            {
+                "_": "Health Sciences"
+            }
+        ],
+        "v480": [
+            {
+                "_": "Instituto Nacional de Salud P\u00fablica"
+            }
+        ],
+        "collection": "spa",
+        "v435": [
+            {
+                "_": "0036-3634",
+                "t": "PRINT"
+            }
+        ],
+        "v117": [
+            {
+                "_": "vancouv"
+            }
+        ],
+        "scimago_id": "19317",
+        "v901": [
+            {
+                "l": "en",
+                "_": "To publish articles both in English and Spanish related to public health topics, in the form of full-length original research papers, brief communications, review articles, essays, updates, classics, indicators, health news, book reviews and letters to the editor. Bi-monthly publication."
+            },
+            {
+                "l": "pt",
+                "_": "Publicar textos, em espanhol e em ingl\u00eas, sobre temas relacionados com a sa\u00fade p\u00fablica, na forma de editoriais, artigos originais, comunica\u00e7\u00f5es breves, artigos de revis\u00e3o, ensaios, atualiza\u00e7\u00f5es, cl\u00e1ssicos, indicadores, not\u00edcias, resenhas bibliogr\u00e1ficas e cartas ao editor. Publica\u00e7\u00e3o bimestral."
+            },
+            {
+                "l": "es",
+                "_": "Publicar textos, en espa\u00f1ol y en ingl\u00e9s, sobre temas relacionados con la salud p\u00fablica, en forma de editoriales, art\u00edculos originales, breves, y de revisi\u00f3n, ensayos, actualizaciones, cl\u00e1sicos, indicadores, noticias, rese\u00f1as bibliogr\u00e1ficas y cartas al editor. Publicaci\u00f3n bimestral."
+            }
+        ],
+        "processing_date": "2017-02-20",
+        "v240": [
+            {
+                "_": "Salud p\u00fablica M\u00e9x"
+            },
+            {
+                "_": "SPM. Salud Publica de Mexico"
+            }
+        ],
+        "v380": [
+            {
+                "_": "B"
+            }
+        ],
+        "v854": [
+            {
+                "_": "Health Policy & Services"
+            }
+        ],
+        "v490": [
+            {
+                "_": "Cuernavaca"
+            }
+        ],
+        "v51": [
+            {
+                "c": "20010701",
+                "d": "C",
+                "a": "20010101",
+                "b": "C",
+                "_": ""
+            }
+        ],
+        "v941": [
+            {
+                "_": "20170220"
+            }
+        ],
+        "v302": [
+            {
+                "_": "1"
+            }
+        ],
+        "v880": [
+            {
+                "_": "0036-3634"
+            }
+        ],
+        "created_at": "1999-06-08",
+        "v150": [
+            {
+                "_": "Salud p\u00fablica M\u00e9x"
+            }
+        ],
+        "v66": [
+            {
+                "_": "art"
+            }
+        ],
+        "v50": [
+            {
+                "_": "C"
+            }
+        ],
+        "v100": [
+            {
+                "_": "Salud P\u00fablica de M\u00e9xico"
+            }
+        ],
+        "v992": [
+            {
+                "_": "spa"
+            }
+        ],
+        "v400": [
+            {
+                "_": "0036-3634"
+            }
+        ],
+        "v301": [
+            {
+                "_": "1959"
+            }
+        ],
+        "v421": [
+            {
+                "_": "Salud Publica Mex."
+            }
+        ],
+        "v303": [
+            {
+                "_": "1"
+            }
+        ],
+        "v6": [
+            {
+                "_": "c"
+            }
+        ],
+        "v310": [
+            {
+                "_": "MX"
+            }
+        ],
+        "v942": [
+            {
+                "_": "19990608"
+            }
+        ],
+        "v541": [
+            {
+                "_": "BY-NC-SA/4.0"
+            }
+        ],
+        "v35": [
+            {
+                "_": "PRINT"
+            }
+        ],
+        "code": "0036-3634",
+        "updated_date": "2016-05-24",
+        "v5": [
+            {
+                "_": "S"
+            }
+        ],
+        "v440": [
+            {
+                "_": "SAUDE PUBLICA"
+            }
+        ],
+        "v935": [
+            {
+                "_": "0036-3634"
+            }
+        ],
+        "v230": [
+            {
+                "_": "Public Health of Mexico"
+            }
+        ],
+        "v151": [
+            {
+                "_": "Salud p\u00fablica M\u00e9x"
+            }
+        ],
+        "v85": [
+            {
+                "_": "nd"
+            }
+        ],
+        "v350": [
+            {
+                "_": "en"
+            },
+            {
+                "_": "es"
+            }
+        ],
+        "v320": [
+            {
+                "_": "Morelos"
+            }
+        ],
+        "v64": [
+            {
+                "_": "spm@insp3.insp.mx"
+            }
+        ],
+        "v67": [
+            {
+                "_": "na"
+            }
+        ],
+        "v62": [
+            {
+                "_": "Instituto Nacional de Salud P\u00fablica"
+            }
+        ],
+        "v63": [
+            {
+                "_": "Av. Universidad 655, Edificio de Gobierno, Planta Baja, Col. Santa Mar\u00eda Ahuacatitl\u00e1n, Cuernavaca, Morelos, MX, 62508, (52 73) 17-5745"
+            }
+        ],
+        "updated_at": "2017-08-10",
+        "v450": [
+            {
+                "_": "CURRENT CONTENTS/SOCIAL AND BEHAVIORAL SCIENCES"
+            },
+            {
+                "_": "SOCIAL SCIENCES CITATION INDEX"
+            },
+            {
+                "_": "RESEARH ALERT"
+            },
+            {
+                "_": "INDEX MEDICUS"
+            },
+            {
+                "_": "INDEX MEDICUS LATINOAMERICANO"
+            },
+            {
+                "_": "EMBASE/EXCERPTA MEDICA"
+            },
+            {
+                "_": "CAB HEALTH/CAB ABSTRACT"
+            },
+            {
+                "_": "EUROPEAN CLEARING HOUSE ON HEALTH SYSTEMS REFORMS"
+            },
+            {
+                "_": "INDICE DE REVISTAS MEXICANAS DE INVESTIGACI\u00d3N CIENT\u00cdFICA Y TECNOL\u00d3GICA DEL CONACYT"
+            },
+            {
+                "_": "BIBLIOMEX-SALUD"
+            },
+            {
+                "_": "PERI\u00d3DICA"
+            },
+            {
+                "_": "INDICE DE REVISTAS DE EDUCACI\u00d3N SUPERIOR E INVESTIGACI\u00d3N EDUCATIVA (IRESIE)"
+            },
+            {
+                "_": "MEDLINE"
+            },
+            {
+                "_": "LILACS"
+            },
+            {
+                "_": "ARTEMISA"
+            }
+        ],
+        "v68": [
+            {
+                "_": "spm"
+            }
+        ],
+        "v140": [
+            {
+                "_": "Instituto Nacional de Salud Publica (INSP)"
+            }
+        ],
+        "issns": [
+            "0036-3634"
+        ]
+    },
+    "version": "html",
+    "validated_scielo": "False",
+    "created_at": "2001-08-08",
+    "processing_date": "2001-08-08",
+    "fulltexts": {
+        "html": {
+            "es": "http://www.scielosp.org/scielo.php?script=sci_arttext&pid=S0036-36341997000100001&tlng=es"
+        }
+    },
+    "issue": {
+        "issue": {
+            "v48": [
+                {
+                    "l": "es",
+                    "h": "Sumario",
+                    "_": ""
+                },
+                {
+                    "l": "pt",
+                    "h": "Sum\u00e1rio",
+                    "_": ""
+                },
+                {
+                    "l": "en",
+                    "h": "Table of Contents",
+                    "_": ""
+                }
+            ],
+            "v480": [
+                {
+                    "_": "Instituto Nacional de Salud P\u00fablica"
+                }
+            ],
+            "v992": [
+                {
+                    "_": "spa"
+                }
+            ],
+            "v930": [
+                {
+                    "_": "SPM"
+                }
+            ],
+            "v36": [
+                {
+                    "_": "19971"
+                }
+            ],
+            "v421": [
+                {
+                    "_": "Salud p\u00fablica M\u00e9x"
+                }
+            ],
+            "v30": [
+                {
+                    "_": "Salud p\u00fablica M\u00e9x"
+                }
+            ],
+            "v6": [
+                {
+                    "_": "001"
+                }
+            ],
+            "v991": [
+                {
+                    "_": "1"
+                }
+            ],
+            "v31": [
+                {
+                    "_": "39"
+                }
+            ],
+            "v4": [
+                {
+                    "_": "v39n1"
+                }
+            ],
+            "v700": [
+                {
+                    "_": "0"
+                }
+            ],
+            "v117": [
+                {
+                    "_": "other"
+                }
+            ],
+            "v706": [
+                {
+                    "_": "i"
+                }
+            ],
+            "v35": [
+                {
+                    "_": "0036-3634"
+                }
+            ],
+            "v200": [
+                {
+                    "_": "1"
+                }
+            ],
+            "v91": [
+                {
+                    "_": "20010808"
+                }
+            ],
+            "v65": [
+                {
+                    "_": "19970100"
+                }
+            ],
+            "v49": [
+                {
+                    "l": "es",
+                    "c": "SPM010",
+                    "_": "",
+                    "t": "Art\u00edculos originales"
+                },
+                {
+                    "l": "es",
+                    "c": "SPM030",
+                    "_": "",
+                    "t": "Ensayos"
+                },
+                {
+                    "l": "es",
+                    "c": "SPM040",
+                    "_": "",
+                    "t": "Actualizaciones"
+                },
+                {
+                    "l": "es",
+                    "c": "SPM050",
+                    "_": "",
+                    "t": "Art\u00edculos especiales"
+                },
+                {
+                    "l": "es",
+                    "c": "SPM060",
+                    "_": "",
+                    "t": "Indicadores"
+                },
+                {
+                    "l": "es",
+                    "c": "SPM070",
+                    "_": "",
+                    "t": "Editorial"
+                },
+                {
+                    "l": "es",
+                    "c": "SPM150",
+                    "_": "",
+                    "t": "Art\u00edculos breves"
+                },
+                {
+                    "l": "en",
+                    "c": "SPM010",
+                    "_": "",
+                    "t": "Original articles"
+                },
+                {
+                    "l": "en",
+                    "c": "SPM030",
+                    "_": "",
+                    "t": "Essays"
+                },
+                {
+                    "l": "en",
+                    "c": "SPM040",
+                    "_": "",
+                    "t": "Updates"
+                },
+                {
+                    "l": "en",
+                    "c": "SPM050",
+                    "_": "",
+                    "t": "Special articles"
+                },
+                {
+                    "l": "en",
+                    "c": "SPM060",
+                    "_": "",
+                    "t": "Indicators"
+                },
+                {
+                    "l": "en",
+                    "c": "SPM070",
+                    "_": "",
+                    "t": "Editorial"
+                },
+                {
+                    "l": "en",
+                    "c": "SPM150",
+                    "_": "",
+                    "t": "Short papers"
+                }
+            ],
+            "v43": [
+                {
+                    "m": "ene./feb.",
+                    "a": "1997",
+                    "n": "n.1",
+                    "t": "Salud p\u00fablica M\u00e9x",
+                    "l": "es",
+                    "c": "Cuernavaca",
+                    "_": "",
+                    "v": "v.39"
+                },
+                {
+                    "m": "jan./fev.",
+                    "a": "1997",
+                    "n": "n.1",
+                    "t": "Salud p\u00fablica M\u00e9x",
+                    "l": "pt",
+                    "c": "Cuernavaca",
+                    "_": "",
+                    "v": "v.39"
+                },
+                {
+                    "m": "Jan./Feb.",
+                    "a": "1997",
+                    "n": "n.1",
+                    "t": "Salud p\u00fablica M\u00e9x",
+                    "l": "en",
+                    "c": "Cuernavaca",
+                    "_": "",
+                    "v": "vol.39"
+                }
+            ],
+            "v230": [
+                {
+                    "_": "Public Health of Mexico"
+                }
+            ],
+            "v32": [
+                {
+                    "_": "1"
+                }
+            ],
+            "v85": [
+                {
+                    "_": "nd"
+                }
+            ],
+            "v122": [
+                {
+                    "_": "15"
+                }
+            ],
+            "v880": [
+                {
+                    "_": "0036-363419970001"
+                }
+            ],
+            "v701": [
+                {
+                    "_": "1"
+                }
+            ],
+            "v151": [
+                {
+                    "_": "Salud p\u00fablica M\u00e9x"
+                }
+            ],
+            "v130": [
+                {
+                    "_": "Salud P\u00fablica de M\u00e9xico"
+                }
+            ],
+            "v42": [
+                {
+                    "_": "1"
+                }
+            ]
+        },
+        "created_at": "2001-08-08",
+        "processing_date": "2001-08-08",
+        "publication_year": "1997",
+        "publication_date": "1997-01",
+        "collection": "spa",
+        "code_title": [
+            "0036-3634"
+        ],
+        "code": "0036-363419970001",
+        "issue_type": "regular",
+        "_shard_id": "d8d458a8197b42daab954c529654a786"
+    },
+    "code_title": [
+        "0036-3634"
+    ],
+    "doi": "10.1590/S0036-36341997000100001",
+    "license": "by/3.0",
+    "applicable": "True",
+    "validated_wos": "False",
+    "citations": [],
+    "updated_at": "2017-08-29",
+    "sent_wos": "False",
+    "normalized": {
+        "article": {
+            "v70": {
+                "p": [
+                    true
+                ]
+            }
+        }
+    },
+    "code_issue": "0036-363419970001",
+    "publication_year": "1997",
+    "collection": "spa",
+    "code": "S0036-36341997000100001",
+    "section": {
+        "es": "Editorial",
+        "en": "Editorial"
+    },
+    "document_type": "editorial"
+}

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,0 +1,156 @@
+import tempfile
+import json
+import shutil
+from unittest import TestCase, mock
+from pathlib import Path
+
+from lxml import etree
+
+from documentstore_migracao.export.sps_package import SPS_Package
+from documentstore_migracao.processing import conversion
+
+
+def save_json_file(source_path, document_pid, article_metadata):
+    json_file_path = Path(source_path).joinpath(Path(document_pid + ".json"))
+    metadata = {
+        "article": article_metadata,
+    }
+    with json_file_path.open("w") as json_file:
+        json.dump(metadata, json_file)
+
+
+class TestCompletePubDate(TestCase):
+    def setUp(self):
+        self.xml = """<article specific-use="sps-1.9"><article-meta>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0074-02761962000200006</article-id>
+            {volume}
+            {issue}
+            {pub_date_collection}
+            {pub_date_pub}
+        </article-meta></article>"""
+        self.source_path = tempfile.mkdtemp(".")
+
+    def tearDown(self):
+        shutil.rmtree(self.source_path)
+
+    def test_complete_pub_date_adds_document_pubdate_if_date_not_in_xml(self):
+        volume = "<volume>50</volume>"
+        issue = "<issue>1</issue>"
+        pub_date_collection = """<pub-date date-type="collection" publication-format="electronic">
+            <year>2010</year>
+        </pub-date>"""
+        xml_txt = self.xml.format(
+            volume=volume,
+            issue=issue,
+            pub_date_collection=pub_date_collection,
+            pub_date_pub="",
+        )
+        xmltree = etree.fromstring(xml_txt)
+        xml_sps = SPS_Package(xmltree, None)
+        metadata = {
+            "v65": [{"_": "19970300"}],
+            "v223": [{"_": "20200124"}],
+        }
+        save_json_file(self.source_path, xml_sps.scielo_pid_v2, metadata)
+        with mock.patch.dict("os.environ", {"SOURCE_PATH": str(self.source_path)}):
+            conversion.complete_pub_date(xml_sps)
+        self.assertEqual(xml_sps.document_pubdate, ("2020", "01", "24"))
+        self.assertEqual(xml_sps.documents_bundle_pubdate, ("2010", "", ""))
+
+    def test_complete_pub_date_adds_creation_date_if_date_not_in_xml_and_no_document_pubdate(
+        self,
+    ):
+        volume = "<volume>50</volume>"
+        issue = "<issue>1</issue>"
+        pub_date_collection = """<pub-date date-type="collection" publication-format="electronic">
+            <year>2010</year>
+        </pub-date>"""
+        xml_txt = self.xml.format(
+            volume=volume,
+            issue=issue,
+            pub_date_collection=pub_date_collection,
+            pub_date_pub="",
+        )
+        xmltree = etree.fromstring(xml_txt)
+        xml_sps = SPS_Package(xmltree, None)
+        metadata = {
+            "v65": [{"_": "19970300"}],
+            "v93": [{"_": "20000401"}],
+        }
+        save_json_file(self.source_path, xml_sps.scielo_pid_v2, metadata)
+        with mock.patch.dict("os.environ", {"SOURCE_PATH": str(self.source_path)}):
+            conversion.complete_pub_date(xml_sps)
+        self.assertEqual(xml_sps.document_pubdate, ("2000", "04", "01"))
+        self.assertEqual(xml_sps.documents_bundle_pubdate, ("2010", "", ""))
+
+    def test_complete_pub_date_adds_update_date_if_date_not_in_xml_and_no_document_pubdate_nor_creation_date(
+        self,
+    ):
+        volume = "<volume>50</volume>"
+        issue = "<issue>1</issue>"
+        pub_date_collection = """<pub-date date-type="collection" publication-format="electronic">
+            <year>2010</year>
+        </pub-date>"""
+        xml_txt = self.xml.format(
+            volume=volume,
+            issue=issue,
+            pub_date_collection=pub_date_collection,
+            pub_date_pub="",
+        )
+        xmltree = etree.fromstring(xml_txt)
+        xml_sps = SPS_Package(xmltree, None)
+        metadata = {
+            "v65": [{"_": "19970300"}],
+            "v91": [{"_": "19990319"}],
+        }
+        save_json_file(self.source_path, xml_sps.scielo_pid_v2, metadata)
+        with mock.patch.dict("os.environ", {"SOURCE_PATH": str(self.source_path)}):
+            conversion.complete_pub_date(xml_sps)
+        self.assertEqual(xml_sps.document_pubdate, ("1999", "03", "19"))
+        self.assertEqual(xml_sps.documents_bundle_pubdate, ("2010", "", ""))
+
+    def test_complete_pub_date_fix_pubdate_if_it_is_aop(self):
+        pub_date_collection = """<pub-date date-type="collection" publication-format="electronic">
+            <year>2010</year><month>5</month><day>13</day>
+        </pub-date>"""
+        xml_txt = self.xml.format(
+            volume="",
+            issue="",
+            pub_date_collection=pub_date_collection,
+            pub_date_pub="",
+        )
+        xmltree = etree.fromstring(xml_txt)
+        xml_sps = SPS_Package(xmltree, None)
+        metadata = {
+            "v65": [{"_": "19970300"}],
+            "v223": [{"_": "20200124"}],
+        }
+        save_json_file(self.source_path, xml_sps.scielo_pid_v2, metadata)
+        with mock.patch.dict("os.environ", {"SOURCE_PATH": str(self.source_path)}):
+            conversion.complete_pub_date(xml_sps)
+        self.assertEqual(xml_sps.document_pubdate, ("2020", "01", "24"))
+        self.assertEqual(xml_sps.documents_bundle_pubdate, ("", "", ""))
+
+    def test_complete_pub_date_adds_bundle_pubdate_if_date_not_in_xml(self):
+        volume = "<volume>50</volume>"
+        issue = "<issue>1</issue>"
+        pub_date_pub = """<pub-date date-type="pub" publication-format="electronic">
+            <year>2010</year><month>5</month><day>13</day>
+        </pub-date>"""
+        xml_txt = self.xml.format(
+            volume=volume,
+            issue=issue,
+            pub_date_collection="",
+            pub_date_pub=pub_date_pub,
+        )
+        xmltree = etree.fromstring(xml_txt)
+        xml_sps = SPS_Package(xmltree, None)
+        metadata = {
+            "v65": [{"_": "19970300"}],
+            "v223": [{"_": "20200124"}],
+        }
+        save_json_file(self.source_path, xml_sps.scielo_pid_v2, metadata)
+        with mock.patch.dict("os.environ", {"SOURCE_PATH": str(self.source_path)}):
+            conversion.complete_pub_date(xml_sps)
+        self.assertEqual(xml_sps.document_pubdate, ("2010", "05", "13"))
+        self.assertEqual(xml_sps.documents_bundle_pubdate, ("1997", "03", ""))

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -5,6 +5,7 @@ from unittest import TestCase, mock
 from pathlib import Path
 
 from lxml import etree
+from xylose.scielodocument import Article
 
 from documentstore_migracao.export.sps_package import SPS_Package
 from documentstore_migracao.processing import conversion
@@ -19,138 +20,45 @@ def save_json_file(source_path, document_pid, article_metadata):
         json.dump(metadata, json_file)
 
 
-class TestCompletePubDate(TestCase):
-    def setUp(self):
-        self.xml = """<article specific-use="sps-1.9"><article-meta>
-            <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0074-02761962000200006</article-id>
-            {volume}
-            {issue}
-            {pub_date_collection}
-            {pub_date_pub}
-        </article-meta></article>"""
-        self.source_path = tempfile.mkdtemp(".")
-
-    def tearDown(self):
-        shutil.rmtree(self.source_path)
-
-    def test_complete_pub_date_adds_document_pubdate_if_date_not_in_xml(self):
-        volume = "<volume>50</volume>"
-        issue = "<issue>1</issue>"
-        pub_date_collection = """<pub-date date-type="collection" publication-format="electronic">
-            <year>2010</year>
-        </pub-date>"""
-        xml_txt = self.xml.format(
-            volume=volume,
-            issue=issue,
-            pub_date_collection=pub_date_collection,
-            pub_date_pub="",
-        )
-        xmltree = etree.fromstring(xml_txt)
-        xml_sps = SPS_Package(xmltree, None)
+class TestGetArticleDates(TestCase):
+    def test_should_return_issue_publication_date_if_it_is_presente(self):
         metadata = {
-            "v65": [{"_": "19970300"}],
-            "v223": [{"_": "20200124"}],
+            "article": {"v65": [{"_": "19970300"}], "v223": [{"_": "20200124"}],},
         }
-        save_json_file(self.source_path, xml_sps.scielo_pid_v2, metadata)
-        with mock.patch.dict("os.environ", {"SOURCE_PATH": str(self.source_path)}):
-            conversion.complete_pub_date(xml_sps)
-        self.assertEqual(xml_sps.document_pubdate, ("2020", "01", "24"))
-        self.assertEqual(xml_sps.documents_bundle_pubdate, ("2010", "", ""))
+        article = Article(metadata)
+        __, issue_pubdate = conversion.get_article_dates(article)
+        self.assertEqual(issue_pubdate, ("1997", "03", ""))
 
-    def test_complete_pub_date_adds_creation_date_if_date_not_in_xml_and_no_document_pubdate(
+    def test_should_return_document_publication_date_if_it_is_presente(self):
+        metadata = {
+            "article": {"v65": [{"_": "19970300"}], "v223": [{"_": "20200124"}],},
+        }
+        article = Article(metadata)
+        document_pubdate, __ = conversion.get_article_dates(article)
+        self.assertEqual(document_pubdate, ("2020", "01", "24"))
+
+    def test_should_return_creation_date_if_no_document_publication_date(self):
+        metadata = {
+            "article": {"v65": [{"_": "19970300"}], "v93": [{"_": "20000401"}],},
+        }
+        article = Article(metadata)
+        document_pubdate, __ = conversion.get_article_dates(article)
+        self.assertEqual(document_pubdate, ("2000", "04", "01"))
+
+    def test_should_return_update_date_if_no_document_publication_date_nor_creation_date(
         self,
     ):
-        volume = "<volume>50</volume>"
-        issue = "<issue>1</issue>"
-        pub_date_collection = """<pub-date date-type="collection" publication-format="electronic">
-            <year>2010</year>
-        </pub-date>"""
-        xml_txt = self.xml.format(
-            volume=volume,
-            issue=issue,
-            pub_date_collection=pub_date_collection,
-            pub_date_pub="",
-        )
-        xmltree = etree.fromstring(xml_txt)
-        xml_sps = SPS_Package(xmltree, None)
         metadata = {
-            "v65": [{"_": "19970300"}],
-            "v93": [{"_": "20000401"}],
+            "article": {"v65": [{"_": "19970300"}], "v91": [{"_": "19990319"}],},
         }
-        save_json_file(self.source_path, xml_sps.scielo_pid_v2, metadata)
-        with mock.patch.dict("os.environ", {"SOURCE_PATH": str(self.source_path)}):
-            conversion.complete_pub_date(xml_sps)
-        self.assertEqual(xml_sps.document_pubdate, ("2000", "04", "01"))
-        self.assertEqual(xml_sps.documents_bundle_pubdate, ("2010", "", ""))
+        article = Article(metadata)
+        document_pubdate, __ = conversion.get_article_dates(article)
+        self.assertEqual(document_pubdate, ("1999", "03", "19"))
 
-    def test_complete_pub_date_adds_update_date_if_date_not_in_xml_and_no_document_pubdate_nor_creation_date(
-        self,
-    ):
-        volume = "<volume>50</volume>"
-        issue = "<issue>1</issue>"
-        pub_date_collection = """<pub-date date-type="collection" publication-format="electronic">
-            <year>2010</year>
-        </pub-date>"""
-        xml_txt = self.xml.format(
-            volume=volume,
-            issue=issue,
-            pub_date_collection=pub_date_collection,
-            pub_date_pub="",
-        )
-        xmltree = etree.fromstring(xml_txt)
-        xml_sps = SPS_Package(xmltree, None)
+    def test_should_return_none_if_no_document_dates(self):
         metadata = {
-            "v65": [{"_": "19970300"}],
-            "v91": [{"_": "19990319"}],
+            "article": {"v65": [{"_": "19970300"}],},
         }
-        save_json_file(self.source_path, xml_sps.scielo_pid_v2, metadata)
-        with mock.patch.dict("os.environ", {"SOURCE_PATH": str(self.source_path)}):
-            conversion.complete_pub_date(xml_sps)
-        self.assertEqual(xml_sps.document_pubdate, ("1999", "03", "19"))
-        self.assertEqual(xml_sps.documents_bundle_pubdate, ("2010", "", ""))
-
-    def test_complete_pub_date_fix_pubdate_if_it_is_aop(self):
-        pub_date_collection = """<pub-date date-type="collection" publication-format="electronic">
-            <year>2010</year><month>5</month><day>13</day>
-        </pub-date>"""
-        xml_txt = self.xml.format(
-            volume="",
-            issue="",
-            pub_date_collection=pub_date_collection,
-            pub_date_pub="",
-        )
-        xmltree = etree.fromstring(xml_txt)
-        xml_sps = SPS_Package(xmltree, None)
-        metadata = {
-            "v65": [{"_": "19970300"}],
-            "v223": [{"_": "20200124"}],
-        }
-        save_json_file(self.source_path, xml_sps.scielo_pid_v2, metadata)
-        with mock.patch.dict("os.environ", {"SOURCE_PATH": str(self.source_path)}):
-            conversion.complete_pub_date(xml_sps)
-        self.assertEqual(xml_sps.document_pubdate, ("2020", "01", "24"))
-        self.assertEqual(xml_sps.documents_bundle_pubdate, ("", "", ""))
-
-    def test_complete_pub_date_adds_bundle_pubdate_if_date_not_in_xml(self):
-        volume = "<volume>50</volume>"
-        issue = "<issue>1</issue>"
-        pub_date_pub = """<pub-date date-type="pub" publication-format="electronic">
-            <year>2010</year><month>5</month><day>13</day>
-        </pub-date>"""
-        xml_txt = self.xml.format(
-            volume=volume,
-            issue=issue,
-            pub_date_collection="",
-            pub_date_pub=pub_date_pub,
-        )
-        xmltree = etree.fromstring(xml_txt)
-        xml_sps = SPS_Package(xmltree, None)
-        metadata = {
-            "v65": [{"_": "19970300"}],
-            "v223": [{"_": "20200124"}],
-        }
-        save_json_file(self.source_path, xml_sps.scielo_pid_v2, metadata)
-        with mock.patch.dict("os.environ", {"SOURCE_PATH": str(self.source_path)}):
-            conversion.complete_pub_date(xml_sps)
-        self.assertEqual(xml_sps.document_pubdate, ("2010", "05", "13"))
-        self.assertEqual(xml_sps.documents_bundle_pubdate, ("1997", "03", ""))
+        article = Article(metadata)
+        document_pubdate, __ = conversion.get_article_dates(article)
+        self.assertIsNone(document_pubdate)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -97,7 +97,7 @@ class TestExportArticle(unittest.TestCase):
     def test_ext_article_json(self, mk_ext_article):
 
         result = article.ext_article_json("S0036-36341997000100001")
-        mk_ext_article.assert_called_once_with("S0036-36341997000100001")
+        mk_ext_article.assert_called_once_with("S0036-36341997000100001", format="json")
 
     @patch("documentstore_migracao.export.article.ext_article")
     def test_ext_article_json_returns_none_if_no_ext_article(self, mk_ext_article):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -58,8 +58,19 @@ class TestProcessingConversion(unittest.TestCase):
         )
         self.assertTrue(os.path.exists(new_file_xml_path))
 
+    def test_convert_article_xml_completes_pubdate(self):
+        file_xml_path = os.path.join(SAMPLES_PATH, "S0036-36341997000100001.xml")
+        with utils.environ(
+            SOURCE_PATH=SAMPLES_PATH, CONVERSION_PATH=self.conversion_path
+        ):
+            conversion.convert_article_xml(file_xml_path)
 
+        new_file_xml_path = os.path.join(
+            self.conversion_path, "S0036-36341997000100001.es.xml"
         )
+        xmltree = etree.parse(new_file_xml_path, etree.XMLParser())
+        self.assertIsNotNone(xmltree.find('.//pub-date[@date-type="pub"]'))
+        self.assertIsNotNone(xmltree.find('.//pub-date[@date-type="collection"]'))
 
     @patch("documentstore_migracao.processing.conversion.convert_article_xml")
     def test_convert_article_ALLxml(self, mk_convert_article_xml):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,5 +1,7 @@
 import os
 import unittest
+import tempfile
+import shutil
 from lxml import etree
 from unittest.mock import patch, ANY, call, Mock, MagicMock
 
@@ -38,62 +40,25 @@ class TestProcessingExtracted(unittest.TestCase):
 
 
 class TestProcessingConversion(unittest.TestCase):
-    @patch("documentstore_migracao.processing.conversion.SPS_Package")
-    @patch("documentstore_migracao.processing.conversion.xml")
-    def test_convert_article_xml_sets_sps_and_dtd_versions(
-        self, mk_utils_xml, MockSPS_Package
-    ):
-        mk_obj_xml = MagicMock()
-        mk_obj_xmltree = MagicMock()
-        mk_obj_xmltree.getroot.return_value = mk_obj_xml
-        mk_utils_xml.loadToXML.return_value = mk_obj_xmltree
-        conversion.convert_article_xml(
-            os.path.join(SAMPLES_PATH, "S0036-36341997000100001.xml")
-        )
-        mk_obj_xml.set.assert_has_calls(
-            [call("specific-use", "sps-1.9"), call("dtd-version", "1.1")]
-        )
+    def setUp(self):
+        self.conversion_path = tempfile.mkdtemp()
 
-    @patch("documentstore_migracao.processing.conversion.SPS_Package")
-    @patch("documentstore_migracao.processing.conversion.xml")
-    def test_convert_article_xml_creates_sps_package_instance(
-        self, mk_utils_xml, MockSPS_Package
-    ):
-        mk_obj_xmltree = MagicMock()
-        mk_utils_xml.loadToXML.return_value = mk_obj_xmltree
-        conversion.convert_article_xml(
-            os.path.join(SAMPLES_PATH, "S0036-36341997000100001.xml")
+    def tearDown(self):
+        shutil.rmtree(self.conversion_path)
+
+    def test_convert_article_xml_saves_xml_obj_in_conversion_path(self):
+        file_xml_path = os.path.join(SAMPLES_PATH, "S0036-36341997000100001.xml")
+        with utils.environ(
+            SOURCE_PATH=SAMPLES_PATH, CONVERSION_PATH=self.conversion_path
+        ):
+            conversion.convert_article_xml(file_xml_path)
+
+        new_file_xml_path = os.path.join(
+            self.conversion_path, "S0036-36341997000100001.es.xml"
         )
-        MockSPS_Package.assert_called_once_with(mk_obj_xmltree)
+        self.assertTrue(os.path.exists(new_file_xml_path))
 
-    @patch("documentstore_migracao.processing.conversion.SPS_Package")
-    @patch("documentstore_migracao.processing.conversion.xml")
-    def test_convert_article_xml_calls_sps_package_transform_body(
-        self, mk_utils_xml, MockSPS_Package
-    ):
-        mk_xml_sps = MagicMock()
-        MockSPS_Package.return_value = mk_xml_sps
-        conversion.convert_article_xml(
-            os.path.join(SAMPLES_PATH, "S0036-36341997000100001.xml")
-        )
-        mk_xml_sps.transform_body.assert_called_once()
 
-    @patch("documentstore_migracao.processing.conversion.SPS_Package")
-    @patch("documentstore_migracao.processing.conversion.xml")
-    def test_convert_article_xml_calls_sps_package_transform_content(
-        self, mk_utils_xml, MockSPS_Package
-    ):
-        mk_xml_sps = MagicMock()
-        MockSPS_Package.return_value = mk_xml_sps
-        conversion.convert_article_xml(
-            os.path.join(SAMPLES_PATH, "S0036-36341997000100001.xml")
-        )
-        mk_xml_sps.transform_content.assert_called_once()
-
-    def test_convert_article_xml(self):
-
-        conversion.convert_article_xml(
-            os.path.join(SAMPLES_PATH, "S0036-36341997000100001.xml")
         )
 
     @patch("documentstore_migracao.processing.conversion.convert_article_xml")

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -1536,6 +1536,16 @@ class Test_DocumentsBundlePubdateSPS1_9(unittest.TestCase):
         self.sps_package.documents_bundle_pubdate = ("2012", "", "")
         self.assertEqual(self.sps_package.documents_bundle_pubdate, ("2012", "", ""))
 
+    def test_set_documents_bundle_pubdate_to_none(self):
+        self.xml = """<article specific-use="sps-1.9"><article-meta>
+            <pub-date publication-format="electronic" date-type="collection">
+                <year>2010</year><month>5</month></pub-date>
+        </article-meta></article>"""
+        xmltree = etree.fromstring(self.xml)
+        self.sps_package = SPS_Package(xmltree, None)
+        self.sps_package.documents_bundle_pubdate = None
+        self.assertEqual(self.sps_package.documents_bundle_pubdate, ("", "", ""))
+
 
 class Test_DocumentsBundlePubdateSPS1_8(unittest.TestCase):
     def setUp(self):
@@ -1557,6 +1567,16 @@ class Test_DocumentsBundlePubdateSPS1_8(unittest.TestCase):
         self.sps_package.documents_bundle_pubdate = ("2012", "", "")
         self.assertEqual(self.sps_package.documents_bundle_pubdate, ("2012", "", ""))
 
+    def test_set_documents_bundle_pubdate_to_none(self):
+        self.xml = """<article specific-use="sps-1.8"><article-meta>
+            <pub-date pub-type="collection">
+                <year>2010</year><month>5</month></pub-date>
+        </article-meta></article>"""
+        xmltree = etree.fromstring(self.xml)
+        self.sps_package = SPS_Package(xmltree, None)
+        self.sps_package.documents_bundle_pubdate = None
+        self.assertEqual(self.sps_package.documents_bundle_pubdate, ("", "", ""))
+
 
 class Test_DocumentsBundlePubdateSPS1_4(unittest.TestCase):
     def setUp(self):
@@ -1577,6 +1597,16 @@ class Test_DocumentsBundlePubdateSPS1_4(unittest.TestCase):
     def test_set_incomplete_documents_bundle_pubdate(self):
         self.sps_package.documents_bundle_pubdate = ("2012", "", "")
         self.assertEqual(self.sps_package.documents_bundle_pubdate, ("2012", "", ""))
+
+    def test_set_documents_bundle_pubdate_to_none(self):
+        self.xml = """<article specific-use="sps-1.4"><article-meta>
+            <pub-date pub-type="epub-ppub">
+                <year>2010</year><month>5</month></pub-date>
+        </article-meta></article>"""
+        xmltree = etree.fromstring(self.xml)
+        self.sps_package = SPS_Package(xmltree, None)
+        self.sps_package.documents_bundle_pubdate = None
+        self.assertEqual(self.sps_package.documents_bundle_pubdate, ("", "", ""))
 
 
 @mock.patch(

--- a/tests/test_xylose_converter.py
+++ b/tests/test_xylose_converter.py
@@ -1,11 +1,15 @@
 from copy import deepcopy
 import unittest
+import json
+from pathlib import Path
+
 from documentstore_migracao.utils.xylose_converter import (
     journal_to_kernel,
     issue_to_kernel,
     parse_date,
     get_journal_issns_from_issue,
     find_documents_bundles,
+    json_file_to_xylose_article,
 )
 from xylose.scielodocument import Journal, Issue
 from . import SAMPLE_ISSUES_JSON, SAMPLE_KERNEL_JOURNAL, SAMPLE_ISSUES_KERNEL
@@ -290,3 +294,14 @@ class TestFindDocumentBundles(unittest.TestCase):
         issues = [Issue({"issue": self.issue_json})]
         journal_issues = find_documents_bundles(SAMPLE_KERNEL_JOURNAL, issues)
         self.assertListEqual([], journal_issues)
+
+
+class TestJsonFileToXyloseArticle(unittest.TestCase):
+    def setUp(self):
+        self.json_file_path = Path("./tests/samples/S0036-36341997000100001.json")
+
+    def test_should_return_xylose_article(self):
+        article = json_file_to_xylose_article(self.json_file_path)
+        with self.json_file_path.open() as json_file:
+            article_data = json.load(json_file)
+            self.assertEqual(article.data, article_data)


### PR DESCRIPTION
#### O que esse PR faz?
Este PR completa datas de publicação dos documentos provenientes de HTML com os metadados extraídos do Article Meta. Assim como o XML SPS, os metadados são extraídos do Article Meta e salvos em um arquivo JSON junto com o XML. Na etapa de conversão, após a adaptação da data para a versão 1.9, os metadados são lidos utilizando o Xylose e colocados no XML, obedecendo a ordem colocada em https://github.com/scieloorg/document-store-migracao/issues/250#issuecomment-585674304.
Também foram feitas melhorias em testes unitários e correções necessárias.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
Rodando os testes unitários: `python setup.py test`, em especial:
- `tests.test_export`
- `tests.test_sps_package`
- `tests.test_conversion`
- `tests.test_processing`

OU

Utilizando o `ds_migracao`:
- Execute o comando `extract`
- Execute o comando `convert`
- Os documentos devem estar com as tags `pub-date` conforme a SPS 1.9

#### Algum cenário de contexto que queira dar?
O XML extraído do Article Meta atualmente atende à SPS 1.4 e somente um `pub-date` é retornado.

### Screenshots
N/A

#### Quais são tickets relevantes?
#250 

### Referências
N/A
