### PR TITLE
Corrige pipe AssetThumbnailInLinkAndAnchorAndCaption

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1877,10 +1877,11 @@ class ConvertElementsWhichHaveIdPipeline(object):
                 p_next = p.getnext()
                 if p_next.tag != "a":
                     p_next = p_next.findall(".//a[@name]")
-                    if p_next is not None:
-                        p_next = p_next[-1]
-                if p_next.tag != "a":
-                    continue
+                    if len(p_next) == 0:
+                        continue
+                    p_next = p_next[-1]
+                    if p_next.tag != "a":
+                        continue
 
                 a_name = p_next
 


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige pipe `AssetThumbnailInLinkAndAnchorAndCaption()` na conversão do body HTML. Simplesmente altera checagem de nó por conta do retorno, que é uma lista. Caso `findall` não encontre nenhum elemento, retorna uma lista vazia ao invés de None, como era esperado. O if segunte que confere a tag `a` só faz sentido após a mudança de `p_next`, ou seja, dentro do if anterior.

#### Onde a revisão poderia começar?
Em `documentstore_migracao/utils/convert_html_body.py`, L1880

#### Como este poderia ser testado manualmente?
1. Extrair os seguintes documentos:
 - S0074-02762002000900021
 - S0100-84042009000200014
 - S0103-64402007000100012
2. Converter os documentos com o comando `ds_migracao convert`
3. Observe que os XMLs foram convertidos 

#### Algum cenário de contexto que queira dar?
Este PR resolve pontualmente este problema e leva em consideração os pontos das premissas de migração, não focando em resolver problemas de exibição/formatação.

### Screenshots
n/a

#### Quais são tickets relevantes?
#303 

### Referências
.
