### PR TITLE
Move os agradecimentos do body para o back

### DIFF
--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -1924,7 +1924,9 @@ class TestMoveAcknowledgementsFromBodyToBack(unittest.TestCase):
                 <p></p>
             </body>
         </article>"""
-        xmltree = etree.fromstring(self.xml)
+        xmltree = etree.fromstring(
+            self.xml, parser=etree.XMLParser(remove_blank_text=True, no_network=True)
+        )
         self.sps_package = SPS_Package(xmltree, None)
 
     def test_body_without_acknowledgements(self):
@@ -1959,7 +1961,9 @@ class TestDoNotMoveAcknowledgementWordFromBodyText(unittest.TestCase):
                 <p>Texto de teste.</p>
             </body>
         </article>"""
-        xmltree = etree.fromstring(self.xml)
+        xmltree = etree.fromstring(
+            self.xml, parser=etree.XMLParser(remove_blank_text=True, no_network=True)
+        )
         self.sps_package = SPS_Package(xmltree, None)
 
     def test_body_with_acknowledgement_in_body_content(self):
@@ -1977,15 +1981,24 @@ class TestMoveAcknowledgementsFromBodyToExistingBack(unittest.TestCase):
     def setUp(self):
         self.xml = """<article specific-use="sps-1.9" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="pt">
             <body>
-                <p>AGRADECIMENTO</p>
+                <p><bold>Subtítulo do Texto</bold></p>
                 <p></p>
-                <p>Ao Fundo de Amparo à Pesquisa</p>
+                <p>O agradecimento é uma expressão de reconhecimento de uma ação.</p>
+                <p>Texto de teste.</p>
+                <p>
+                    <font face="Verdana, Arial, Helvetica, sans-serif" size="3">AGRADECIMENTO</font>
+                </p>
+                <p></p>
+                <p>
+                    <font face="Verdana, Arial, Helvetica, sans-serif" size="2">Ao Fundo de Amparo à Pesquisa</font></p>
             </body>
             <back>
                 <notes></notes>
             </back>
         </article>"""
-        xmltree = etree.fromstring(self.xml)
+        xmltree = etree.fromstring(
+            self.xml, parser=etree.XMLParser(remove_blank_text=True, no_network=True)
+        )
         self.sps_package = SPS_Package(xmltree, None)
 
     def test_body_without_acknowledgements(self):
@@ -1994,7 +2007,7 @@ class TestMoveAcknowledgementsFromBodyToExistingBack(unittest.TestCase):
         body_txt = etree.tostring(body_tag).decode("utf-8")
         self.assertNotIn("AGRADECIMENTO", body_txt)
         self.assertNotIn("Ao Fundo de Amparo à Pesquisa", body_txt)
-        self.assertEqual(len(body_tag.getchildren()), 0)
+        self.assertEqual(len(body_tag.getchildren()), 4)
 
     def test_existing_back_with_acknowledgements(self):
         self.sps_package._move_acknowledgements_from_body_to_back()
@@ -2029,7 +2042,9 @@ class TestMoveAcknowledgementsFromBodyToBackWithSubArticle(unittest.TestCase):
                 </body>
             </sub-article>
         </article>"""
-        xmltree = etree.fromstring(self.xml)
+        xmltree = etree.fromstring(
+            self.xml, parser=etree.XMLParser(remove_blank_text=True, no_network=True)
+        )
         self.sps_package = SPS_Package(xmltree, None)
 
     def test_article_body_without_acknowledgements(self):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR tem como objetivo mover os agradecimentos do body para o back, focando em mantê-los no XML mesmo com o body removido. A estratégia usada aqui é tentar identificar a presença de agradecimentos no `body` do documento através do título. Esta estratégia tem problemas com agradecimentos que não sejam em um dos idiomas oficiais do SciELO. Ao encontrar o título, ele é retirado do `body` e o primeiro parágrafo contendo texto é movido para o `back`, em uma tag `ack`.

#### Onde a revisão poderia começar?
Em `documentstore_migracao/export/sps_package.py`

#### Como este poderia ser testado manualmente?
- Converta um artigo que tenha o texto completo em PDF. Ex.: http://www.scielo.br/scielo.php?script=sci_arttext&pid=S1807-86212008000100001&lng=en&nrm=iso
- Verifique o XML convertido. Os agradecimentos devem estar no `back`
- Efetue o teste em artigos com traduções.

#### Algum cenário de contexto que queira dar?
Com a remoção do `body` de todo e qualquer documento que tenha o texto "Texto completo disponível apenas em pdf", não foi considerado que haveriam conteúdos neles além do texto citado, como os agradecimentos.

### Screenshots
N/A

#### Quais são tickets relevantes?
#265

### Referências
.
