### PR TITLE
Paraleliza o empacotamento dos XMLs nativos

### DIFF
--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -309,7 +309,7 @@ class BuildPSPackage(object):
         if len(assets_alternatives) > 0:
             self.update_xml_with_alternatives(assets_alternatives, sps_package, xml_target_path)
 
-    def optimise_xml_to_web(self, target_path, xml_target_path):
+    def optimise_xml_to_web(self, target_path, xml_target_path, pid):
         xml_filename = os.path.basename(xml_target_path)
 
         def read_file(filename):
@@ -319,8 +319,8 @@ class BuildPSPackage(object):
                     file_bytes = file_obj.read()
             except OSError as exc:
                 raise packtools.exceptions.SPPackageError(
-                    "Error reading file {} during {} optimization: {}".format(
-                        filename, xml_filename, str(exc)
+                    "[%s] -  Error reading file {} during {} optimization: {}".format(
+                        pid, filename, xml_filename, str(exc)
                     )
                 )
             else:
@@ -335,7 +335,12 @@ class BuildPSPackage(object):
                 xml_filename, os.listdir(target_path), read_file, target_path
             )
         except (etree.XMLSyntaxError, etree.SerialisationError) as exc:
-            logger.error('Error creating XMLWebOptimiser for "%s": %s', str(exc))
+            logger.error(
+                '[%s] - Error creating XMLWebOptimiser for "%s": %s',
+                pid,
+                xml_target_path,
+                str(exc),
+            )
         else:
             optimised_xml = xml_web_optimiser.get_xml_file()
             logger.debug("Saving optimised XML file %s", xml_filename)
@@ -345,7 +350,9 @@ class BuildPSPackage(object):
             for asset_filename, asset_bytes in xml_web_optimiser.get_optimised_assets():
                 if asset_bytes is None:
                     logger.error(
-                        'Error saving image file "%s" referenced in "%s": no file bytes',
+                        '[%s] - Error saving image file "%s" referenced in "%s": '
+                        "no file bytes",
+                        pid,
                         asset_filename,
                         xml_filename,
                     )
@@ -356,7 +363,9 @@ class BuildPSPackage(object):
             for asset_filename, asset_bytes in xml_web_optimiser.get_assets_thumbnails():
                 if asset_bytes is None:
                     logger.error(
-                        'Error saving image file "%s" referenced in "%s": no file bytes',
+                        '[%s] - Error saving image file "%s" referenced in "%s": '
+                        "no file bytes",
+                        pid,
                         asset_filename,
                         xml_filename,
                     )
@@ -464,7 +473,6 @@ class BuildPSPackage(object):
                     )
                     self.save_renditions_manifest(
                         target_path, dict(renditions))
-                    self.optimise_xml_to_web(target_path, xml_target_path)
 
 
 def main():

--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -186,7 +186,15 @@ class BuildPSPackage(object):
             target_path, os.path.basename(xml_relative_path))
         return xml_target_path
 
-    def collect_renditions(self, target_path, acron, issue_folder, pack_name, langs):
+    def collect_renditions(
+        self,
+        target_path,
+        acron,
+        issue_folder,
+        pack_name,
+        langs,
+        pid,
+    ):
         source_path = os.path.join(self.pdf_folder, acron, issue_folder)
         renditions = []
         renditions_files = [(pack_name+".pdf", pack_name+".pdf")]
@@ -196,12 +204,14 @@ class BuildPSPackage(object):
                     pack_name + "-" + lang + ".pdf"))
         for source, dest in renditions_files:
             logger.debug('Collecting PDF "%s" for XML "%s.xml"', source, pack_name)
+            file_path = os.path.join(source_path, source)
             try:
-                shutil.copy(os.path.join(source_path, source), target_path)
+                shutil.copy(file_path, target_path)
             except FileNotFoundError:
                 logger.error(
-                    'Error collecting rendition "%s" for XML "%s.xml"',
-                    source,
+                    "[%s] - Could not find rendition '%s' during packing XML '%s.xml'.",
+                    pid,
+                    file_path,
                     pack_name,
                 )
             else:
@@ -446,9 +456,6 @@ class BuildPSPackage(object):
                     xml_sps = self.update_xml_file(
                         xml_target_path, row.values(), pack_name
                     )
-                    renditions = self.collect_renditions(
-                        target_path, acron, issue_folder, pack_name,
-                        xml_sps.languages)
                     self.save_renditions_manifest(
                         target_path, dict(renditions))
                     self.collect_assets(

--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -277,16 +277,22 @@ class BuildPSPackage(object):
         xml.objXML2file(xml_target_path, _xmltree, pretty=True)
 
     def collect_assets(
-        self, target_path, acron, issue_folder, pack_name, sps_package, xml_target_path
+        self,
+        target_path,
+        acron,
+        issue_folder,
+        pack_name,
+        sps_package,
+        xml_target_path,
+        pid,
     ):
         assets_alternatives = {}
         source_path = os.path.join(self.img_folder, acron, issue_folder)
         for img in set(sps_package.assets):
-            logger.debug(
-                'Collection asset "%s" from %s into %s', img, source_path, target_path
-            )
+            img_source_path = os.path.join(source_path, img)
+            logger.debug('Collection asset "%s" to %s', img_source_path, target_path)
             try:
-                shutil.copy(os.path.join(source_path, img), target_path)
+                shutil.copy(img_source_path, target_path)
             except FileNotFoundError:
                 alternatives = self.collect_asset_alternatives(
                     img, source_path, target_path
@@ -295,10 +301,10 @@ class BuildPSPackage(object):
                     assets_alternatives[img] = alternatives
                 else:
                     logger.error(
-                        'Asset "%s" not found in %s to pack "%s"',
-                        img,
-                        source_path,
-                        target_path,
+                        "[%s] - Could not find asset '%s' during packing XML '%s'.",
+                        pid,
+                        img_source_path,
+                        xml_target_path,
                     )
         if len(assets_alternatives) > 0:
             self.update_xml_with_alternatives(assets_alternatives, sps_package, xml_target_path)
@@ -458,14 +464,6 @@ class BuildPSPackage(object):
                     )
                     self.save_renditions_manifest(
                         target_path, dict(renditions))
-                    self.collect_assets(
-                        target_path,
-                        acron,
-                        issue_folder,
-                        pack_name,
-                        xml_sps,
-                        xml_target_path,
-                    )
                     self.optimise_xml_to_web(target_path, xml_target_path)
 
 

--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -70,7 +70,7 @@ class BuildPSPackage(object):
         try:
             copy.copy_file(src_fs, src_path, dst_fs, dst_path)
 
-            logger.info(
+            logger.debug(
                 "Copy asset: %s to: %s"
                 % (
                     path.join(src_fs.root_path, src_path),
@@ -79,9 +79,9 @@ class BuildPSPackage(object):
             )
 
         except errors.ResourceNotFound as e:
-            logger.info(e)
+            logger.error(e)
 
-    def _update_sps_package_obj(self, sps_package, pack_name, row):
+    def _update_sps_package_obj(self, sps_package, pack_name, row, xml_target_path):
         """
         Atualiza instancia SPS_Package com os dados de artigos do arquivo
         articles_data_reader, um CSV com os seguintes campos:
@@ -111,7 +111,7 @@ class BuildPSPackage(object):
                 logger.debug('Updating document with %s "%s"', date_label, date_value)
                 return _parse_date(date_value)
             else:
-                logger.debug('Missing date_label "%s"', date_label)
+                logger.debug('Missing "%s" into XML file "%s".', date_label, xml_target_path)
 
         _sps_package = deepcopy(sps_package)
         f_pid, f_pid_aop, f_file, f_dt_collection, f_dt_created, f_dt_updated = row
@@ -158,7 +158,7 @@ class BuildPSPackage(object):
 
         logger.debug('Updating XML "%s" with CSV info', xml_target_path)
         sps_package = self._update_sps_package_obj(
-            SPS_Package(obj_xmltree), pack_name, row
+            SPS_Package(obj_xmltree), pack_name, row, xml_target_path
         )
 
         # Salva XML com alterações

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -128,7 +128,13 @@ class TestBuildSPSPackage(TestBuildSPSPackageBase):
     @mock.patch("documentstore_migracao.utils.build_ps_package.shutil.copy")
     def test_collect_renditions_for_document_without_translations(self, mock_copy):
         result = self.builder.collect_renditions(
-            "/data/output/abc/v1n1/bla", "abc", "v1n1", "bla", ["pt"])
+            "/data/output/abc/v1n1/bla",
+            "abc",
+            "v1n1",
+            "bla",
+            ["pt"],
+            "S0101-02022020000010001",
+        )
         mock_copy.assert_called_once_with(
             "/data/pdfs/abc/v1n1/bla.pdf", "/data/output/abc/v1n1/bla"
         )
@@ -137,8 +143,13 @@ class TestBuildSPSPackage(TestBuildSPSPackageBase):
     @mock.patch("documentstore_migracao.utils.build_ps_package.shutil.copy")
     def test_collect_renditions_for_document_with_translations_in_en_and_es(self, mock_copy):
         result = self.builder.collect_renditions(
-            "/data/output/abc/v1n1/bla", "abc", "v1n1", "bla",
-            ["pt", "en", "es"])
+            "/data/output/abc/v1n1/bla",
+            "abc",
+            "v1n1",
+            "bla",
+            ["pt", "en", "es"],
+            "S0101-02022020000010001",
+        )
         assert mock_copy.call_args_list == [
             mock.call(
                 "/data/pdfs/abc/v1n1/bla.pdf", "/data/output/abc/v1n1/bla"

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -175,7 +175,7 @@ class TestBuildSPSPackagePIDUpdade(TestBuildSPSPackageBase):
         pack_name = "1806-0013-test-01-01-0001"
         row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,".split(",")
         result = self.builder._update_sps_package_obj(
-            mk_sps_package, pack_name, row
+            mk_sps_package, pack_name, row, pack_name + ".xml"
         )
         self.assertEqual(result.scielo_pid_v2, "S0101-01012019000100001")
 
@@ -188,7 +188,7 @@ class TestBuildSPSPackagePIDUpdade(TestBuildSPSPackageBase):
         row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,".split(",")
         pack_name = "1806-0013-test-01-01-0001"
         result = self.builder._update_sps_package_obj(
-            mk_sps_package, pack_name, row
+            mk_sps_package, pack_name, row, pack_name + ".xml"
         )
         self.assertEqual(result.scielo_pid_v2, "S0101-01012019000100999")
 
@@ -201,7 +201,7 @@ class TestBuildSPSPackageAOPPIDUpdade(TestBuildSPSPackageBase):
         pack_name = "1806-0013-test-01-01-0002"
         mock_getattr.side_effect = [None, None]
         result = self.builder._update_sps_package_obj(
-            mk_sps_package, pack_name, self.rows[1]
+            mk_sps_package, pack_name, self.rows[1], pack_name + ".xml"
         )
         self.assertEqual(result.aop_pid, "S0101-01012019005000001")
 
@@ -213,7 +213,7 @@ class TestBuildSPSPackageAOPPIDUpdade(TestBuildSPSPackageBase):
         )
         pack_name = "1806-0013-test-01-01-0002"
         result = self.builder._update_sps_package_obj(
-            mk_sps_package, pack_name, self.rows[1]
+            mk_sps_package, pack_name, self.rows[1], pack_name + ".xml"
         )
         self.assertEqual(result.aop_pid, "S0101-01012019005000001")
 
@@ -225,7 +225,7 @@ class TestBuildSPSPackageAOPPIDUpdade(TestBuildSPSPackageBase):
         )
         pack_name = "1806-0013-test-01-01-0001"
         result = self.builder._update_sps_package_obj(
-            mk_sps_package, pack_name, self.rows[0]
+            mk_sps_package, pack_name, self.rows[0], pack_name + ".xml"
         )
         self.assertIsNone(result.aop_pid)
 
@@ -243,7 +243,7 @@ class TestBuildSPSPackageAOPPubDate(TestBuildSPSPackageBase):
         )
         pack_name = "1806-0013-test-01-01-0003"
         result = self.builder._update_sps_package_obj(
-            mk_sps_package, pack_name, self.rows[2]
+            mk_sps_package, pack_name, self.rows[2], pack_name + ".xml"
         )
         mk_sps_package.document_pubdate.assert_not_called()
         mk_sps_package.documents_bundle_pubdate.assert_not_called()
@@ -265,14 +265,14 @@ class TestBuildSPSPackageRollingPassDocumentPubDate(TestBuildSPSPackageBase):
     def test__update_sps_package_obj_completes_documents_bundle_pubdate(self):
         self.mk_sps_package.documents_bundle_pubdate = ("", "", "",)
         result = self.builder._update_sps_package_obj(
-            self.mk_sps_package, self.pack_name, self.rows[1]
+            self.mk_sps_package, self.pack_name, self.rows[1], self.pack_name + ".xml"
         )
         self.assertEqual(result.documents_bundle_pubdate, ("2019", "02", "",))
 
     def test__update_sps_package_obj_does_not_change_documents_bundle_pubdate(self):
         self.mk_sps_package.documents_bundle_pubdate = ("2012", "", "",)
         result = self.builder._update_sps_package_obj(
-            self.mk_sps_package, self.pack_name, self.rows[1]
+            self.mk_sps_package, self.pack_name, self.rows[1], self.pack_name + ".xml"
         )
         self.assertEqual(result.documents_bundle_pubdate, ("2012", "", "",))
 
@@ -293,7 +293,7 @@ class TestBuildSPSPackageDocumentInRegularIssuePubDate(TestBuildSPSPackageBase):
         self.mk_sps_package.documents_bundle_pubdate = ("2012", "02", "03",)
         self.mk_sps_package.document_pubdate = ("", "", "",)
         result = self.builder._update_sps_package_obj(
-            self.mk_sps_package, self.pack_name, self.rows[1]
+            self.mk_sps_package, self.pack_name, self.rows[1], self.pack_name + ".xml"
         )
         self.assertEqual(result.document_pubdate, ("2019", "01", "15",))
 
@@ -301,7 +301,7 @@ class TestBuildSPSPackageDocumentInRegularIssuePubDate(TestBuildSPSPackageBase):
         self.mk_sps_package.documents_bundle_pubdate = ("2012", "02", "",)
         self.mk_sps_package.document_pubdate = ("2012", "01", "15",)
         result = self.builder._update_sps_package_obj(
-            self.mk_sps_package, self.pack_name, self.rows[1]
+            self.mk_sps_package, self.pack_name, self.rows[1], self.pack_name + ".xml"
         )
         self.assertEqual(result.document_pubdate, ("2012", "01", "15",))
 

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -612,6 +612,7 @@ class TestBuildSPSPackageCollectAsset(TestBuildSPSPackageBase):
             self.pack_name,
             self.sps_package,
             self.xml_target_path,
+            "S0101-01012019000100001",
         )
         self.assertTrue(
             pathlib.Path(self.target_path, "1234-5678-rctb-45-05-0110-gf01.tiff").exists()
@@ -632,6 +633,7 @@ class TestBuildSPSPackageCollectAsset(TestBuildSPSPackageBase):
             self.pack_name,
             self.sps_package,
             self.xml_target_path,
+            "S0101-01012019000100001",
         )
         for image_file, __ in self.image_files:
             with self.subTest(image_file=image_file):
@@ -652,6 +654,7 @@ class TestBuildSPSPackageCollectAsset(TestBuildSPSPackageBase):
             self.pack_name,
             self.sps_package,
             self.xml_target_path,
+            "S0101-01012019000100001",
         )
         with self.xml_target_path.open() as xmlfile:
             xml_result = etree.parse(
@@ -686,6 +689,7 @@ class TestBuildSPSPackageCollectAsset(TestBuildSPSPackageBase):
             self.pack_name,
             self.sps_package,
             self.xml_target_path,
+            "S0101-01012019000100001",
         )
         for image_file, __ in self.image_files:
             with self.subTest(image_file=image_file):
@@ -706,6 +710,7 @@ class TestBuildSPSPackageCollectAsset(TestBuildSPSPackageBase):
             self.pack_name,
             self.sps_package,
             self.xml_target_path,
+            "S0101-01012019000100001",
         )
         with self.xml_target_path.open() as xmlfile:
             xml_result = etree.parse(

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -768,7 +768,9 @@ class TestBuildSPSPackageXMLWEBOptimiser(TestBuildSPSPackageBase):
         with self.xml_target_path.open("w") as xml_file:
             xml_file.write(xml)
 
-        self.builder.optimise_xml_to_web(self.target_path, str(self.xml_target_path))
+        self.builder.optimise_xml_to_web(
+            self.target_path, str(self.xml_target_path), "S0101-01012019000100001"
+        )
 
         target_path_files = [
             filename.name for filename in pathlib.Path(self.target_path).iterdir()
@@ -805,7 +807,9 @@ class TestBuildSPSPackageXMLWEBOptimiser(TestBuildSPSPackageBase):
         with self.xml_target_path.open("w") as xml_file:
             xml_file.write(xml)
 
-        self.builder.optimise_xml_to_web(self.target_path, str(self.xml_target_path))
+        self.builder.optimise_xml_to_web(
+            self.target_path, str(self.xml_target_path), "S0101-01012019000100001"
+        )
 
         target_path_files = [
             filename.name for filename in pathlib.Path(self.target_path).iterdir()
@@ -835,7 +839,9 @@ class TestBuildSPSPackageXMLWEBOptimiser(TestBuildSPSPackageBase):
         with self.xml_target_path.open("w") as xml_file:
             xml_file.write(xml)
 
-        self.builder.optimise_xml_to_web(self.target_path, str(self.xml_target_path))
+        self.builder.optimise_xml_to_web(
+            self.target_path, str(self.xml_target_path), "S0101-01012019000100001"
+        )
 
         target_path_files = [
             filename for filename in pathlib.Path(self.target_path).iterdir()


### PR DESCRIPTION
#### O que esse PR faz?
Este PR paraleliza o empacotamento dos XMLs nativos, seus ativos digitais e suas manifestações PDF. Também foram alterados métodos do processo para melhorar os logs, tanto nas mensagens logadas como nas informações nelas contidas.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
Com CSV contendo documentos XML referenciando ativos digitais não encontrados:

1. Execute o comando `ds_migracao pack_from_site`
2. Verifique o diretório informado na opção `-Ofolder`
3. Observe que o pacote foi gerado com sucesso
4. Observe que agora a aplicação executa o empacotamento em paralelo e a barra de progresso é exibida

Exemplo de CSV: 
[base_artigos_erro.txt](https://github.com/scieloorg/document-store-migracao/files/4495184/base_artigos_erro.txt)

#### Algum cenário de contexto que queira dar?
.

### Screenshots
.

#### Quais são tickets relevantes?
#310 

### Referências
.