### PR TITLE
Corrige erros na conversão ao tentar acessar métodos em objeto vazio

### DIFF
--- a/documentstore_migracao/processing/conversion.py
+++ b/documentstore_migracao/processing/conversion.py
@@ -67,7 +67,8 @@ def convert_article_xml(file_xml_path: str, poison_pill=PoisonPill()):
 
     if poison_pill.poisoned:
         return
-
+    logger.info(file_xml_path)
+    print(file_xml_path)
     obj_xmltree = xml.loadToXML(file_xml_path)
     obj_xml = obj_xmltree.getroot()
 

--- a/documentstore_migracao/processing/conversion.py
+++ b/documentstore_migracao/processing/conversion.py
@@ -68,7 +68,7 @@ def convert_article_xml(file_xml_path: str, poison_pill=PoisonPill()):
     if poison_pill.poisoned:
         return
     logger.info(file_xml_path)
-    print(file_xml_path)
+
     obj_xmltree = xml.loadToXML(file_xml_path)
     obj_xml = obj_xmltree.getroot()
 

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1558,7 +1558,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
             self.TablePipe(),
             self.SupplementaryMaterialPipe(),
             self.FnMovePipe(),
-            self.FnBoldPipe(),
+            self.FnPipe_FindBoldWhichIsNextFromFnAndWrapItInLabel(),
             self.FnLabelOfPipe(),
             self.FnAddContentPipe(),
             self.GetFnContentFromNextElementPipe(),
@@ -3241,20 +3241,21 @@ class ConvertElementsWhichHaveIdPipeline(object):
             node.addnext(fn_copy)
             node.remove(fn)
 
-    class FnBoldPipe(plumber.Pipe):
-        """Cria fn a partir de label[@label-of]
-        ou adiciona label em fn
+    class FnPipe_FindBoldWhichIsNextFromFnAndWrapItInLabel(plumber.Pipe):
+        """Encontra bold que é vizinho posterior de fn e 
+        inclui dentro do elemento novo label, desconsidera o bold.tail
         """
-
         def transform(self, data):
             logger.debug("INICIO: %s" % type(self).__name__)
             raw, xml = data
-            logger.debug("FnBoldPipe")
             for node in xml.findall(".//fn"):
                 next = node.getnext()
                 if next is not None and next.tag == "bold":
                     label = etree.Element("label")
-                    label.append(deepcopy(next))
+                    bold = deepcopy(next)
+                    if bold.tail:
+                        bold.tail = ""
+                    label.append(bold)
                     node.addnext(label)
                     _remove_tag(next, True)
             logger.debug("FIM: %s" % type(self).__name__)

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -388,7 +388,7 @@ class HTML2SPSPipeline(object):
             return data
 
     class RemoveEmptyPipe(plumber.Pipe):
-        EXCEPTIONS = ["a", "br", "img", "hr", "td"]
+        EXCEPTIONS = ["a", "br", "img", "hr", "td", "body"]
 
         def _is_empty_element(self, node):
             return node.findall("*") == [] and not get_node_text(node)

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1558,7 +1558,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
             self.TablePipe(),
             self.SupplementaryMaterialPipe(),
             self.FnMovePipe(),
-            self.FnPipe_FindBoldWhichIsNextFromFnAndWrapItInLabel(),
+            self.FnPipe_FindStyleTagWhichIsNextFromFnAndWrapItInLabel(),
             self.MoveSuffixAndPrefixIntoLabelPipe(),
             self.FnPipe_FindLabelOfAndCreateNewEmptyFnAsPreviousElemOfLabel(),
             self.FnPipe_AddContentToEmptyFn(),
@@ -3242,21 +3242,22 @@ class ConvertElementsWhichHaveIdPipeline(object):
             node.addnext(fn_copy)
             node.remove(fn)
 
-    class FnPipe_FindBoldWhichIsNextFromFnAndWrapItInLabel(plumber.Pipe):
+    class FnPipe_FindStyleTagWhichIsNextFromFnAndWrapItInLabel(plumber.Pipe):
         """Encontra bold que é vizinho posterior de fn e 
         inclui dentro do elemento novo label, desconsidera o bold.tail
         """
         def transform(self, data):
+            STYLE_TAGS = ("bold", "sup")
             logger.debug("INICIO: %s" % type(self).__name__)
             raw, xml = data
             for node in xml.findall(".//fn"):
                 next = node.getnext()
-                if next is not None and next.tag == "bold":
+                if next is not None and next.tag in STYLE_TAGS:
                     label = etree.Element("label")
-                    bold = deepcopy(next)
-                    if bold.tail:
-                        bold.tail = ""
-                    label.append(bold)
+                    style_elem = deepcopy(next)
+                    if style_elem.tail:
+                        style_elem.tail = ""
+                    label.append(style_elem)
                     node.addnext(label)
                     _remove_tag(next, True)
             logger.debug("FIM: %s" % type(self).__name__)

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -3190,6 +3190,7 @@ class TestRemoveFnWhichHasOnlyXref(unittest.TestCase):
         self.assertIsNotNone(xml.find("./p[@id='p1']/xref"))
 
 
+
 class TestFnFixLabel(unittest.TestCase):
     def setUp(self):
         pl = ConvertElementsWhichHaveIdPipeline()
@@ -3220,3 +3221,22 @@ class TestFnFixLabel(unittest.TestCase):
         xml = etree.fromstring(text)
         text, xml = self.pipe.transform((text, xml))
         self.assertEqual(xml.find("./fn").getchildren()[0].tag, "label")
+
+
+class TestFnPipe_FindBoldWhichIsNextFromFnAndWrapItInLabel(unittest.TestCase):
+    def test_transform(self):
+        text = """<root>
+        <body><fn/><bold>título</bold>texto fora do bold</body>
+        </root>"""
+        expected = (
+            """<root>
+        <body><fn/><label><bold>título</bold></label>texto fora do bold</body>
+        </root>"""
+        )
+        xml = etree.fromstring(text)
+        pl = ConvertElementsWhichHaveIdPipeline()
+        pipe = pl.FnPipe_FindBoldWhichIsNextFromFnAndWrapItInLabel()
+        text, xml = pipe.transform((text, xml))
+        self.assertEqual(xml.findtext(".//label/bold"), "título")
+        self.assertEqual(xml.find(".//label/bold").tail, "")
+        self.assertEqual(xml.find(".//label").tail, "texto fora do bold")

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -3240,3 +3240,29 @@ class TestFnPipe_FindBoldWhichIsNextFromFnAndWrapItInLabel(unittest.TestCase):
         self.assertEqual(xml.findtext(".//label/bold"), "título")
         self.assertEqual(xml.find(".//label/bold").tail, "")
         self.assertEqual(xml.find(".//label").tail, "texto fora do bold")
+
+
+class TestFnPipe_FindLabelOfAndCreateNewEmptyFnAsPreviousElemOfLabel(unittest.TestCase):
+    def test_transform_creates_fn_to_second_label(self):
+        text = """<root>
+        <label href="#home" xml_text="*" label-of="back">*</label> Corresponding author
+        <label href="#home" xml_text="*" label-of="back">*</label> Corresponding author
+        </root>"""
+        xml = etree.fromstring(text)
+        pl = ConvertElementsWhichHaveIdPipeline()
+        pipe = pl.FnPipe_FindLabelOfAndCreateNewEmptyFnAsPreviousElemOfLabel()
+        text, xml = pipe.transform((text, xml))
+        labels = xml.findall(".//label")
+        self.assertIsNone(labels[0].getprevious())
+        self.assertEqual(labels[1].getprevious().tag, "fn")
+
+    def test_transform_creates_fn_as_previous_elem_of_label(self):
+        text = """<root>
+        <label href="#home" xml_text="*" label-of="back">*</label> Corresponding author
+        </root>"""
+        xml = etree.fromstring(text)
+        pl = ConvertElementsWhichHaveIdPipeline()
+        pipe = pl.FnPipe_FindLabelOfAndCreateNewEmptyFnAsPreviousElemOfLabel()
+        text, xml = pipe.transform((text, xml))
+        labels = xml.findall(".//label")
+        self.assertEqual(labels[0].getprevious().tag, "fn")

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -3218,6 +3218,73 @@ class TestRemoveFnWhichHasOnlyXref(unittest.TestCase):
         self.assertIsNotNone(xml.find("./p[@id='p1']/xref"))
 
 
+class TestGetPFromFnParentNextPipe(unittest.TestCase):
+    def setUp(self):
+        pl = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = pl.GetPFromFnParentNextPipe()
+
+    def test_transform_get_p_from_fn_parent_next(self):
+        text = """<root>
+        <p id="p1">
+            <fn>
+                <label>LABEL</label>
+            </fn>
+        </p>
+        <p id="p1">
+            TEXTO
+        </p>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertEqual(xml.find(".//fn/p").text.strip(), "TEXTO")
+        self.assertEqual(len(xml.find(".").getchildren()), 1)
+
+    def test_transform_do_not_get_p_from_fn_parent_next_because_it_has_fn(self):
+        text = """<root>
+        <p id="p1">
+            <fn>
+                <label>LABEL</label>
+            </fn>
+        </p>
+        <p id="p1">
+            <fn>TEXTO</fn>
+        </p>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertIsNone(xml.find(".//fn/p"))
+        self.assertEqual(len(xml.find(".").getchildren()), 2)
+
+    def test_transform_do_not_get_p_from_fn_parent_next_because_it_is_body(self):
+        text = """<root>
+        <body>
+            <fn>
+                <label>LABEL</label>
+            </fn>
+            <p>TEXTO</p>
+        </body>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertIsNone(xml.find(".//fn/p"))
+        self.assertEqual(len(xml.find(".").getchildren()), 1)
+
+    def test_transform_do_not_get_p_from_fn_parent_next_because_it_is_not_p(self):
+        text = """<root>
+        <p id="p1">
+            <fn>
+                <label>LABEL</label>
+            </fn>
+        </p>
+        <x id="p1">
+            TEXTO
+        </x>
+        </root>"""
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+        self.assertIsNone(xml.find(".//fn/p"))
+        self.assertEqual(len(xml.find(".").getchildren()), 2)
+
 
 class TestFnFixLabel(unittest.TestCase):
     def setUp(self):

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -2165,10 +2165,10 @@ class TestFnIdentifyLabelAndPPipe(unittest.TestCase):
 
     def test__creates_p(self):
         text = """<root><fn id="nt01">
-           <italic>Isso é conhecido pelos pesquisadores como</italic></fn>
+           <li>Isso é conhecido pelos pesquisadores como</li></fn>
          </root>"""
         expected = """<root><fn id="nt01"><p>
-            <italic>Isso é conhecido pelos pesquisadores como</italic></p></fn>
+            <li>Isso é conhecido pelos pesquisadores como</li></p></fn>
         </root>"""
 
         xml = etree.fromstring(text)
@@ -2176,9 +2176,9 @@ class TestFnIdentifyLabelAndPPipe(unittest.TestCase):
         text, xml = self.pipe.transform((text, xml))
         fn = xml.find(".//fn")
         self.assertEqual(
-            fn.find("p/italic").text, "Isso é conhecido pelos pesquisadores como"
+            fn.find("p/li").text, "Isso é conhecido pelos pesquisadores como"
         )
-        self.assertIsNone(fn.find("p/italic").tail)
+        self.assertIsNone(fn.find("p/li").tail)
         self.assertIsNone(fn.find("label"))
 
 
@@ -2208,8 +2208,6 @@ class TestFnPipe(unittest.TestCase):
         text, xml = self.html_pl.BRPipe().transform((text, xml))
         text, xml = self.html_pl.ConvertElementsWhichHaveIdPipe().transform((text, xml))
         text, xml = self.html_pl.RemoveInvalidBRPipe().transform((text, xml))
-        text, xml = self.html_pl.ConvertElementsWhichHaveIdPipe().transform((text, xml))
-        text, xml = self.html_pl.RemoveInvalidBRPipe().transform((text, xml))
         text, xml = self.html_pl.BRPipe().transform((text, xml))
         text, xml = self.html_pl.BR2PPipe().transform((text, xml))
 
@@ -2222,7 +2220,7 @@ class TestFnPipe(unittest.TestCase):
         )
         self.assertEqual(p[2].text.strip(), "Avenida Granadeiro Guimarães, 270")
         self.assertEqual(p[3].text.strip(), "CEP: 12100-000 – Taubaté (SP), Brazil.")
-        self.assertEqual(p[4].find("email").text, "prolungatti@uol.com.br")
+        self.assertEqual(p[5].find("email").text, "prolungatti@uol.com.br")
 
     def test_creates_fn_list(self):
         text = """

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -3291,31 +3291,14 @@ class TestFnFixLabel(unittest.TestCase):
         pl = ConvertElementsWhichHaveIdPipeline()
         self.pipe = pl.FnFixLabel()
 
-    def test_fix_label_get_characters_from_previous_text_and_from_tail(self):
-        text = """<root>
-            <fn><p>(<label>1</label>) Texto</p></fn>
-        </root>"""
-        xml = etree.fromstring(text)
-        text, xml = self.pipe.transform((text, xml))
-        self.assertEqual(xml.findtext("./fn/label"), "(1)")
-        self.assertEqual(xml.find("./fn").getchildren()[0].tag, "label")
-
-    def test_fix_label_get_characteres_from_previous_and_next(self):
-        text = """<root>
-            <fn><p>(</p><label>1</label><p>) Texto</p></fn>
-        </root>"""
-        xml = etree.fromstring(text)
-        text, xml = self.pipe.transform((text, xml))
-        self.assertEqual(xml.findtext("./fn/label"), "(1)")
-        self.assertEqual(xml.find("./fn").getchildren()[0].tag, "label")
-
     def test_fix_label_make_label_first_child_of_fn(self):
         text = """<root>
-            <fn><p></p><p><label>1</label> Texto</p></fn>
+            <fn><p><label>1</label> Texto</p></fn>
         </root>"""
         xml = etree.fromstring(text)
         text, xml = self.pipe.transform((text, xml))
         self.assertEqual(xml.find("./fn").getchildren()[0].tag, "label")
+        self.assertEqual(xml.find("./fn").getchildren()[1].text.strip(), "Texto")
 
 
 class TestFnPipe_FindStyleTagWhichIsNextFromFnAndWrapItInLabel(unittest.TestCase):

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -3253,7 +3253,7 @@ class TestFnFixLabel(unittest.TestCase):
         self.assertEqual(xml.find("./fn").getchildren()[0].tag, "label")
 
 
-class TestFnPipe_FindBoldWhichIsNextFromFnAndWrapItInLabel(unittest.TestCase):
+class TestFnPipe_FindStyleTagWhichIsNextFromFnAndWrapItInLabel(unittest.TestCase):
     def test_transform(self):
         text = """<root>
         <body><fn/><bold>título</bold>texto fora do bold</body>
@@ -3265,7 +3265,7 @@ class TestFnPipe_FindBoldWhichIsNextFromFnAndWrapItInLabel(unittest.TestCase):
         )
         xml = etree.fromstring(text)
         pl = ConvertElementsWhichHaveIdPipeline()
-        pipe = pl.FnPipe_FindBoldWhichIsNextFromFnAndWrapItInLabel()
+        pipe = pl.FnPipe_FindStyleTagWhichIsNextFromFnAndWrapItInLabel()
         text, xml = pipe.transform((text, xml))
         self.assertEqual(xml.findtext(".//label/bold"), "título")
         self.assertEqual(xml.find(".//label/bold").tail, "")


### PR DESCRIPTION
#### O que esse PR faz?
O tipo de erro era o mesmo objeto (None) acessando um atributo. Mas acontecia em 3 pontos diferentes, por motivos diferentes.

1) Conversão de notas de rodapé. Tive que revisar/refatorar os pipes relacionados pois no ponto onde ocorre o erro, o resultado do XML esperado naquele ponto era diferente do obtido.
2) Conversão de tabelas (ativos digitais). Resolvido conforme sugerido
3) Ausência de body. Um dos pipes estava removendo o body por estar vazio. Passou a manter o elemento body, vazio.

Então, foram 3 soluções diferentes. Uma delas foi a sugestão do comentário
https://github.com/scieloorg/document-store-migracao/issues/293#issuecomment-611654852

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Estabeleça os passos necessários para que a funcionalidade seja testada manualmente pelo revisor.

```python
python setup.py test -s tests.test_convert_html_body
```

*Notas de rodapé*
```
ds_migracao --loglevel DEBUG convert --file xml/source/S0011-52581998000100005.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0011-52581998000300005.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0011-52582000000200001.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0102-44501997000100004.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0102-85292009000300001.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0102-86501998000100005.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0102-86501998000100007.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1413-85572005000100004.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1516-44462009000100001.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1516-44462009000400001.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1517-97022008000300002.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1517-97022008000300007.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1517-97022008000300011.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1678-31662007000400005.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1980-65742010000300014.xml

```

*body*

```shell
ds_migracao --loglevel DEBUG convert --file xml/source/S0034-71672009000600001.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0080-62342009000100001.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0100-204X2009000400016.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1414-32832000000100001.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1415-790X2009000100004.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1415-790X2009000100007.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1516-44462009000100001.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1516-44462009000400001.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1517-97022008000300002.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1517-97022008000300007.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1517-97022008000300011.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1678-31662007000400005.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S1980-65742010000300014.xml
```

*Table*
```shell
ds_migracao --loglevel DEBUG convert --file xml/source/S0100-879X2007000700007.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0100-879X2009000200006.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0100-879X2010000400011.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0100-879X2010001100004.xml

```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#293

### Referências
n/a
