### PR TITLE
Adiciona otimizador de documentos do Packtools

### DIFF
--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -13,7 +13,7 @@ from copy import deepcopy
 import fs
 from fs import path, copy, errors
 
-from documentstore_migracao.utils import xml
+from documentstore_migracao.utils import xml, files
 from documentstore_migracao.export.sps_package import SPS_Package
 
 
@@ -189,12 +189,12 @@ class BuildPSPackage(object):
     def collect_renditions(self, target_path, acron, issue_folder, pack_name, langs):
         source_path = os.path.join(self.pdf_folder, acron, issue_folder)
         renditions = []
-        files = [(pack_name+".pdf", pack_name+".pdf")]
+        renditions_files = [(pack_name+".pdf", pack_name+".pdf")]
         for lang in langs[1:]:
-            files.append(
+            renditions_files.append(
                 (lang + "_" + pack_name + ".pdf",
                     pack_name + "-" + lang + ".pdf"))
-        for source, dest in files:
+        for source, dest in renditions_files:
             try:
                 shutil.copy(os.path.join(source_path, source), target_path)
             except FileNotFoundError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ minio==4.0.16
 more-itertools==6.0.0
 nose==1.3.7
 numpy==1.16.3
-packtools==2.5
+packtools==2.6.2
 paginate==0.5.6
 PasteDeploy==2.0.1
 pathlib2==2.3.3

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requires = [
     "picles.plumber",
     "lxml",
     "scielo-kernel",
-    "packtools",
+    "packtools>=2.6.2",
     "paginate",
     "minio",
     "tqdm",


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona o otimizador de documentos e ativos digitais no packtools, utilizando o `packtools.XMLWebOptimiser`.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
Com CSV contendo documentos XML referenciando ativos digitais TIFF:

1. Execute o comando `ds_migracao pack_from_site`
2. Verifique o diretório informado na opção `-Ofolder`
3. Observe que o pacote foi gerado com sucesso

Exemplo de CSV: [base_artigos.txt](https://github.com/scieloorg/document-store-migracao/files/4471829/base_artigos.txt)

#### Algum cenário de contexto que queira dar?
Este PR não resolve o problema dos arquivos referenciados não encontrados. O ticket #304 foi aberto para resolver este problema.

### Screenshots
n/a

#### Quais são tickets relevantes?
Resolve parcialmente o #283 

### Referências
.