### PR TITLE
Corrige relacionamento entre documentos e fascículo

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -339,13 +339,16 @@ class SPS_Package:
 
     @property
     def supplement(self):
-        issue = dict(self.parse_article_meta).get("issue")
-        if issue:
-            if "s" in issue and "spe" not in issue:
-                if "-s" in issue:
-                    return issue[issue.find("-s") + 2 :]
-                if issue.startswith("s"):
-                    return issue[1:]
+        if self.article_meta is not None:
+            issue_tag = self.article_meta.find("./issue")
+            if issue_tag is not None:
+                issue_tag_text = issue_tag.text.strip()
+                lower_value = issue_tag_text.lower()
+                if "sup" in lower_value:
+                    issue_words = lower_value.split()
+                    if "sup" in issue_words[-1]:    # suppl "0"
+                        return "0"
+                    return issue_tag_text.split()[-1]
 
     @property
     def year(self):

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -325,14 +325,17 @@ class SPS_Package:
 
     @property
     def number(self):
-        issue = dict(self.parse_article_meta).get("issue")
-        if issue:
-            if "s" in issue and "spe" not in issue:
-                if "-s" in issue:
-                    return issue[: issue.find("-s")]
-                if issue.startswith("s"):
-                    return None
-        return issue
+        if self.article_meta is not None:
+            issue_tag = self.article_meta.find("./issue")
+            if issue_tag is not None:
+                issue_tag_text = issue_tag.text.strip()
+                lower_value = issue_tag_text.lower()
+                if "sup" in lower_value:
+                    index = lower_value.find("sup")
+                    if index == 0:  # starts with "s"
+                        return None
+                    issue_tag_text = issue_tag_text[:index].strip()
+                return "".join(issue_tag_text.split())
 
     @property
     def supplement(self):

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -411,7 +411,7 @@ class Test_SPS_Package_VolNumFpageLpage(unittest.TestCase):
         self.assertEqual(self.sps_package.supplement, None)
 
     def test_number(self):
-        self.assertEqual(self.sps_package.number, "05")
+        self.assertEqual(self.sps_package.number, "5")
 
     def test_package_name_vol_num_fpage(self):
         self.assertEqual(
@@ -601,7 +601,7 @@ class Test_SPS_Package_VolNumSpeFpageLpage(unittest.TestCase):
         self.assertEqual(self.sps_package.supplement, None)
 
     def test_number(self):
-        self.assertEqual(self.sps_package.number, "05-spe")
+        self.assertEqual(self.sps_package.number, "5spe")
 
     def test_package_name_vol_num_spe_fpage(self):
         self.assertEqual(
@@ -662,6 +662,9 @@ class Test_SPS_Package_VolSpeNumFpageLpage(unittest.TestCase):
         self.assertEqual(
             self.sps_package.package_name, "1234-5678-acron-volume-spenum-fpage-lpage"
         )
+
+    def test_number(self):
+        self.assertEqual(self.sps_package.number, "spenum")
 
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, False)
@@ -894,7 +897,7 @@ class Test_SPS_Package_VolNumSuplFpageLpage(unittest.TestCase):
         self.assertEqual(self.sps_package.supplement, "0")
 
     def test_number(self):
-        self.assertEqual(self.sps_package.number, "02")
+        self.assertEqual(self.sps_package.number, "2")
 
     def test_package_name_vol_num_suppl_fpage(self):
         self.assertEqual(

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -833,7 +833,7 @@ class Test_SPS_Package_VolSuplAFpageLpage(unittest.TestCase):
         )
 
     def test_supplement(self):
-        self.assertEqual(self.sps_package.supplement, "a")
+        self.assertEqual(self.sps_package.supplement, "A")
 
     def test_number(self):
         self.assertIsNone(self.sps_package.number)
@@ -841,6 +841,67 @@ class Test_SPS_Package_VolSuplAFpageLpage(unittest.TestCase):
     def test_package_name_vol_suppl_a_fpage(self):
         self.assertEqual(
             self.sps_package.package_name, "1234-5678-acron-volume-sa-fpage-lpage"
+        )
+
+    def test_is_only_online_publication(self):
+        self.assertEqual(self.sps_package.is_only_online_publication, False)
+
+    def test_order_meta(self):
+        self.assertEqual(
+            self.sps_package.order_meta,
+            (
+                ("other", "00006"),
+                ("fpage", "fpage"),
+                ("lpage", "lpage"),
+                ("documents_bundle_pubdate", ("2010", "", "")),
+                ("document_pubdate", ("", "", "")),
+                ("elocation-id", ""),
+            ),
+        )
+
+    def test_order(self):
+        self.assertEqual(
+            self.sps_package.order,
+            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
+        )
+
+    def test_is_ahead_of_print_false(self):
+        self.assertFalse(self.sps_package.is_ahead_of_print)
+
+
+class Test_SPS_Package_VolSuplSpeFpageLpage(unittest.TestCase):
+    def setUp(self):
+        article_meta_xml = """<volume>volume</volume>
+            <issue>Suplemento spe</issue>
+            <fpage>fpage</fpage>
+            <lpage>lpage</lpage>
+            """
+        self.sps_package = sps_package(article_meta_xml)
+
+    def test_parse_article_meta_vol_suppl_a_fpage(self):
+        self.assertEqual(
+            self.sps_package.parse_article_meta,
+            [
+                ("volume", "volume"),
+                ("issue", "sspe"),
+                ("fpage", "fpage"),
+                ("lpage", "lpage"),
+                ("year", "2010"),
+                ("doi", "S0074-02761962000200006"),
+                ("publisher-id", "S0074-02761962000200006"),
+                ("other", "00006"),
+            ],
+        )
+
+    def test_supplement(self):
+        self.assertEqual(self.sps_package.supplement, "spe")
+
+    def test_number(self):
+        self.assertIsNone(self.sps_package.number)
+
+    def test_package_name_vol_suppl_a_fpage(self):
+        self.assertEqual(
+            self.sps_package.package_name, "1234-5678-acron-volume-sspe-fpage-lpage"
         )
 
     def test_is_only_online_publication(self):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR resolve a origem do problema da criação do arquivo JSON gerado pelo comando `ds_migracao import`.
Basicamente, altera os retornos das propriedades `number` e `supplement` do `SPS_Package`, que tentam retornar o dado mais próximo possível do que está representado no XML, tendo em vista que as duas são extraídas da mesma tag: `article_meta/issue`.
Também altera leitura de JSON de saída do comando `import` do `ds_migracao` durante a execução do comando `ds_migracao link_documents_issues` para obter os dados corretamente.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
- Empacote artigos órfãos apontados no issue #274 (alguns exemplos no anexo [1])
- Execute o comando `ds_migracao import`
- Verifique o JSON de saída do comando anterior. O número e o suplemento devem estar representados como no XML importado
- Execute o comando `ds_migracao link_documents_issues`
- Ao final, os documentos deverão estar relacionados em `items` dos respectivos `bundles` no Kernel.

#### Algum cenário de contexto que queira dar?
N/A.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#274

### Referências

### Anexo
[[1] documentos-orfaos-pids.txt](https://github.com/scieloorg/document-store-migracao/files/4348806/documentos-orfaos-pids.txt)

