### PR TITLE
Corrige erros de serialização durante a atualização de artigos XML

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -1,6 +1,7 @@
 import os
 import itertools
 import logging
+from typing import Tuple
 
 from copy import deepcopy
 from lxml import etree
@@ -468,22 +469,26 @@ class SPS_Package:
                 new_node.text = val
                 pubdate_node.append(new_node)
         existing_pubdate = self.article_meta.find("pub-date")
-        existing_pubdate.addnext(pubdate_node)
+
+        if existing_pubdate is not None:
+            existing_pubdate.addnext(pubdate_node)
 
     @property
-    def document_pubdate(self):
+    def document_pubdate(self) -> Tuple[str, str, str]:
         xpaths = (
             'pub-date[@pub-type="epub"]',
             'pub-date[@date-type="pub"]',
             'pub-date',
         )
         pub_date = self._match_pubdate(xpaths)
-        is_collection_pubdate = (
+        pub_date_or_empty = ("", "", "")
+
+        if pub_date is not None and not (
             pub_date.get("date-type", pub_date.get("pub-type")) == "collection"
-        )
-        if not is_collection_pubdate:
-            return parse_date(pub_date)
-        return ("", "", "")
+        ):
+            pub_date_or_empty = parse_date(pub_date)
+
+        return pub_date_or_empty
 
     @document_pubdate.setter
     def document_pubdate(self, value):

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -76,8 +76,8 @@ class SPS_Package:
     @xmltree.setter
     def xmltree(self, value):
         try:
-            etree.tostring(value)
-        except TypeError:
+            etree.tostring(value, encoding="utf-8")
+        except (TypeError, etree.SerialisationError):
             raise
         else:
             self._xmltree = value


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request resolve principalmente o erro de serialização durante a atualização de documentos nativamente XML. Também corrige acesso a objetos vazios durante atualização da data de publicação.

#### Onde a revisão poderia começar?

- `documentstore_migracao/export/sps_package.py` L: `80`

#### Como este poderia ser testado manualmente?

Para testar este pull request manualmente, deve-se:
- Fazer o download da lista de documentos com erro em [1];
- Realizar o empacotamento com a lista [1];
- Verificar que os documentos não apresentam mais erro de _enconding_.

#### Algum cenário de contexto que queira dar?
O erro relacionado com o documento `S0036-46652014000300185` não foi tratado
porque é um problema de XML e precisa ser corrigido manualmente. Segue o erro:

```
Exception: Entity 'squf' not defined, line 546, column 99 (0036-4665-rimtsp-56-03-185.xml, line 546)
```

### Screenshots
N/A

#### Quais são tickets relevantes?
closes #325 

### Anexos

[[1] - issue-325.txt](https://github.com/scieloorg/document-store-migracao/files/4665036/issue-325.txt)

### Referências
N/A

