### PR TITLE
Corrige tag a inválida e prevê existência de tags inválidas

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -245,6 +245,7 @@ class HTML2SPSPipeline(object):
         self._ppl = plumber.Pipeline(
             self.SetupPipe(),
             self.SaveRawBodyPipe(super_obj=self),
+            self.FixATagPipe(),
             self.ConvertRemote2LocalPipe(),
             self.RemoveReferencesFromBodyPipe(super_obj=self),
             self.RemoveCommentPipe(),
@@ -320,6 +321,20 @@ class HTML2SPSPipeline(object):
             )
             logger.debug("FIM: %s" % type(self).__name__)
             return data, xml
+
+    class FixATagPipe(plumber.Pipe):
+        def _change_src_to_href(self, node):
+            href = node.attrib.get("href")
+            src = node.attrib.get("src")
+            if not href and src:
+                node.attrib["href"] = node.attrib.pop("src")
+
+        def transform(self, data):
+            logger.debug("INICIO: %s" % type(self).__name__)
+            raw, xml = data
+            _process(xml, "a[@src]", self._change_src_to_href)
+            logger.debug("FIM: %s" % type(self).__name__)
+            return data
 
     class ConvertRemote2LocalPipe(plumber.Pipe):
         def transform(self, data):

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1209,6 +1209,8 @@ class HTML2SPSPipeline(object):
                 node.set("href", href.replace('"', ""))
                 href = node.get("href")
 
+            if not href:
+                return
             if href[0] in ["#", "."] or href.startswith("/img/revistas/"):
                 return
             if "mailto" in href or "@" in href:

--- a/tests/test_convert_html_body.py
+++ b/tests/test_convert_html_body.py
@@ -1978,6 +1978,41 @@ class TestImgPipe(unittest.TestCase):
                 self.assertEqual(len(node.attrib), 1)
 
 
+class TestFixATagPipe(unittest.TestCase):
+    def setUp(self):
+        self.pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")
+        self.pipe = self.pipeline.FixATagPipe()
+
+    def test_changes_existing_src_attrib_to_href(self):
+        text = """
+            <root><body>
+                <a href="" src="/img/revista/test/a01tb1.gif">texto 1</a>
+                <a href="/img/revista/test/a01tb2.gif">texto 2</a>
+            </body></root>
+        """
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+
+        nodes = xml.findall(".//a")
+        self.assertEqual(nodes[0].attrib.get("href"), "/img/revista/test/a01tb1.gif")
+        self.assertIsNone(nodes[0].attrib.get("src"))
+        self.assertEqual(nodes[1].attrib.get("href"), "/img/revista/test/a01tb2.gif")
+
+    def test_does_nothing_if_a_href_is_correct(self):
+        text = """
+            <root><body>
+                <a href="/img/revista/test/a01tb1.gif">texto 1</a>
+                <a href="/img/revista/test/a01tb2.gif">texto 2</a>
+            </body></root>
+        """
+        xml = etree.fromstring(text)
+        text, xml = self.pipe.transform((text, xml))
+
+        nodes = xml.findall(".//a")
+        self.assertEqual(nodes[0].attrib.get("href"), "/img/revista/test/a01tb1.gif")
+        self.assertEqual(nodes[1].attrib.get("href"), "/img/revista/test/a01tb2.gif")
+
+
 class TestConvertRemote2LocalPipe(unittest.TestCase):
     def test_transform_imports_html_content(self):
         pipeline = HTML2SPSPipeline(pid="S1234-56782018000100011")


### PR DESCRIPTION
#### O que esse PR faz?
Este PR trata tags `a` inválidas que tem atributo `src` ao invés de `href` para o link. Também verifica a inexistência do atributo `href` em tags `a` antes de tratá-la pela conversão, pois é um atributo obrigatório.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
1. Extraia os documentos em [pids_issue_299.txt](https://github.com/scieloorg/document-store-migracao/files/4470707/pids_issue_299.txt) através do comando `ds_migracao extract`
2. Converta os documentos com o comando `ds_migracao convert`
3. Todos os documentos devem ser convertidos com sucesso

#### Algum cenário de contexto que queira dar?
Conforme reportado no https://github.com/scieloorg/document-store-migracao/issues/299#issuecomment-617922715, mesmo sem este PR foi possível converter quase todos os documentos. O único documentos que tem efeito em sua conversão é o `S0101-20612004000200001`.

### Screenshots
n/a

#### Quais são tickets relevantes?
#299 

### Referências
.
