### PR TITLE
Adiciona migração direta para o site dos logos

### DIFF
--- a/documentstore_migracao/exceptions.py
+++ b/documentstore_migracao/exceptions.py
@@ -13,3 +13,9 @@ class XMLError(Exception):
     """ Represents errors that would block HTMLGenerator instance from
     being created.
     """
+
+
+class NoJournalInWebsiteError(Exception):
+    """Não há periódicos no site para migração dos logos. É necessário que a migração
+    dos periódicos seja feita antes da migração dos logos.
+    """

--- a/documentstore_migracao/main/__init__.py
+++ b/documentstore_migracao/main/__init__.py
@@ -6,6 +6,7 @@ import logging
 from .migrate_isis import migrate_isis_parser
 from .migrate_articlemeta import migrate_articlemeta_parser
 from .tools import tools_parser
+from .migrate_logos import migrate_logos_parser
 
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,10 @@ def main_migrate_isis():
 
 def tools():
     sys.exit(tools_parser(sys.argv[1:]))
+
+
+def main_migrate_logos():
+    sys.exit(migrate_logos_parser(sys.argv[1:]))
 
 
 if __name__ == "__main__":

--- a/documentstore_migracao/main/migrate_logos.py
+++ b/documentstore_migracao/main/migrate_logos.py
@@ -1,0 +1,39 @@
+import logging
+from argparse import ArgumentParser
+
+from documentstore_migracao.website.migrate_to_website import (
+    connect_to_databases,
+    migrate_logos_to_website,
+)
+from .base import base_parser, mongodb_parser
+
+
+logger = logging.getLogger(__name__)
+
+
+def migrate_logos_parser(args):
+    parser = ArgumentParser(
+        description="Journal Logos migration tool",
+        parents=[base_parser(args), mongodb_parser(args)]
+    )
+    parser.add_argument(
+        "--websitedb",
+        help='URI to connect at SQLite database of new website. e.g: "sqlite:////path/to/database.db"',
+        required=True,
+    )
+    parser.add_argument(
+        "--website_img_dir",
+        help='Path to website images media directory',
+        required=True,
+    )
+    args = parser.parse_args(args)
+
+    # Set log level
+    level = getattr(logging, args.loglevel.upper())
+    logger.setLevel(level)
+
+    # Create MongoDB and SQLite connections
+    sqlite_session = connect_to_databases(args.uri, args.db, args.websitedb)
+
+    migrate_logos_to_website(sqlite_session, args.website_img_dir)
+    logger.info("Logo migration complete successfully!")

--- a/documentstore_migracao/website/migrate_to_website.py
+++ b/documentstore_migracao/website/migrate_to_website.py
@@ -1,0 +1,46 @@
+import logging
+
+from mongoengine import connect
+from sqlalchemy import create_engine, Column, Integer, String, Sequence
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.declarative import declarative_base
+
+
+logger = logging.getLogger(__name__)
+
+
+Base = declarative_base()
+
+
+class Image(Base):
+    """Image Model
+    CREATE TABLE image (
+        id INTEGER NOT NULL,
+        name VARCHAR(64) NOT NULL,
+        path VARCHAR(256) NOT NULL,
+        language VARCHAR(255),
+        PRIMARY KEY (id)
+    );
+    """
+    __tablename__ = 'image'
+    id = Column(Integer, Sequence('image_id_seq'), primary_key=True)
+    name = Column(String(64), nullable=False)
+    path = Column(String(256), nullable=False)
+    language = Column(String(255))
+
+    def __repr__(self):
+        return '<Image(id="%s", name="%s", path="%s")>' % (
+            self.id, self.name, self.path
+        )
+
+
+def connect_to_databases(mongodb_uri, mongodb_db, sqlite_db):
+    """Connect to Website MongoDB and SQLite"""
+    logger.info("Connecting to %s/%s", mongodb_uri, mongodb_db)
+    connect(db=mongodb_db, host=mongodb_uri)
+
+    logger.info("Connecting to %s", sqlite_db)
+    engine = create_engine(sqlite_db)
+    Session = sessionmaker(bind=engine)
+    return Session()
+

--- a/documentstore_migracao/website/migrate_to_website.py
+++ b/documentstore_migracao/website/migrate_to_website.py
@@ -1,9 +1,14 @@
 import logging
+import os
 
 from mongoengine import connect
 from sqlalchemy import create_engine, Column, Integer, String, Sequence
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
+from opac_schema.v1.models import Journal
+
+from documentstore_migracao import config, exceptions
+from documentstore_migracao.utils import files, request
 
 
 logger = logging.getLogger(__name__)
@@ -44,3 +49,49 @@ def connect_to_databases(mongodb_uri, mongodb_db, sqlite_db):
     Session = sessionmaker(bind=engine)
     return Session()
 
+
+def migrate_logos_to_website(session, website_img_dir):
+    """Read all Journals from Website MongoDB collection and, for each one, get journal
+    logo from current website, save to website media directory, create an image record
+    in SQLite Image Table and update journal document with logo URL.
+
+    session: SQLite DB session created in `connect_to_databases`
+    website_img_dir: Website media directory
+    """
+    journals = Journal.objects.all()
+    if len(journals) == 0:
+        raise exceptions.NoJournalInWebsiteError(
+            "No journals in Website Database. Migrate Isis Journals first."
+        )
+
+    for journal in journals:
+        logger.debug("Journal acronym %s", journal.acronym)
+        logo_old_filename = "glogo.gif"
+        logo_url = "{}img/revistas/{}/glogo.gif".format(
+            config.get("STATIC_URL_FILE"), journal.acronym
+        )
+        try:
+            logger.debug("Getting Journal logo in %s", logo_url)
+            request_file = request.get(
+                logo_url, timeout=int(config.get("TIMEOUT") or 10)
+            )
+        except request.HTTPGetError as e:
+            try:
+                msg = str(e)
+            except TypeError:
+                msg = "Unknown error"
+            logger.error(msg)
+        else:
+            logo_filename =  "_".join([journal.acronym, logo_old_filename])
+            dest_path_file = os.path.join(website_img_dir, logo_filename)
+            logger.debug("Saving Journal logo in %s", dest_path_file)
+            files.write_file_binary(dest_path_file, request_file.content)
+
+            image_path = "images/%s" % logo_filename
+            logger.debug("Saving logo as image in %s", image_path)
+            session.add(Image(name=logo_filename, path=image_path))
+            session.commit()
+
+            journal.logo_url = "/media/%s" % image_path
+            logger.debug("Updating Journal with logo_url %s", journal.logo_url)
+            journal.save()

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,3 +64,5 @@ WebTest==2.0.33
 zope.deprecation==4.4.0
 zope.interface==4.6.0
 fs==2.4.5
+-e git+https://github.com/scieloorg/opac_schema.git@v2.54#egg=opac_schema
+SQLAlchemy==1.3.13

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setuptools.setup(
             ds_migracao=documentstore_migracao.main:main_migrate_articlemeta
             ds_tools=documentstore_migracao.main:tools
             migrate_isis=documentstore_migracao.main:main_migrate_isis
+            migrate_logos=documentstore_migracao.main:main_migrate_logos
         [paste.app_factory]
             main=documentstore_migracao.webserver:main
     """,

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ requires = [
     "minio",
     "tqdm",
     "fs",
+    "opac_schema",
+    "sqlalchemy",
 ]
 
 tests_require = [
@@ -48,6 +50,9 @@ setuptools.setup(
     include_package_data=True,
     extras_require={"testing": tests_require},
     install_requires=requires,
+    dependency_links=[
+        "git+https://github.com/scieloorg/opac_schema.git@v2.54#egg=opac_schema",
+    ],
     python_requires=">=3.6",
     test_suite="tests",
     classifiers=[

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,6 +5,7 @@ from documentstore_migracao.main import (
     main_migrate_articlemeta,
     main_migrate_isis,
     tools,
+    main_migrate_logos,
 )
 
 
@@ -28,4 +29,10 @@ class TestMain(unittest.TestCase):
 
         mk_process.return_value = 0
         self.assertRaises(SystemExit, tools)
+        mk_process.assert_called_once_with(["test"])
+
+    @patch("documentstore_migracao.main.migrate_logos_parser")
+    def test_main_migrate_logos(self, mk_process):
+        mk_process.return_value = 0
+        self.assertRaises(SystemExit, main_migrate_logos)
         mk_process.assert_called_once_with(["test"])

--- a/tests/test_migrate_logos.py
+++ b/tests/test_migrate_logos.py
@@ -1,0 +1,113 @@
+from unittest import TestCase, mock
+
+from documentstore_migracao.main.migrate_logos import migrate_logos_parser
+
+"""
+migrate_logos --uri mongodb://0.0.0.0:27017/ --db document-store --websitedb ../data-webapp
+
+usage: migrate_logos [-h] --uri URI --db DB --websitedb path
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --uri URI             URI to connect at MongoDB where the import will be
+                        done, e.g: "mongodb://user:password@mongodb-
+                        host/?authSource=admin"
+  --db DB               Database name to import registers
+  --websitedb path
+                        Path to SQLite Database from new website
+"""
+
+
+class TestMigrateLogosParser(TestCase):
+    @mock.patch("documentstore_migracao.main.migrate_logos.connect_to_databases")
+    @mock.patch("documentstore_migracao.main.migrate_logos.migrate_logos_to_website")
+    @mock.patch("documentstore_migracao.main.migrate_logos.base_parser")
+    @mock.patch("documentstore_migracao.main.migrate_logos.mongodb_parser")
+    @mock.patch("documentstore_migracao.main.migrate_logos.ArgumentParser")
+    def test_argument_parser_description_and_mongodb_parser(
+        self,
+        MockArgumentParser,
+        mk_mongodb_parser,
+        mk_base_parser,
+        mk_migrate_logos_to_website,
+        mk_connect_to_databases,
+    ):
+        command_args = "--uri mongodb://0.0.0.0:27017/ --db opac --websitedb ../data-webapp --website_img_dir ../data-webapp/images".split()
+        MockArgumentParser.return_value.parse_args.return_value.loglevel = "INFO"
+        migrate_logos_parser(command_args)
+        mk_mongodb_parser.assert_called_once_with(command_args)
+        MockArgumentParser.assert_called_once_with(
+            description="Journal Logos migration tool",
+            parents=[mk_base_parser.return_value, mk_mongodb_parser.return_value]
+        )
+
+    @mock.patch("documentstore_migracao.main.migrate_logos.connect_to_databases")
+    @mock.patch("documentstore_migracao.main.migrate_logos.migrate_logos_to_website")
+    @mock.patch("documentstore_migracao.main.migrate_logos.ArgumentParser")
+    def test_calls_parser_parse_args_with_command_args(
+        self, MockArgumentParser, migrate_logos_to_website, mk_connect_to_databases
+    ):
+        mk_parser = mock.MagicMock(name="MockArgParser")
+        mk_parser.parse_args.return_value.loglevel = "INFO"
+        MockArgumentParser.return_value = mk_parser
+        command_args = "--uri mongodb://0.0.0.0:27017/ --db opac --websitedb ../data-webapp --website_img_dir ../data-webapp/images".split()
+        migrate_logos_parser(command_args)
+        mk_parser.parse_args.assert_called_once_with(command_args)
+
+    @mock.patch("documentstore_migracao.main.migrate_logos.connect_to_databases")
+    @mock.patch("documentstore_migracao.main.migrate_logos.migrate_logos_to_website")
+    @mock.patch("documentstore_migracao.main.migrate_logos.ArgumentParser")
+    def test_adds_website_db_argument(
+        self, MockArgumentParser, mk_migrate_logos_to_website, mk_connect_to_databases
+    ):
+        mk_parser = mock.MagicMock(name="MockArgParser")
+        mk_parser.parse_args.return_value.loglevel = "INFO"
+        MockArgumentParser.return_value = mk_parser
+        command_args = "--uri mongodb://0.0.0.0:27017/ --db opac --websitedb ../data-webapp --website_img_dir ../data-webapp/images".split()
+        migrate_logos_parser(command_args)
+        mk_parser.add_argument.assert_any_call(
+            "--websitedb",
+            help='URI to connect at SQLite database of new website. e.g: "sqlite:////path/to/database.db"',
+            required=True,
+        )
+
+    @mock.patch("documentstore_migracao.main.migrate_logos.connect_to_databases")
+    @mock.patch("documentstore_migracao.main.migrate_logos.migrate_logos_to_website")
+    @mock.patch("documentstore_migracao.main.migrate_logos.ArgumentParser")
+    def test_adds_website_img_dir_argument(
+        self, MockArgumentParser, mk_migrate_logos_to_website, mk_connect_to_databases
+    ):
+        mk_parser = mock.MagicMock(name="MockArgParser")
+        mk_parser.parse_args.return_value.loglevel = "INFO"
+        MockArgumentParser.return_value = mk_parser
+        command_args = "--uri mongodb://0.0.0.0:27017/ --db opac --websitedb ../data-webapp --website_img_dir ../data-webapp/images".split()
+        migrate_logos_parser(command_args)
+        mk_parser.add_argument.assert_any_call(
+            "--website_img_dir",
+            help='Path to website images media directory',
+            required=True,
+        )
+
+    @mock.patch("documentstore_migracao.main.migrate_logos.connect_to_databases")
+    @mock.patch("documentstore_migracao.main.migrate_logos.migrate_logos_to_website")
+    @mock.patch("documentstore_migracao.main.migrate_logos.ArgumentParser.error")
+    def test_no_mongodb_parser_args(
+        self, mk_parser_error, mk_migrate_logos_to_website, mk_connect_to_databases
+    ):
+        command_args = "--websitedb ../data-webapp --website_img_dir ../data-webapp/images".split()
+        migrate_logos_parser(command_args)
+        mk_parser_error.assert_any_call(
+            "the following arguments are required: --uri, --db"
+        )
+
+    @mock.patch("documentstore_migracao.main.migrate_logos.connect_to_databases")
+    @mock.patch("documentstore_migracao.main.migrate_logos.migrate_logos_to_website")
+    @mock.patch("documentstore_migracao.main.migrate_logos.ArgumentParser.error")
+    def test_no_website_args(
+        self, mk_parser_error, mk_migrate_logos_to_website, mk_connect_to_databases
+    ):
+        command_args = "--uri mongodb://0.0.0.0:27017/ --db opac".split()
+        migrate_logos_parser(command_args)
+        mk_parser_error.assert_any_call(
+            "the following arguments are required: --websitedb, --website_img_dir"
+        )

--- a/tests/test_migrate_to_website.py
+++ b/tests/test_migrate_to_website.py
@@ -1,0 +1,95 @@
+import tempfile
+import shutil
+import os
+from unittest import TestCase, mock
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from documentstore_migracao import exceptions
+from documentstore_migracao.utils import request
+from documentstore_migracao.website import migrate_to_website
+from documentstore_migracao.website.migrate_to_website import Base, Image
+
+
+class TestMigrateLogosToWebsite(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.bind = cls.engine
+        Base.metadata.create_all()
+
+    def setUp(self):
+        Session = sessionmaker(bind=self.engine)
+        self.session = Session()
+        self.website_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.website_dir)
+
+    @mock.patch("documentstore_migracao.website.migrate_to_website.Journal")
+    def test_raises_error_if_no_journals(self, MockJournal):
+        MockJournal.objects.all.return_value = []
+        self.assertRaises(
+            exceptions.NoJournalInWebsiteError,
+            migrate_to_website.migrate_logos_to_website,
+            self.session,
+            self.website_dir
+        )
+
+    @mock.patch("documentstore_migracao.website.migrate_to_website.logger")
+    @mock.patch("documentstore_migracao.website.migrate_to_website.request.get")
+    @mock.patch("documentstore_migracao.website.migrate_to_website.Journal")
+    def test_logs_error_if_logo_url_in_curent_website_not_found(
+        self, MockJournal, mk_request_get, MockLogger
+    ):
+        MockJournal.objects.all.return_value = [mock.MagicMock()]
+        mk_request_get.side_effect = request.HTTPGetError("HTTP Get Error")
+        migrate_to_website.migrate_logos_to_website(self.session, self.website_dir)
+        MockLogger.error.assert_any_call("HTTP Get Error")
+
+    @mock.patch("documentstore_migracao.website.migrate_to_website.request.get")
+    @mock.patch("documentstore_migracao.website.migrate_to_website.Journal")
+    def test_no_updates_if_logo_url_in_curent_website_not_found(
+        self, MockJournal, mk_request_get
+    ):
+        MockedJournal = mock.MagicMock()
+        MockJournal.objects.all.return_value = [MockedJournal]
+        mk_request_get.side_effect = request.HTTPGetError("HTTP Get Error")
+        migrate_to_website.migrate_logos_to_website(self.session, self.website_dir)
+        MockedJournal.save.assert_not_called()
+
+    @mock.patch("documentstore_migracao.website.migrate_to_website.request.get")
+    @mock.patch("documentstore_migracao.website.migrate_to_website.Journal")
+    def test_saves_image_file_in_website_dir(self, MockJournal, mk_request_get):
+        MockedJournal = mock.MagicMock(acronym="test")
+        MockJournal.objects.all.return_value = [MockedJournal]
+        MockedResponse = mock.MagicMock(content=b"123Image")
+        mk_request_get.return_value = MockedResponse
+        migrate_to_website.migrate_logos_to_website(self.session, self.website_dir)
+        self.assertTrue(
+            os.path.isfile(os.path.join(self.website_dir, "test_glogo.gif"))
+        )
+
+    @mock.patch("documentstore_migracao.website.migrate_to_website.request.get")
+    @mock.patch("documentstore_migracao.website.migrate_to_website.Journal")
+    def test_adds_image_record_in_sqlite_db(self, MockJournal, mk_request_get):
+        MockedJournal = mock.MagicMock(acronym="test")
+        MockJournal.objects.all.return_value = [MockedJournal]
+        MockedResponse = mock.MagicMock(content=b"123Image")
+        mk_request_get.return_value = MockedResponse
+        migrate_to_website.migrate_logos_to_website(self.session, self.website_dir)
+        q = self.session.query(Image).filter_by(name="test_glogo.gif").\
+            filter_by(path="images/test_glogo.gif").first()
+        self.assertIsNotNone(q)
+
+    @mock.patch("documentstore_migracao.website.migrate_to_website.request.get")
+    @mock.patch("documentstore_migracao.website.migrate_to_website.Journal")
+    def test_updates_journal_with_logo_url(self, MockJournal, mk_request_get):
+        MockedJournal = mock.MagicMock(acronym="test")
+        MockJournal.objects.all.return_value = [MockedJournal]
+        MockedResponse = mock.MagicMock(content=b"123Image")
+        mk_request_get.return_value = MockedResponse
+        migrate_to_website.migrate_logos_to_website(self.session, self.website_dir)
+        self.assertEqual(MockedJournal.logo_url, "/media/images/test_glogo.gif")
+        MockedJournal.save.assert_called_once()


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona a capacidade de migrar os logos do site atual para o site novo, evitando que eles sejam cadastrados manualmente.
Ao rodar o comando de migração, são lidos os periódicos cadastrados no MongoDB do site novo e, para cada um deles, é obtido o logo do site atual, salva-o no diretório de mídias do site, cadastra na tabela image do banco SQLite e atualiza a URL da imagem do logo do periódico no MongoDB.
Caso não exista periódicos no site, um erro é exibido.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
Tendo uma instância do OPAC em funcionamento:
- Instale a nova versão com o `setup.py`
- Execute o comando `migrate_logos`. Para informações de utilização, use `-h`
- Caso não exista periódicos no site, observe que um erro é exibido ao executar o comando
- Com os periódicos migrados:
  - Acesse o admin do site em Assets > Images e os logos devem ser exibidos na lista
  - Acesse a home dos periódicos e verifique que os logos dos periódicos são exibidos no cabeçalho

#### Algum cenário de contexto que queira dar?
O site novo mantém os logos em um cadastro de imagens, que são armazenadas em arquivos no diretório de mídias. Este cadastro é mantido em um banco de dados SQLite e os arquivos em um diretório configurável. Para a exibição do logo do periódico nos cabeçalhos do site, é lida a URL do logo no cadastro de periódicos, mantido em uma coleção no MongoDB.
Pelo fato da pré-visualização das imagens na interface de administração serem feitas hoje através do upload de arquivos via formulário de cadastro, não é possível visualizar as imagens migradas.

### Screenshots
N/A

#### Quais são tickets relevantes?
#123

### Referências
Documentação do SQLAlchemy: https://docs.sqlalchemy.org/
