### PR TITLE
Altera import de asset HTML para preservar links quebrados na conversão

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -3471,23 +3471,24 @@ class Remote2LocalConversion:
         f, ext = os.path.splitext(href)
         new_href = os.path.basename(f)
 
-        self._update_a_href(a_link_type, new_href)
-
         if href in self.imported_files:
-            return
-
-        self.imported_files.append(href)
-
-        html_body = self._get_html_body(href)
-        if html_body is not None:
-            content_type = "html"
-            delete_tag = "REMOVE_" + content_type
-            node_content = self._create_new_element_for_imported_html_file(
-                new_href, html_body, delete_tag
-            )
-            new_p = self._create_new_p(new_href, node_content, content_type)
-            etree.strip_tags(new_p, delete_tag)
-            return new_p
+            self._update_a_href(a_link_type, new_href)
+        else:
+            self.imported_files.append(href)
+            html_body = self._get_html_body(href)
+            if html_body is None:
+                logger.info("Alterando para link para externo")
+                a_link_type.set("link-type", "asset-not-found")
+            else:
+                self._update_a_href(a_link_type, new_href)
+                content_type = "html"
+                delete_tag = "REMOVE_" + content_type
+                node_content = self._create_new_element_for_imported_html_file(
+                    new_href, html_body, delete_tag
+                )
+                new_p = self._create_new_p(new_href, node_content, content_type)
+                etree.strip_tags(new_p, delete_tag)
+                return new_p
 
     def _get_html_body(self, href):
         """

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -1905,6 +1905,22 @@ class TestConvertRemote2LocalPipe(unittest.TestCase):
         self.assertEqual(a_href_items[0].get("href"), "#a05tab01")
         self.assertEqual(a_href_items[1].get("href"), "#a05tab01")
 
+    def test_transform_preserve_original_a_href_if_html_not_found(self):
+        pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
+        text = """<root><body>
+        <p>
+        <a href="/img/revistas/az/v99nspe/html/a10tab02.htm">Table 2</a>
+        </p>
+        </body></root>"""
+        xml = etree.fromstring(text)
+
+        text, xml = pipeline.ConvertRemote2LocalPipe().transform((text, xml))
+        a_href_items = xml.findall(".//a[@href]")
+        self.assertEqual(
+            a_href_items[0].get("href"), "/img/revistas/az/v99nspe/html/a10tab02.htm"
+        )
+        self.assertEqual(a_href_items[0].get("link-type"), "asset-not-found")
+
     def test_transform_removes_repeated_imported_images(self):
         pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
         text = """<root><body>

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -1905,7 +1905,13 @@ class TestConvertRemote2LocalPipe(unittest.TestCase):
         self.assertEqual(a_href_items[0].get("href"), "#a05tab01")
         self.assertEqual(a_href_items[1].get("href"), "#a05tab01")
 
-    def test_transform_preserve_original_a_href_if_html_not_found(self):
+    @patch(
+        "documentstore_migracao.utils.convert_html_body.Remote2LocalConversion._get_html_body"
+    )
+    def test_transform_preserve_original_a_href_if_html_not_found(
+        self, mk_get_html_body
+    ):
+        mk_get_html_body.return_value = None
         pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
         text = """<root><body>
         <p>


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera a conversão do body HTML para, caso não seja possível obter o body de ativos digitais HTML, definir atributo na tag `a` como "não encontrado" e preservar o link original para possíveis correções manuais.

#### Onde a revisão poderia começar?
Em `tests/test_convert_html_body.py` para entender o que é esperado através do teste.

#### Como este poderia ser testado manualmente?
- Converta um artigo originalmente em HTML que contenha algum ativo digital em HTML e que esteja quebrado. Ex: `S1414-32832007000100005`
- Observe que o XML resultado da conversão preserva o link do ativo digital HTML não encontrado.
- Execute o mesmo teste com artigos que contenham ativos digitais em HTML que estejam corretos e a conversão deve permanecer como anteriormente.

#### Algum cenário de contexto que queira dar?
Esta é parte da correção do tícket #205

### Screenshots
N/A

#### Quais são tickets relevantes?
#210

### Referências
Nenhuma.