### PR TITLE
Padroniza caminho do documento XML nativo

### DIFF
--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -572,6 +572,31 @@ class TestBuildSPSPackageCollectAssetAlternatives(TestBuildSPSPackageBase):
         self.assertEqual(result, [image_file for image_file, __ in self.image_files])
 
 
+class TestBuildSPSPackageGetExistingXMLPath(TestBuildSPSPackageBase):
+    def setUp(self):
+        super().setUp()
+
+    def test_file_path_ok(self):
+        result = self.builder.get_existing_xml_path(
+            "acron/v1n1/document.xml", "ACRON", "v1n1"
+        )
+        self.assertEqual(result, "acron/v1n1/document.xml")
+
+    def test_absolute_posix_file_path(self):
+        result = self.builder.get_existing_xml_path(
+            "/spf/data/xml/acron/v1n1/document.xml", "ACRON", "v1n1",
+        )
+        self.assertEqual(result, "acron/v1n1/document.xml")
+
+    def test_win_file_path(self):
+        result = self.builder.get_existing_xml_path(
+            "\\\\dir1\\dir2\\dir3\\SciELO\\serial\\acron\\2009nahead\\xml\\document.xml",
+            "ACRON",
+            "v1n1",
+        )
+        self.assertEqual(result, "acron/v1n1/document.xml")
+
+
 class TestBuildSPSPackageCollectAsset(TestBuildSPSPackageBase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
#### O que esse PR faz?
Para padronizar o caminho relativo onde o XML nativo deveria estar para a estrutura do site atual, lê as informações necessárias do CSV e remonta o path com o acrônimo do periódico, label do fascículo e nome do arquivo XML do campo `file` do CSV.

#### Onde a revisão poderia começar?
Em `tests/test_build_ps_package.py`, para entender os paths como são esperados hoje.

#### Como este poderia ser testado manualmente?
Com CSV atualizado, contendo as informações do acrônimo do periódico e label do fascículo, :
1. Execute o comando `ds_migracao pack_from_site`
2. Verifique o caminho que os documentos XMLs estão sendo buscados, que deve ser `<acrônimo>/<label do fascículo>/<arquivo XML>`
3. Observe que os diretórios no caminho informado no argumento `-Ofolder` do comando segue o padrão esperado do empacotamento

[Arquivo com paths de documentos fora do padrão esperado anteriormente](https://github.com/scieloorg/document-store-migracao/files/4574543/nativos-XMLNotFound.txt)

#### Algum cenário de contexto que queira dar?
Apesar do ajuste deste PR, ainda assim não foi possível testar com o ambiente real que temos pois os documentos que apresentaram problema durante o último teste de empacotamento não foram encontrados nos pontos de montagem utilizados.

### Screenshots
n/a

#### Quais são tickets relevantes?
#318 

### Referências
.