### PR TITLE
Altera coleta de ativos digitais referenciados nos XMLs nativos

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -281,23 +281,24 @@ class SPS_Package:
     @property
     def assets(self):
         xpaths = (
-            '//graphic[@xlink:href]',
-            '//media[@xlink:href]',
-            '//inline-graphic[@xlink:href]',
-            '//supplementary-material[@xlink:href]',
-            '//inline-supplementary-material[@xlink:href]',
+            './/graphic[@xlink:href]',
+            './/media[@xlink:href]',
+            './/inline-graphic[@xlink:href]',
+            './/supplementary-material[@xlink:href]',
+            './/inline-supplementary-material[@xlink:href]',
         )
+        iterators = [
+            self.xmltree.iterfind(
+                xpath, namespaces={'xlink': 'http://www.w3.org/1999/xlink'}
+            )
+            for xpath in xpaths
+        ]
         items = []
-        for xpath in xpaths:
-            for node in self.xmltree.findall(
-                    xpath,
-                    namespaces={"xlink": "http://www.w3.org/1999/xlink"}):
-                href = node.get("{http://www.w3.org/1999/xlink}href")
-                if ":" not in href and "/" not in href:
-                    name, ext = os.path.splitext(href)
-                    if not ext:
-                        href += '.jpg'
-                    items.append(href)
+        for node in itertools.chain(*iterators):
+            href = node.get("{http://www.w3.org/1999/xlink}href")
+            if ":" not in href and "/" not in href:
+                name, ext = os.path.splitext(href)
+                items.append(href)
         return items
 
     @property

--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -217,6 +217,19 @@ class BuildPSPackage(object):
             with open(_renditions_manifest_path, "w") as jfile:
                 jfile.write(json.dumps(metadata))
 
+    def collect_asset_alternatives(self, img_filename, source_path, target_path):
+        # Try to find other files with the same filename root
+        filenames_to_update = []
+        filename_root, __ = os.path.splitext(img_filename)
+        with os.scandir(source_path) as it:
+            for entry in it:
+                entry_name_root, __ = os.path.splitext(os.path.basename(entry.name))
+                if entry.is_file() and entry_name_root == filename_root:
+                    logger.debug("File found: %s", entry.name)
+                    shutil.copy(os.path.join(source_path, entry.name), target_path)
+                    filenames_to_update.append(entry.name)
+        return filenames_to_update
+
     def collect_assets(self, target_path, acron, issue_folder, pack_name, images):
         source_path = os.path.join(self.img_folder, acron, issue_folder)
         for img in set(images):

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -312,11 +312,52 @@ class TestBuildSPSPackageDocumentInRegularIssuePubDate(TestBuildSPSPackageBase):
         self.assertEqual(result.document_pubdate, ("2012", "01", "15",))
 
 
-class TestBuildSPSPackageXMLWEBOptimiser(TestBuildSPSPackageBase):
+def create_image_file(filename, format):
+    new_image = Image.new("RGB", (50, 50))
+    new_image.save(filename, format)
 
-    def create_image_file(self, filename, format):
-        new_image = Image.new("RGB", (50, 50))
-        new_image.save(filename, format)
+
+class TestBuildSPSPackageCollectAssetAlternatives(TestBuildSPSPackageBase):
+    def setUp(self):
+        super().setUp()
+        self.source_path = tempfile.mkdtemp()
+        self.target_path = tempfile.mkdtemp()
+        self.image_files = (
+            ("1234-5678-rctb-45-05-0110-gf01.tiff", "TIFF"),
+            ("1234-5678-rctb-45-05-0110-gf01.png", "PNG"),
+            ("1234-5678-rctb-45-05-0110-gf01.jpg", "JPEG"),
+        )
+        for image_filename, format in self.image_files:
+            image_file_path = pathlib.Path(self.source_path, image_filename)
+            create_image_file(image_file_path, format)
+
+    def tearDown(self):
+        shutil.rmtree(self.source_path)
+        shutil.rmtree(self.target_path)
+
+    def test_no_alternatives(self):
+        result = self.builder.collect_asset_alternatives(
+            "1234-5678-rctb-45-05-0110-gf02.tiff", self.source_path, self.target_path
+        )
+        self.assertEqual(type(result), list)
+        self.assertEqual(len(result), 0)
+
+    def test_saves_alternatives_into_target_path(self):
+        self.builder.collect_asset_alternatives(
+            "1234-5678-rctb-45-05-0110-gf01.gif", self.source_path, self.target_path
+        )
+        for image_file, __ in self.image_files:
+            with self.subTest(image_file=image_file):
+                self.assertTrue(pathlib.Path(self.target_path, image_file).exists())
+
+    def test_returns_dict_with_alternatives(self):
+        result = self.builder.collect_asset_alternatives(
+            "1234-5678-rctb-45-05-0110-gf01.gif", self.source_path, self.target_path
+        )
+        self.assertEqual(result, [image_file for image_file, __ in self.image_files])
+
+
+class TestBuildSPSPackageXMLWEBOptimiser(TestBuildSPSPackageBase):
 
     def setUp(self):
         super().setUp()
@@ -350,7 +391,7 @@ class TestBuildSPSPackageXMLWEBOptimiser(TestBuildSPSPackageBase):
         )
         for image_filename, format in image_files:
             image_file_path = pathlib.Path(self.target_path, image_filename)
-            self.create_image_file(image_file_path, format)
+            create_image_file(image_file_path, format)
 
     def tearDown(self):
         shutil.rmtree(self.target_path)
@@ -362,7 +403,7 @@ class TestBuildSPSPackageXMLWEBOptimiser(TestBuildSPSPackageBase):
         )
         for image_filename, format in image_files:
             image_file_path = pathlib.Path(self.target_path, image_filename)
-            self.create_image_file(image_file_path, format)
+            create_image_file(image_file_path, format)
         graphic_01 = '<graphic xlink:href="1234-5678-rctb-45-05-0110-e01.tif"/>'
         graphic_02 = '<inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.tiff"/>'
         xml = self.xml.format(graphic_01=graphic_01, graphic_02=graphic_02)
@@ -399,7 +440,7 @@ class TestBuildSPSPackageXMLWEBOptimiser(TestBuildSPSPackageBase):
         )
         for image_filename, format in image_files:
             image_file_path = pathlib.Path(self.target_path, image_filename)
-            self.create_image_file(image_file_path, format)
+            create_image_file(image_file_path, format)
         graphic_01 = '<graphic xlink:href="1234-5678-rctb-45-05-0110-e01.tif"/>'
         graphic_02 = '<inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.tiff"/>'
         xml = self.xml.format(graphic_01=graphic_01, graphic_02=graphic_02)
@@ -429,7 +470,7 @@ class TestBuildSPSPackageXMLWEBOptimiser(TestBuildSPSPackageBase):
         )
         for image_filename, format in image_files:
             image_file_path = pathlib.Path(self.target_path, image_filename)
-            self.create_image_file(image_file_path, format)
+            create_image_file(image_file_path, format)
         graphic_01 = '<graphic xlink:href="1234-5678-rctb-45-05-0110-e01.tif"/>'
         graphic_02 = '<inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.tiff"/>'
         xml = self.xml.format(graphic_01=graphic_01, graphic_02=graphic_02)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona busca à alternativas aos ativos digitais referenciados nos XMLs nativos. Essa busca é feita somente se os ativos digitais não forem encontrados como referenciados no XMLs: sem extensão de arquivo, com extensões diferentes. Caso a busca encontre alternativas, o XML coletado é atualizado com as alternativas.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
Com CSV contendo documentos XML referenciando ativos digitais não encontrados:

1. Execute o comando `ds_migracao pack_from_site`
2. Verifique o diretório informado na opção `-Ofolder`
3. Observe que o pacote foi gerado com sucesso

Exemplo de CSV: [base_artigos.txt](https://github.com/scieloorg/document-store-migracao/files/4471829/base_artigos.txt)

#### Algum cenário de contexto que queira dar?
Existem alguns problemas que não são resolvidos neste PR, como ausência completa de ativos digitais com nomes referenciados, materiais suplementares que não se encontram no diretório de imagens e erros nos XMLs originais.

### Screenshots
n/a

#### Quais são tickets relevantes?
#283 #304

### Referências
.