### PR TITLE
Remove `a[@name]` se é âncora do topo do documento

### DIFF
--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -689,6 +689,30 @@ class TestEvaluateElementAToDeleteOrMarkAsFnLabelPipe(unittest.TestCase):
         self.assertEqual(len(xml.findall(".//a[@href]")), 3)
         self.assertEqual(etree.tostring(xml), text)
 
+    def test_pipe_remove_a_name_and_a_href(self):
+        """
+        Remove
+        <a name="top" id="top"/>
+        <a href="#top"/>
+
+        de
+        <root>
+        <a name="top" id="top"/>
+        <a href="#top"/>
+        </root>
+        """
+        text = b"""
+        <root>
+        <a name="top" id="top"/>
+        <a href="#top"/>
+        </root>
+        """.strip()
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertEqual(len(xml.findall(".//a[@name]")), 0)
+        self.assertEqual(len(xml.findall(".//a[@href]")), 0)
+        self.assertEqual(etree.tostring(xml), b'<root>\n        \n        \n        </root>')
+
     def test_pipe_remove_id_duplicated(self):
         text = """<root>
         <a id="B1" name="B1">Texto 1</a><p>Texto 2</p>


### PR DESCRIPTION

#### O que esse PR faz?
Remove `a[@name]` se é âncora do topo do documento

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
`ds_migracao convert --file xml/source/S0102-67202007000100001.xml`

Outros arquivos similares
[source.zip](https://github.com/scieloorg/document-store-migracao/files/4288601/source.zip)

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
**antes:**

`fn` não deveria existir

<img width="794" alt="Captura de Tela 2020-03-04 às 13 57 08" src="https://user-images.githubusercontent.com/505143/75903289-202ce900-5e20-11ea-9467-f4fb7518d0df.png">

`xref` não deveria existir
<img width="572" alt="Captura de Tela 2020-03-04 às 13 57 21" src="https://user-images.githubusercontent.com/505143/75903265-17d4ae00-5e20-11ea-8156-e677fcc405f6.png">


**depois:**

Não gerou o `<fn>`

<img width="747" alt="Captura de Tela 2020-03-04 às 13 55 48" src="https://user-images.githubusercontent.com/505143/75903331-291dba80-5e20-11ea-8182-24e11838f9ec.png">

Removido o `xref`
<img width="597" alt="Captura de Tela 2020-03-04 às 13 56 13" src="https://user-images.githubusercontent.com/505143/75903318-26bb6080-5e20-11ea-986b-afdb85ed5b25.png">


#### Quais são tickets relevantes?
#259

### Referências
n/a
