### PR TITLE
Ajusta método de atualização de XML nativo para receber novo CSV

### DIFF
--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -117,7 +117,7 @@ class BuildPSPackage(object):
                 logger.debug('Missing "%s" into XML file "%s".', date_label, xml_target_path)
 
         _sps_package = deepcopy(sps_package)
-        f_pid, f_pid_aop, f_file, f_dt_collection, f_dt_created, f_dt_updated = row
+        f_pid, f_pid_aop, f_file, f_dt_collection, f_dt_created, f_dt_updated, __, __ = row
         # Verificar se tem PID
         if _has_attr_to_set("scielo_pid_v2"):
             if f_pid:

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -61,19 +61,25 @@ class TestBuildSPSPackageBase(TestCase):
              'test/v1n1/1806-0013-test-01-01-0001.xml',
              '',
              '',
-             ''],
+             '',
+             'test',
+             'v1n1'],
             ['S0101-01012019000100002',
              'S0101-01012019005000001',
              'test/v1n1/1806-0013-test-01-01-0002.xml',
              '20190200',
              '20190115',
-             '20190507'],
+             '20190507',
+             'test',
+             'v1n1'],
             ['S0101-01012019000100003',
              '',
              'test/v1n1/1806-0013-test-01-01-0003.xml',
              '',
              '',
-             '']
+             '',
+             'test',
+             'v1n1'],
         ]
         self.xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><body>
         <sec>
@@ -184,7 +190,7 @@ class TestBuildSPSPackagePIDUpdade(TestBuildSPSPackageBase):
         mk_sps_package = mock.Mock(spec=SPS_Package)
         mock_getattr.side_effect = [None, None]
         pack_name = "1806-0013-test-01-01-0001"
-        row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,".split(",")
+        row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,test,v1n1,".split(",")
         result = self.builder._update_sps_package_obj(
             mk_sps_package, pack_name, row, pack_name + ".xml"
         )
@@ -196,7 +202,7 @@ class TestBuildSPSPackagePIDUpdade(TestBuildSPSPackageBase):
             spec=SPS_Package, scielo_pid_v2="S0101-01012019000100999")
         mock_getattr.side_effect = ["S0101-01012019000100999", None]
 
-        row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,".split(",")
+        row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,test,v1n1,".split(",")
         pack_name = "1806-0013-test-01-01-0001"
         result = self.builder._update_sps_package_obj(
             mk_sps_package, pack_name, row, pack_name + ".xml"


### PR DESCRIPTION
#### O que esse PR faz?
Com novo formato de CSV, também foi necessário alterar o método de atualização de XMLs nativos para que duas novas colunas são esperadas em cada linha do arquivo.

#### Onde a revisão poderia começar?
Em `documentstore_migracao/utils/build_ps_package.py`

#### Como este poderia ser testado manualmente?
Com o CSV novo, contendo as colunas de acrônimo e label do fascículo, execute o comando `ds_migracao pack_from_site`. Nenhum erro deve ocorrer.

#### Algum cenário de contexto que queira dar?
Complementa o PR #321.

### Screenshots
n/a

#### Quais são tickets relevantes?
#318

### Referências
.
