### PR TITLE
Corrige a issue "Referências dentro de uma lista HTML não são retiradas do body e erro ocorre" (#291)"

### DIFF
--- a/documentstore_migracao/processing/conversion.py
+++ b/documentstore_migracao/processing/conversion.py
@@ -67,7 +67,7 @@ def convert_article_xml(file_xml_path: str, poison_pill=PoisonPill()):
 
     if poison_pill.poisoned:
         return
-    logger.info(file_xml_path)
+    logger.info(os.path.basename(file_xml_path))
 
     obj_xmltree = xml.loadToXML(file_xml_path)
     obj_xml = obj_xmltree.getroot()

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1583,7 +1583,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
             self.RemoveXrefWhichRefTypeIsSecOrOrdinarySecPipe(),
             self.CreateSectionElemetWithSectionTitlePipe(),
             self.RemoveEmptyPAndEmptySectionPipe(),
-            self.InsertSectionChildrenPipe(),
+            self.AddParagraphsToSectionPipe(),
             self.AssetElementFixPositionPipe(),
             self.CreateDispFormulaPipe(),
             self.AssetElementAddContentPipe(),
@@ -2518,7 +2518,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
             logger.debug("FIM: %s" % type(self).__name__)
             return data
 
-    class InsertSectionChildrenPipe(plumber.Pipe):
+    class AddParagraphsToSectionPipe(plumber.Pipe):
 
         def _create_children(self, node, last):
             remove_items = []

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1092,14 +1092,23 @@ class HTML2SPSPipeline(object):
             for comment in comments:
                 name = comment.text.strip()
                 if name == "end-ref":
-                    parents = [comment.getparent(), comment.getparent().getparent()]
+                    parents = [
+                        comment.getparent(), comment.getparent().getparent()]
                     for parent in parents:
-                        if parent.tag == "p":
+                        if parent.tag in ["p", "li"]:
                             parent.set("content-type", "ref-to-delete")
                             break
+                    if parent.get("content-type") is None:
+                        try:
+                            previous = comment.getprevious()
+                            if previous is not None and previous.tag == "li":
+                                previous.set("content-type", "ref-to-delete")
+                        except AttributeError:
+                            pass
+
                 elif header is None and name == "ref":
                     header = comment.getprevious()
-            return header, xml.findall(".//p[@content-type='ref-to-delete']")
+            return header, xml.findall(".//*[@content-type='ref-to-delete']")
 
         def _delete_references_header(self, references_header):
             if references_header is not None:

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1460,7 +1460,7 @@ class HTML2SPSPipeline(object):
                     sec_parent = sec.getparent()
                     if sec_parent.tag == "sec":
                         continue
-                    new_elements.insert(0, deepcopy(sec))
+                    new_elements.append(deepcopy(sec))
                     sec_parent.remove(sec)
 
                 for new_e in new_elements:
@@ -2496,6 +2496,7 @@ class ConvertElementsWhichHaveIdPipeline(object):
                     parent.remove(next)
 
                 node.append(deepcopy(title))
+                parent.remove(title)
 
         def _sectype(self, node):
             sectype = get_sectype(node.findtext("title") or node.get("id"))

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1072,7 +1072,12 @@ class HTML2SPSPipeline(object):
                     for p in p_to_delete:
                         _remove_tag(p, True)
                 else:
-                    logger.error("Não removeu referências do body")
+                    logger.error(
+                        "Não removeu referências do body: "
+                        "quantidades de parágrafos (%i) e referências (%i) "
+                        "divergem.",
+                        len(p_to_delete), len(self.super_obj.ref_items)
+                    )
             logger.debug("FIM: %s" % type(self).__name__)
             return data
 

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -3156,11 +3156,11 @@ class TestCreateSectionElemetWithSectionTitlePipe(unittest.TestCase):
         self.assertIsNone(xml.findtext(".//sec[@sec-type]"))
 
 
-class TestInsertSectionChildrenPipe(unittest.TestCase):
+class TestAddParagraphsToSectionPipe(unittest.TestCase):
 
     def setUp(self):
-        pl = ConvertElementsWhichHaveIdPipeline()
-        self.pipe = pl.InsertSectionChildrenPipe()
+        pl = HTML2SPSPipeline(pid="pid")
+        self.pipe = pl.AddParagraphsToSectionPipe()
 
     def test_transform_inserts_elements_in_sec_until_find_other_sec(self):
         text = """<root>

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -73,6 +73,89 @@ class TestConvertHMTLBodySearchAssetNodeBackwards(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestBodySectionsPipe(unittest.TestCase):
+    def setUp(self):
+        self.pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
+        self.pipe = self.pipeline.BodySectionsPipe()
+
+    def test_transform_moves_3_sections(self):
+        raw = """<root>
+            <body>
+                <p>
+                    <sec id="s01"/>
+                    <sec id="s02"/>
+                    <sec id="s03"/>
+                </p>
+            </body>
+        </root>
+        """
+        xml = etree.fromstring(raw)
+        raw, xml = self.pipe.transform((raw, xml))
+        self.assertEqual(
+            ["s01", "s02", "s03"],
+            [node.get("id") for node in xml.findall(".//body/sec")]
+        )
+        self.assertEqual(len(xml.findall(".//body/sec")), 3)
+        self.assertEqual(len(xml.find(".//body/p").getchildren()), 0)
+
+    def test_transform_moves_sections_with_subsections(self):
+        raw = """<root>
+            <body>
+                <p>
+                    <sec id="s01">
+                        <sec/>
+                        <sec/>
+                    </sec>
+                    <sec id="s02">
+                        <sec/>
+                    </sec>
+                    <sec id="s03">
+                        <sec/>
+                        <sec/>
+                        <sec/>
+                    </sec>
+                </p>
+            </body>
+        </root>
+        """
+        xml = etree.fromstring(raw)
+        raw, xml = self.pipe.transform((raw, xml))
+        self.assertEqual(
+            ["s01", "s02", "s03"],
+            [node.get("id") for node in xml.findall(".//body/sec")]
+        )
+        self.assertEqual(len(xml.findall(".//body/sec")), 3)
+        self.assertEqual(len(xml.find(".//body/p").getchildren()), 0)
+        self.assertEqual(len(xml.findall(".//body/sec/sec")), 6)
+
+    def test_transform_do_not_move(self):
+        raw = """<root>
+            <body>
+                <sec id="s01">
+                    <sec/>
+                    <sec/>
+                </sec>
+                <sec id="s02">
+                    <sec/>
+                </sec>
+                <sec id="s03">
+                    <sec/>
+                    <sec/>
+                    <sec/>
+                </sec>
+            </body>
+        </root>
+        """
+        xml = etree.fromstring(raw)
+        raw, xml = self.pipe.transform((raw, xml))
+        self.assertEqual(
+            ["s01", "s02", "s03"],
+            [node.get("id") for node in xml.findall(".//body/sec")]
+        )
+        self.assertEqual(len(xml.findall(".//body/sec")), 3)
+        self.assertEqual(len(xml.findall(".//body/sec/sec")), 6)
+
+
 class TestHTML2SPSPipeline(unittest.TestCase):
     def _transform(self, text, pipe):
         tree = etree.fromstring(text)

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -156,6 +156,24 @@ class TestBodySectionsPipe(unittest.TestCase):
         self.assertEqual(len(xml.findall(".//body/sec/sec")), 6)
 
 
+class TestCreateSectionElemetWithSectionTitlePipe(unittest.TestCase):
+    def setUp(self):
+        self.pipeline = ConvertElementsWhichHaveIdPipeline()
+        self.pipe = self.pipeline.CreateSectionElemetWithSectionTitlePipe()
+
+    def test_transform(self):
+        raw = """<root>
+            <body>
+                <sec id="s01"/><bold>Título</bold>
+            </body>
+        </root>
+        """
+        xml = etree.fromstring(raw)
+        raw, xml = self.pipe.transform((raw, xml))
+        self.assertEqual(xml.findtext(".//sec/title"), "Título")
+        self.assertIsNone(xml.findtext(".//bold"))
+
+
 class TestHTML2SPSPipeline(unittest.TestCase):
     def _transform(self, text, pipe):
         tree = etree.fromstring(text)


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a issue "Referências dentro de uma lista HTML não são retiradas do body e erro ocorre" (#291)"
Na verdade, são dois problemas diferentes. Mas foram tratados neste PR.
Ao investigar o problema, foi identificado que um dos pipes relacionados com as seções (`<sec/>`) estava inserindo `<sec/>` "acima" do "body", modificando o "primeiro nó da árvore" que seria esperado ser o "body", causando uma exceção antes de gravar o XML em arquivo.
Os pipes relacionados às seções tiveram que ser refatorados.
Por casualidade, o erro sobre as referências não removidas, está sendo registrado no migracao.log, fazendo parecer que era a causa do problema. 
Por estar no título da issue, foi tratado juntamente, mesmo que sem nenhuma relação.

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
```shell
ds_migracao --loglevel DEBUG convert --file xml/source/S0074-02762001000200022.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0074-02762000000600014.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0100-879X2006001200008.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0100-879X2006000700007.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0100-879X2007000300001.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0074-02762001000800006.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0074-02761997000800031.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0100-879X2006000800007.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0100-879X2006000900007.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0100-879X2006000700002.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0100-879X2007000400017.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0074-02761997000800022.xml
ds_migracao --loglevel DEBUG convert --file xml/source/S0100-879X2006000700011.xml
```

#### Algum cenário de contexto que queira dar?
Foi bastante difícil de identificar o problema real, pois o log não está registrando as mensagens de DEBUG, mesmo informando no comando como mencionado acima (`--loglevel DEBUG`) e não soube como ajustar isso. No entanto, consegui ver as mensagens "DEBUG" quando alterei o arquivo logger.py localmente. 

```python
"file": {
                    "level": "INFO",
...
}
```
Além disso, a própria natureza do erro, dificultou encontrá-lo. Pois, o XML passava por todos os pipes normalmente sem levantar exceções. O problema ocorria em 

https://github.com/scieloorg/document-store-migracao/blob/504a3e38675de9eba2f594f3e829d383491591a7/documentstore_migracao/export/sps_package.py#L585

O elemento "body" exisitia mas só poderia ser encontrado assim:

```python
obj_html_body.find(".//body")
```

### Screenshots
n/a

#### Quais são tickets relevantes?
#291

### Referências
n/a
