### PR TITLE
Adiciona comando para checar a dispnibilidade de Artigos após a migração

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 It is a tool specifically built to migrate your SciELO collection to a new platform named SciELO Publishing Framework. Those next topics must contain more information about the way to operate this engine.
 
+## Topics
+
+- [Quality assurance](quality-assurance.md)
+
 ### FAQ
 
 - **Q**: During the conversion step the Python process crash.

--- a/docs/quality-assurance.md
+++ b/docs/quality-assurance.md
@@ -1,0 +1,38 @@
+
+# Quality Assurance
+After migrating the collection you should verify if the process worked as expected. This guide assists you to verify if articles are not available at the new Website.
+
+## Verifying articles' availability at the new Website
+
+Use a list containing the articles identifiers (also known as PID) that you want to check. Also, you need to provide an URL that is used to check if articles are accessible. For example, you can define certain URL templates:
+
+- `http://www.scielo.br/article/\$id`.
+- `http://www.scielo.br/scielo.php?script=sci_arttext&pid=\$id`.
+
+The `$id` in the URLs is used to replace identifiers collected in the first step (the backslash is used to escape `$` in Linux terminal).
+
+### Example
+
+We made one list containing five identifiers (aka PIDs), see:
+
+```shell
+$ cat articles_identifiers.txt
+```
+```
+S0044-59672004000100001
+S0044-59672004000100002
+S0044-59672004000100003
+S0044-59672004000100004
+S0044-59672004000100005
+```
+So let's check if they are available in the new Website:
+
+```shell
+ds_migracao quality articles_identifiers.txt "http://new-website.scielo.br/article/\$id"
+``` 
+
+If all is well, no message will be displayed in the terminal. Otherwise, manually check what happened to all articles reported as missing. Be free to explore other options in the tool, execute:
+
+```shell
+ds_migracao quality --help
+```

--- a/documentstore_migracao/main/migrate_articlemeta.py
+++ b/documentstore_migracao/main/migrate_articlemeta.py
@@ -6,6 +6,7 @@ from .base import base_parser, minio_parser, mongodb_parser
 
 from documentstore_migracao import config
 from documentstore_migracao.utils.build_ps_package import BuildPSPackage
+from documentstore_migracao.utils import quality_checker
 
 from documentstore_migracao.processing import (
     extracted,
@@ -203,6 +204,27 @@ def migrate_articlemeta_parser(sargs):
         help="Override old mixed citations in XML file",
     )
 
+    quality_parser = subparsers.add_parser(
+        "quality", help="Help to check the quality of the migration process.",
+    )
+
+    quality_parser.add_argument(
+        "pids",
+        help="File containg a list of pids to check.",
+        type=argparse.FileType("r"),
+    )
+
+    quality_parser.add_argument(
+        "--output",
+        help="Path to the output file that will contain URLs unavailable.",
+        type=argparse.FileType("a"),
+    )
+
+    quality_parser.add_argument(
+        "target",
+        help='Define an URL template for target Website (e.g "http://www.scielo.br/article/\$id"',
+    )
+
     ################################################################################################
     args = parser.parse_args(sargs)
 
@@ -278,9 +300,11 @@ def migrate_articlemeta_parser(sargs):
             override=args.override,
         )
 
-    else:
-        raise SystemExit(
-            "Vc deve escolher algum parametro, ou '--help' ou '-h' para ajuda"
+    elif args.command == "quality":
+        quality_checker.check_documents_availability_in_website(
+            args.pids.readlines(), args.target, args.output
         )
+    else:
+        parser.print_help()
 
     return 0

--- a/documentstore_migracao/utils/quality_checker.py
+++ b/documentstore_migracao/utils/quality_checker.py
@@ -1,0 +1,87 @@
+import logging
+import string
+from typing import IO, List
+
+import requests
+from tqdm import tqdm
+
+from documentstore_migracao import config
+from documentstore_migracao.utils import DoJobsConcurrently
+
+logger = logging.getLogger(__name__)
+
+
+def check_documents_availability_in_website(
+    pids: List[str], target_string: str, output: IO = None
+) -> None:
+
+    """ Dada uma lista de pids, esta função verifica no site informado quais
+    pids não estão disponíveis.
+    
+    Params:
+        pids (List[str]): Lista de pids para verificar.
+        target_string (str): Endereço da página de artigo no site algo.
+        output (IO): Arquivo onde as URLs não disponíveis serão registradas.
+
+    Return:
+        None
+    """
+
+    template = string.Template(target_string)
+
+    if "$id" not in target_string:
+        return logger.error(
+            "The target string must contain a $id variable. If you are facing"
+            "troubles try to scape the variable e.g '\$id'."
+        )
+
+    def access_website_and_report(url, output, poison_pill):
+        """Acessa uma URL e reporta o seu status de resposta"""
+
+        if poison_pill.poisoned:
+            return
+
+        response = requests.head(url)
+
+        if response.status_code not in (200, 301, 302):
+            logger.error(
+                "The URL '%s' is not available. Returned the status code '%s'.",
+                url,
+                response.status_code,
+            )
+
+            if output is not None:
+                try:
+                    output.write(url + "\n")
+                except IOError as exc:
+                    logger.error(
+                        "Cannot write in the file. The exception '%s' was raided ", exc
+                    )
+
+    jobs = [
+        {"url": template.substitute({"id": pid.strip()}), "output": output}
+        for pid in pids
+    ]
+
+    with tqdm(total=len(jobs)) as pbar:
+
+        def update_bar(pbar=pbar):
+            pbar.update(1)
+
+        def exception_callback(exception, job, logger=logger, output=output):
+            logger.error(
+                "Could not check availability for URL '%s'. The following exception "
+                "was raised: '%s'.",
+                job["url"],
+                exception,
+            )
+
+            logger.exception(exception)
+
+        DoJobsConcurrently(
+            access_website_and_report,
+            jobs,
+            max_workers=int(config.get("THREADPOOL_MAX_WORKERS")),
+            exception_callback=exception_callback,
+            update_bar=update_bar,
+        )

--- a/tests/test_migrate_articlemeta.py
+++ b/tests/test_migrate_articlemeta.py
@@ -95,8 +95,3 @@ class TestMigrateProcess(unittest.TestCase):
             session_db=ANY, file_documents=ANY, file_journals=ANY
         )
 
-    def test_not_arg(self):
-
-        with self.assertRaises(SystemExit) as cm:
-            migrate_articlemeta_parser([])
-            self.assertEqual("Vc deve escolher algum parametro", str(cm.exception))


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request adiciona um comando que ajuda a verificação de artigos não importados em uma instância.

#### Onde a revisão poderia começar?
- `documentstore_migracao/main/migrate_articlemeta.py`

#### Como este poderia ser testado manualmente?

Para testar este pull request manualmente, deve-se:
- Obter uma lista de pids migrados ou não para uma instância (dsteste);
- Executar o comando `ds_migracao quality arquivo-de-pids.txt "http://dsteste.scielo.br/article/\$id"`;

- Observar quais artigos não estão disponíveis na instância indicada.

#### Algum cenário de contexto que queira dar?

É com muita vergonha que vos digo: não criei testes para este pull request. Não consegui encontrar um modo fácil de criar testes para este PR visto que a funcionalidade em si é dada apenas por realizar requisições HTTP, então seria necessário gerar mocks e mais mocks, perdão.

PS2: Por favor verificar a documentação que foi adicionada.

### Screenshots
N/A

#### Quais são tickets relevantes?
close #279 

### Referências
N/A

