### PR TITLE
Corrige os XML que contém "menu" das seções no body

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -2281,17 +2281,18 @@ class ConvertElementsWhichHaveIdPipeline(object):
 
     class InsertSectionChildrenPipe(plumber.Pipe):
 
-        def _create_children(self, node):
+        def _create_children(self, node, last):
             remove_items = []
             next = node
             while True:
                 next = next.getnext()
-                print(next)
                 if next is None:
                     break
-                print(next.tag)
                 if next.tag == "sec":
                     break
+                if node is last:
+                    if len(node.getchildren()) > 1:
+                        break
                 node.append(deepcopy(next))
                 remove_items.append(next)
             for item in remove_items:
@@ -2300,8 +2301,9 @@ class ConvertElementsWhichHaveIdPipeline(object):
 
         def transform(self, data):
             raw, xml = data
-            for sec in xml.findall(".//sec"):
-                self._create_children(sec)
+            sections = xml.findall(".//sec")
+            for sec in sections:
+                self._create_children(sec, sections[-1])
             return data
 
     class AssetElementFixPositionPipe(plumber.Pipe):

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1403,6 +1403,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
             self.DeduceAndSuggestConversionPipe(),
             self.ApplySuggestedConversionPipe(),
             self.CreateSectionElemetWithSectionTitlePipe(),
+            self.InsertSectionChildrenPipe(),
             self.AssetElementFixPositionPipe(),
             self.CreateDispFormulaPipe(),
             self.AssetElementAddContentPipe(),
@@ -2276,6 +2277,31 @@ class ConvertElementsWhichHaveIdPipeline(object):
                 self._create_sec(sec)
             for sec in xml.findall(".//ordinary-sec"):
                 self._create_sec(sec)
+            return data
+
+    class InsertSectionChildrenPipe(plumber.Pipe):
+
+        def _create_children(self, node):
+            remove_items = []
+            next = node
+            while True:
+                next = next.getnext()
+                print(next)
+                if next is None:
+                    break
+                print(next.tag)
+                if next.tag == "sec":
+                    break
+                node.append(deepcopy(next))
+                remove_items.append(next)
+            for item in remove_items:
+                parent = item.getparent()
+                parent.remove(item)
+
+        def transform(self, data):
+            raw, xml = data
+            for sec in xml.findall(".//sec"):
+                self._create_children(sec)
             return data
 
     class AssetElementFixPositionPipe(plumber.Pipe):

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -52,7 +52,6 @@ def get_sectype(titles):
         resp = difflib.get_close_matches(item, possibilities, n=1, cutoff=0.6)
         if resp:
             results.append(SECTIONS_CODE_AND_TITLES.get(resp[0]))
-    print(titles, results)
 
     return "|".join([r for r in results if r])
 
@@ -1291,13 +1290,6 @@ class HTML2SPSPipeline(object):
                 return
             if not get_node_text(node):
                 _remove_tag(node, True)
-                # name = node.get("href")[1:]
-                # node_name = node.getroottree(
-                #     ).find(".//a[@name='{}']".format(name))
-                # print(name, etree.tostring(node))
-                # print(name, etree.tostring(node_name))
-                # if node_name is not None:
-                #     _remove_tag(node_name, True)
 
         def transform(self, data):
             raw, xml = data

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1481,6 +1481,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
             self.GetFnContentFromNextElementPipe(),
             self.FnIdentifyLabelAndPPipe(),
             self.FnFixContentPipe(),
+            self.RemoveFnWhichHasOnlyXref(),
         )
 
     def deploy(self, raw):
@@ -3289,6 +3290,23 @@ class ConvertElementsWhichHaveIdPipeline(object):
                         fn.append(deepcopy(parent_next))
                         parent = parent.getparent()
                         parent.remove(parent_next)
+            return data
+
+    class RemoveFnWhichHasOnlyXref(plumber.Pipe):
+        """
+        As âncoras que não identificadas como ativos digitais, seções etc,
+        por exclusão são consideradas notas de rodapé (fn). No entanto, há
+        padrões que podem desconsiderá-las notas de rodapé.
+        Um fn que contém apenas xref, não é nota de rodapé
+        """
+        def transform(self, data):
+            raw, xml = data
+            logger.debug("RemoveFnWhichHasOnlyXref")
+            for p in xml.findall(".//fn/p[xref]"):
+                fn = p.getparent()
+                if get_node_text(fn) == get_node_text(p.find("xref")):
+                    _remove_tag(p)
+                    _remove_tag(fn)
             return data
 
 

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1451,6 +1451,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
             self.EvaluateElementAToDeleteOrMarkAsFnLabelPipe(),
             self.DeduceAndSuggestConversionPipe(),
             self.ApplySuggestedConversionPipe(),
+            self.RemoveXrefWhichRefTypeIsSecOrOrdinarySecPipe(),
             self.CreateSectionElemetWithSectionTitlePipe(),
             self.RemoveEmptyPAndEmptySectionPipe(),
             self.InsertSectionChildrenPipe(),
@@ -2306,6 +2307,15 @@ class ConvertElementsWhichHaveIdPipeline(object):
                     self._update_a_href_items(a_hrefs, new_id, reftype)
                 else:
                     self._remove_a(a_name, a_hrefs)
+            return data
+
+    class RemoveXrefWhichRefTypeIsSecOrOrdinarySecPipe(plumber.Pipe):
+        def transform(self, data):
+            raw, xml = data
+            for xref in xml.findall(".//xref[@ref-type='sec']"):
+                _remove_tag(xref, True)
+            for xref in xml.findall(".//xref[@ref-type='ordinary-sec']"):
+                _remove_tag(xref, True)
             return data
 
     class CreateSectionElemetWithSectionTitlePipe(plumber.Pipe):

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1255,11 +1255,13 @@ class HTML2SPSPipeline(object):
                 return
             if not get_node_text(node):
                 _remove_tag(node, True)
-                name = node.get("href")[1:]
-                node_name = node.getroottree(
-                    ).find(".//a[@name='{}']".format(name))
-                if node_name is not None:
-                    _remove_tag(node_name, True)
+                # name = node.get("href")[1:]
+                # node_name = node.getroottree(
+                #     ).find(".//a[@name='{}']".format(name))
+                # print(name, etree.tostring(node))
+                # print(name, etree.tostring(node_name))
+                # if node_name is not None:
+                #     _remove_tag(node_name, True)
 
         def transform(self, data):
             raw, xml = data
@@ -3010,7 +3012,10 @@ class ConvertElementsWhichHaveIdPipeline(object):
             for node in xml.findall(".//fn"):
                 next = node.getnext()
                 if next is not None and next.tag == "bold":
-                    next.tag = "label"
+                    label = etree.Element("label")
+                    label.append(deepcopy(next))
+                    node.addnext(label)
+                    _remove_tag(next, True)
             return data
 
     class FnLabelOfPipe(plumber.Pipe):
@@ -3280,9 +3285,10 @@ class ConvertElementsWhichHaveIdPipeline(object):
                 if len(children) == 1:
                     parent = fn.getparent()
                     parent_next = parent.getnext()
-                    fn.append(deepcopy(parent_next))
-                    parent = parent.getparent()
-                    parent.remove(parent_next)
+                    if parent_next is not None:
+                        fn.append(deepcopy(parent_next))
+                        parent = parent.getparent()
+                        parent.remove(parent_next)
             return data
 
 

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1255,6 +1255,11 @@ class HTML2SPSPipeline(object):
                 return
             if not get_node_text(node):
                 _remove_tag(node, True)
+                name = node.get("href")[1:]
+                node_name = node.getroottree(
+                    ).find(".//a[@name='{}']".format(name))
+                if node_name is not None:
+                    _remove_tag(node_name, True)
 
         def transform(self, data):
             raw, xml = data

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -2312,7 +2312,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
 
         def _create_title(self, node):
             title = node.getnext()
-            if title is not None:
+            if title is not None and title.tag == "bold":
                 title.tag = "title"
                 node.append(deepcopy(title))
                 parent = node.getparent()

--- a/documentstore_migracao/utils/convert_html_body.txt
+++ b/documentstore_migracao/utils/convert_html_body.txt
@@ -60,3 +60,8 @@ alg|fig
 e|disp-formula
 t|table-wrap
 f|fig
+bibr|ordinary-sec
+resu|ordinary-sec
+abst|ordinary-sec
+refe|ordinary-sec
+ackn|ordinary-sec

--- a/documentstore_migracao/utils/convert_html_body.txt
+++ b/documentstore_migracao/utils/convert_html_body.txt
@@ -1,3 +1,15 @@
+img|fig
+supplementary|sec
+material|sec
+cases|sec
+cases reports|sec
+conclusions|sec
+discussion|sec
+introduction|sec
+methods|sec
+methodology|sec
+results|sec
+subjects|sec
 corresp|corresp
 figure|fig
 tab|table-wrap
@@ -48,6 +60,3 @@ alg|fig
 e|disp-formula
 t|table-wrap
 f|fig
-img|fig
-supplementary|supplementary-material
-material|supplementary-material

--- a/documentstore_migracao/utils/convert_html_body_inferer.py
+++ b/documentstore_migracao/utils/convert_html_body_inferer.py
@@ -8,16 +8,10 @@ from documentstore_migracao.utils import files
 class Inferer:
 
     REFTYPE = {"table-wrap": "table", "ref": "bibr"}
-    BODY_SECS = (
-        "intr",
-        "subj",
-        "meto",
-        "méto",
-        "disc",
+    OTHER_SECTIONS = (
         "bibr",
         "resu",
         "abst",
-        "mate",
         "refe",
         "ackn",
         "text",
@@ -62,7 +56,7 @@ class Inferer:
         if a_href_text[0].isalpha():
             if len(a_href_text) == 1:
                 return "fn", "fn"
-            if a_href_text[:4] in self.BODY_SECS:
+            if a_href_text[:4] in self.OTHER_SECTIONS:
                 return "target", "other"
             if "corresp" in text or "address" in text or "endereço" in text:
                 return "corresp", "corresp"

--- a/documentstore_migracao/utils/convert_html_body_inferer.py
+++ b/documentstore_migracao/utils/convert_html_body_inferer.py
@@ -33,7 +33,7 @@ class Inferer:
                     if len(clue) == 1 and not name[len(clue) :].isdigit():
                         return "fn", "fn"
                     return tag, self.ref_type(tag)
-            for clue, tag in self.rules.sorted_clue_and_tags_items:
+            for clue, tag in self.rules.sorted_rules:
                 if len(clue) > 1:
                     if clue in name:
                         return tag, self.ref_type(tag)
@@ -73,7 +73,7 @@ class Inferer:
             clue_and_tag_items = self.rules.sorted_by_tag.get(elem_name, [])
             clue_and_tag_items.append((elem_name[0], elem_name))
         else:
-            clue_and_tag_items = self.rules.sorted_clue_and_tags_items
+            clue_and_tag_items = self.rules.sorted_rules
         for clue, tag in clue_and_tag_items:
             if clue == filename:
                 return tag, self.ref_type(tag), filename
@@ -94,24 +94,29 @@ class InfererRules:
         self.rules_file_path = rules_file_path
         file_path, ext = os.path.splitext(rules_file_path)
         dirname = os.path.dirname(rules_file_path)
-        self.json_sorted_by_clue_first_char = os.path.join(
-            dirname, "_inferer_clue.json"
-        )
-        self.json_sorted_by_tag = os.path.join(dirname, "_inferer_tags.json")
-        self._unsorted_clue_and_tag_items = None
-        self._sorted_clue_and_tags_items = None
+        self.inferer_clue_json_file_path = os.path.join(
+            dirname, "_inferer_clue.json")
+        self._inferer_tags_json_file_path = os.path.join(
+            dirname, "_inferer_tags.json")
+        self._rules = None
+        self._sorted_rules = None
         self._sorted_by_clue_len_in_reverse_order = None
         self._sorted_by_tag = None
         self._sorted_by_clue_first_char = None
 
+    def _is_out_of_date(self, file_path):
+        if not os.path.isfile(file_path):
+            return True
+        return os.stat(file_path).st_mtime < os.stat(self.rules_file_path).st_mtime
+
     @property
-    def unsorted_clue_and_tag_items(self):
-        if not self._unsorted_clue_and_tag_items:
+    def rules(self):
+        if not self._rules:
             with open(self.rules_file_path, "r") as fp:
-                self._unsorted_clue_and_tag_items = (
+                self._rules = (
                     tuple(item.strip().split("|")) for item in fp.readlines()
                 )
-        return self._unsorted_clue_and_tag_items
+        return self._rules
 
     @property
     def sorted_by_clue_len_in_reverse_order(self):
@@ -119,20 +124,20 @@ class InfererRules:
             self._sorted_by_clue_len_in_reverse_order = sorted(
                 [
                     (len(text), text, tag)
-                    for text, tag in self.unsorted_clue_and_tag_items
+                    for text, tag in self.rules
                 ],
                 reverse=True,
             )
         return self._sorted_by_clue_len_in_reverse_order
 
     @property
-    def sorted_clue_and_tags_items(self):
-        if not self._sorted_clue_and_tags_items:
-            self._sorted_clue_and_tags_items = [
+    def sorted_rules(self):
+        if not self._sorted_rules:
+            self._sorted_rules = [
                 (text, tag)
                 for lent, text, tag in self.sorted_by_clue_len_in_reverse_order
             ]
-        return self._sorted_clue_and_tags_items
+        return self._sorted_rules
 
     def classify_items_by_tag(self):
         d = {}
@@ -150,22 +155,20 @@ class InfererRules:
         return d
 
     def get_data(self, json_file_path, classification_function):
-        data = None
-        if os.path.isfile(json_file_path):
+        if self._is_out_of_date(json_file_path):
+            data = classification_function()
+            with open(json_file_path, "w") as fp:
+                fp.write(json.dumps(data))
+        else:
             with open(json_file_path, "r") as fp:
                 data = json.loads(fp.read())
-        if not data:
-            data = classification_function()
-            if data:
-                with open(json_file_path, "w") as fp:
-                    fp.write(json.dumps(data))
         return data
 
     @property
     def sorted_by_tag(self):
         if not self._sorted_by_tag:
             self._sorted_by_tag = self.get_data(
-                self.json_sorted_by_tag, self.classify_items_by_tag
+                self._inferer_tags_json_file_path, self.classify_items_by_tag
             )
         return self._sorted_by_tag
 
@@ -173,7 +176,7 @@ class InfererRules:
     def sorted_by_clue_first_char(self):
         if not self._sorted_by_clue_first_char:
             self._sorted_by_clue_first_char = self.get_data(
-                self.json_sorted_by_clue_first_char,
+                self.inferer_clue_json_file_path,
                 self.classify_items_by_clue_first_char,
             )
         return self._sorted_by_clue_first_char

--- a/documentstore_migracao/utils/convert_html_body_inferer.py
+++ b/documentstore_migracao/utils/convert_html_body_inferer.py
@@ -8,14 +8,10 @@ from documentstore_migracao.utils import files
 class Inferer:
 
     REFTYPE = {"table-wrap": "table", "ref": "bibr"}
-    OTHER_SECTIONS = (
-        "bibr",
-        "resu",
-        "abst",
-        "refe",
-        "ackn",
+
+    OTHER_SECTIONS = [
         "text",
-    )
+    ]
 
     def __init__(self):
         self.rules = InfererRules(config.INFERERER_RULES_FILE_PATH)

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2986,7 +2986,7 @@ class TestCreateSectionElemetWithSectionTitlePipe(unittest.TestCase):
             "Introduction"
         )
         sec = xml.find(".//sec")
-        self.assertEqual(sec.get("sec-type"), "introduction")
+        self.assertEqual(sec.get("sec-type"), "intro")
 
     def test_transform_creates_sec_elem_with_title_from_ordinary_sec(self):
         text = """<root>
@@ -3002,9 +3002,43 @@ class TestCreateSectionElemetWithSectionTitlePipe(unittest.TestCase):
         </root>"""
         xml = etree.fromstring(text)
         text, xml = self.pipe.transform((text, xml))
-        print(etree.tostring(xml))
         self.assertEqual(
             xml.findtext(".//sec[@id='abstract']/title"),
             "Abstract"
         )
         self.assertIsNone(xml.findtext(".//sec[@sec-type]"))
+
+
+class TestInsertSectionChildrenPipe(unittest.TestCase):
+
+    def setUp(self):
+        pl = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pl.InsertSectionChildrenPipe()
+
+    def test_transform_inserts_elements_in_sec_until_find_other_sec(self):
+        text = """<root>
+        <body>
+            <sec id="abstract">
+                <title>Abstract</title>
+            </sec>
+            <p>paragrafo 1 de Abstract</p>
+            <sec id="material">
+                <title>Material and Methods</title>
+            </sec>
+            <p>paragrafo 1 de Material and Methods</p>
+            <p>paragrafo 2 de Material and Methods</p>
+            <p>paragrafo 3 de Material and Methods</p>
+        </body>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        print(etree.tostring(xml))
+        self.assertEqual(
+            len(xml.find(".//sec[@id='abstract']").getchildren()),
+            2
+        )
+        self.assertEqual(
+            len(xml.find(".//sec[@id='material']").getchildren()),
+            4
+        )
+

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -3152,3 +3152,37 @@ class TestRemoveEmptyPAndEmptySectionPipe(unittest.TestCase):
         text, xml = self.pipe.transform((text, xml))
         self.assertEqual(len(xml.findall(".//p")), 3)
 
+
+class TestRemoveXrefWhichRefTypeIsSecOrOrdinarySec(unittest.TestCase):
+    def setUp(self):
+        pl = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pl.RemoveXrefWhichRefTypeIsSecOrOrdinarySecPipe()
+
+    def test_transform_removes_all_xref(self):
+        text = """<root>
+        <p>
+        <xref ref-type="ordinary-sec" rid="abstract">Abstract</xref>
+        </p>
+        <p>
+        <xref ref-type="sec" rid="introduction">Introduction</xref>
+        </p>
+        <p>
+        <xref ref-type="sec" rid="material">Material and Methods</xref>
+        </p>
+        <p>
+        <xref ref-type="sec" rid="results">Results</xref>
+        </p>
+        <p>
+        <xref ref-type="sec" rid="discussion">Discussion</xref>
+        </p>
+        <p>
+        <xref ref-type="ordinary-sec" rid="references">References</xref>
+        </p>
+        <p>
+        <xref ref-type="ordinary-sec" rid="acknowledgments">Acknowledgments</xref>
+        </p>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertEqual(len(xml.findall(".//xref")), 0)
+

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -3186,3 +3186,23 @@ class TestRemoveXrefWhichRefTypeIsSecOrOrdinarySec(unittest.TestCase):
         text, xml = self.pipe.transform((text, xml))
         self.assertEqual(len(xml.findall(".//xref")), 0)
 
+
+class TestRemoveFnWhichHasOnlyXref(unittest.TestCase):
+    def setUp(self):
+        pl = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pl.RemoveFnWhichHasOnlyXref()
+
+    def test_transform(self):
+        text = """<root>
+        <p id="p1">
+            <fn>
+                <p id="p2">
+                    <xref ref-type="ordinary-sec" rid="abstract">Abstract</xref>
+                </p>
+            </fn>
+        </p>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertIsNotNone(xml.find("./p[@id='p1']/xref"))
+

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -3065,3 +3065,35 @@ class TestInsertSectionChildrenPipe(unittest.TestCase):
             len(xml.find(".//sec[@id='acknowledgments']").getchildren()),
             2
         )
+
+
+class TestAfterOneSectionAllTheOtherElementsMustBeSectionPipe(unittest.TestCase):
+
+    def setUp(self):
+        pl = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pl.AfterOneSectionAllTheOtherElementsMustBeSectionPipe()
+
+    def test_transform_(self):
+        text = """<root>
+        <body>
+            <p>paragrafo qq 1</p>
+            <p>paragrafo qq 2</p>
+            <p>paragrafo qq 3</p>
+            <sec id="abstract">
+                <title>Abstract</title>
+                <p>paragrafo 1 de Abstract</p>
+            </sec>
+            <p>paragrafo qq 4</p>
+            <p>paragrafo qq 5</p>
+        </body>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        body_chidren = xml.find(".//body").getchildren()
+        self.assertEqual(
+            [node.tag for node in body_chidren],
+            ["p", "p", "p", "sec", "sec", "sec"]
+        )
+        self.assertEqual(body_chidren[-1].findtext("p"), "paragrafo qq 5")
+        self.assertEqual(body_chidren[-2].findtext("p"), "paragrafo qq 4")
+

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2962,3 +2962,49 @@ class TestFixOutSitetablePiep(unittest.TestCase):
         text, xml = pl.FixOutSideTablePipe().transform((text, xml))
         self.assertIn('table',
                       [tag.tag for tag in xml.find(".//table-wrap/p").getchildren()])
+
+
+class TestCreateSectionElemetWithSectionTitlePipe(unittest.TestCase):
+
+    def setUp(self):
+        pl = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pl.CreateSectionElemetWithSectionTitlePipe()
+
+    def test_transform_creates_sec_elem_with_title_from_sec(self):
+        text = """<root>
+        <body>
+            <p>
+                <sec id="introduction"/>
+                <bold>Introduction</bold>
+            </p>
+        </body>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertEqual(
+            xml.findtext(".//sec[@id='introduction']/title"),
+            "Introduction"
+        )
+        sec = xml.find(".//sec")
+        self.assertEqual(sec.get("sec-type"), "introduction")
+
+    def test_transform_creates_sec_elem_with_title_from_ordinary_sec(self):
+        text = """<root>
+        <body>
+            <p>
+                <ordinary-sec id="abstract"/>
+                <bold>Abstract</bold>
+            </p>
+            <p>paragrafo 1 de Material and Methods</p>
+            <p>paragrafo 2 de Material and Methods</p>
+            <p>paragrafo 3 de Material and Methods</p>
+        </body>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        print(etree.tostring(xml))
+        self.assertEqual(
+            xml.findtext(".//sec[@id='abstract']/title"),
+            "Abstract"
+        )
+        self.assertIsNone(xml.findtext(".//sec[@sec-type]"))

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2988,6 +2988,24 @@ class TestCreateSectionElemetWithSectionTitlePipe(unittest.TestCase):
         sec = xml.find(".//sec")
         self.assertEqual(sec.get("sec-type"), "intro")
 
+    def test_transform_does_not_create_sec_elem_with_title_from_sec(self):
+        text = """<root>
+        <body>
+            <p>
+                <sec id="introduction"/>
+                <xref>Introduction</xref>
+            </p>
+        </body>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertEqual(
+            xml.findtext(".//sec[@id='introduction']/title"),
+            None
+        )
+        sec = xml.find(".//sec")
+        self.assertEqual(sec.get("sec-type"), "intro")
+
     def test_transform_creates_sec_elem_with_title_from_ordinary_sec(self):
         text = """<root>
         <body>
@@ -3038,7 +3056,6 @@ class TestInsertSectionChildrenPipe(unittest.TestCase):
         </root>"""
         xml = etree.fromstring(text)
         text, xml = self.pipe.transform((text, xml))
-        print(etree.tostring(xml))
         self.assertEqual(
             len(xml.find(".//sec[@id='abstract']").getchildren()),
             2

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -3028,6 +3028,12 @@ class TestInsertSectionChildrenPipe(unittest.TestCase):
             <p>paragrafo 1 de Material and Methods</p>
             <p>paragrafo 2 de Material and Methods</p>
             <p>paragrafo 3 de Material and Methods</p>
+            <sec id="acknowledgments">
+                <title>Acknowledgments</title>
+            </sec>
+            <p>paragrafo 1 de Acknowledgments</p>
+            <p>paragrafo qq</p>
+            <p>paragrafo qq</p>
         </body>
         </root>"""
         xml = etree.fromstring(text)
@@ -3042,3 +3048,20 @@ class TestInsertSectionChildrenPipe(unittest.TestCase):
             4
         )
 
+    def test_transform_inserts_only_one_element_in_sec_if_it_is_last_sec(self):
+        text = """<root>
+        <body>
+            <sec id="acknowledgments">
+                <title>Acknowledgments</title>
+            </sec>
+            <p>paragrafo 1 de Acknowledgments</p>
+            <p>paragrafo qq</p>
+            <p>paragrafo qq</p>
+        </body>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertEqual(
+            len(xml.find(".//sec[@id='acknowledgments']").getchildren()),
+            2
+        )

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -3070,7 +3070,7 @@ class TestInsertSectionChildrenPipe(unittest.TestCase):
 class TestAfterOneSectionAllTheOtherElementsMustBeSectionPipe(unittest.TestCase):
 
     def setUp(self):
-        pl = ConvertElementsWhichHaveIdPipeline()
+        pl = HTML2SPSPipeline()
         self.pipe = pl.AfterOneSectionAllTheOtherElementsMustBeSectionPipe()
 
     def test_transform_(self):
@@ -3096,4 +3096,21 @@ class TestAfterOneSectionAllTheOtherElementsMustBeSectionPipe(unittest.TestCase)
         )
         self.assertEqual(body_chidren[-1].findtext("p"), "paragrafo qq 5")
         self.assertEqual(body_chidren[-2].findtext("p"), "paragrafo qq 4")
+
+
+class TestRemoveAhrefWhichContentIsOnlyImgPipe(unittest.TestCase):
+
+    def setUp(self):
+        pl = HTML2SPSPipeline()
+        self.pipe = pl.RemoveAhrefWhichContentIsOnlyImgPipe()
+
+    def test_transform_remove_element(self):
+        text = """<root>
+        <body>
+            <p>texto antes <a href="#ancora"><img/></a> texto depois</p>
+        </body>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertEqual(xml.find(".//p").text, "texto antes  texto depois")
 

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -3114,3 +3114,24 @@ class TestRemoveAhrefWhichContentIsOnlyImgPipe(unittest.TestCase):
         text, xml = self.pipe.transform((text, xml))
         self.assertEqual(xml.find(".//p").text, "texto antes  texto depois")
 
+
+class TestRemoveEmptyPAndEmptySectionPipe(unittest.TestCase):
+
+    def setUp(self):
+        pl = HTML2SPSPipeline()
+        self.pipe = pl.RemoveEmptyPAndEmptySectionPipe()
+
+    def test_transform_remove_element(self):
+        text = """<root>
+        <body>
+            <p>texto antes <a href="#ancora"><img/></a> texto depois</p>
+            <p>parágrafo 1</p>
+            <p></p>
+            <p> </p>
+            <p> <img/> </p>
+        </body>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertEqual(len(xml.findall(".//p")), 3)
+


### PR DESCRIPTION
#### O que esse PR faz?
Remove o menu de seções do body e as apresenta no menu da esquerda.

Com a correção:

<img width="192" alt="Captura de Tela 2020-03-23 às 17 10 29" src="https://user-images.githubusercontent.com/505143/77358782-3e07b280-6d29-11ea-9f4a-58ccb4d06ac3.png">


#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Executar a conversão em 
[S0100-879X1997000600002.xml.zip](https://github.com/scieloorg/document-store-migracao/files/4371686/S0100-879X1997000600002.xml.zip)

`ds_migracao convert --file xml/source/S0100-879X1997000600002.xml`
`htmlgenerator xml/conversion/S0100-879X1997000600002.en.xml --nochecks`

Veja a comparação do resultado do master e do tk273
[tk273.zip](https://github.com/scieloorg/document-store-migracao/files/4371679/tk273.zip)


#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#273 

### Referências
https://jats.nlm.nih.gov/publishing/tag-library/1.3d1/attribute/sec-type.html


