### PR TITLE
Adiciona idioma original ao XMLs nativos quando não houver

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -558,6 +558,20 @@ class SPS_Package:
         )
 
     @property
+    def original_language(self):
+        """The language of the main document."""
+        article_tag = self.xmltree.xpath('/article[@xml:lang]')
+        if article_tag:
+            return article_tag[0].attrib["{http://www.w3.org/XML/1998/namespace}lang"]
+
+    @original_language.setter
+    def original_language(self, value):
+        """Set language of the main document."""
+        article_tag = self.xmltree.xpath('/article')
+        if article_tag:
+            article_tag[0].set("{http://www.w3.org/XML/1998/namespace}lang", value)
+
+    @property
     def media_prefix(self):
 
         if not self.scielo_pid_v3:

--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -136,6 +136,13 @@ class BuildPSPackage(object):
             else:
                 logger.debug('No AOP PID for document PID "%s"', f_pid)
 
+        if _has_attr_to_set("original_language"):
+            if f_lang:
+                logger.debug('Updating document "%s" with original language "%s"', f_pid, f_lang)
+                _sps_package.original_language = f_lang
+            else:
+                logger.debug('No original language for document PID "%s"', f_pid)
+
         # Verificar data de publicação e da coleção
         if not _sps_package.is_ahead_of_print:
             if _has_attr_to_set("documents_bundle_pubdate", 4):

--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -94,6 +94,9 @@ class BuildPSPackage(object):
             - 'DATA (COLLECTION)'
             - 'DATA PRIMEIRO PROCESSAMENTO'
             - 'DATA DO ULTIMO PROCESSAMENTO'
+            - 'ACRON'
+            - 'VOLNUM'
+            - 'LANG'
         """
         def _has_attr_to_set(attr, min_attr_len=1):
             _sps_package_attr = getattr(_sps_package, attr) or ""
@@ -117,7 +120,7 @@ class BuildPSPackage(object):
                 logger.debug('Missing "%s" into XML file "%s".', date_label, xml_target_path)
 
         _sps_package = deepcopy(sps_package)
-        f_pid, f_pid_aop, f_file, f_dt_collection, f_dt_created, f_dt_updated, __, __ = row
+        f_pid, f_pid_aop, f_file, f_dt_collection, f_dt_created, f_dt_updated, __, __, f_lang = row
         # Verificar se tem PID
         if _has_attr_to_set("scielo_pid_v2"):
             if f_pid:
@@ -447,7 +450,8 @@ class BuildPSPackage(object):
             f_dt_created,
             f_dt_updated,
             f_acron,
-            f_volnum
+            f_volnum,
+            f_lang,
         ) = row.values()
 
         xml_relative_path = self.get_existing_xml_path(f_file, f_acron, f_volnum)
@@ -509,6 +513,7 @@ class BuildPSPackage(object):
             "date_updated",
             "acron",
             "volnum",
+            "lang",
         )
         with open(self.articles_csvfile, encoding="utf-8", errors="replace") as csvfile:
             # pid, aoppid, file, pubdate, epubdate, update, acron, volnum

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -20,6 +20,9 @@ CSV_FIELDNAMES = (
     "DATA (COLLECTION)",
     "DATA PRIMEIRO PROCESSAMENTO",
     "DATA DO ULTIMO PROCESSAMENTO",
+    "ACRON",
+    "VOLNUM",
+    "LANG",
 )
 
 
@@ -39,9 +42,9 @@ def create_xml(xml_file_path, article_meta_xml, sps_version="sps-1.9"):
 
 def fake_csv():
     return io.StringIO(
-        "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,\n"
-        "S0101-01012019000100002,S0101-01012019005000001,test/v1n1/1806-0013-test-01-01-0002.xml,20190200,20190115,20190507\n"
-        "S0101-01012019000100003,,test/v1n1/1806-0013-test-01-01-0003.xml,,,\n"
+        "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,test,v1n1,pt\n"
+        "S0101-01012019000100002,S0101-01012019005000001,test/v1n1/1806-0013-test-01-01-0002.xml,20190200,20190115,20190507,test,v1n1,es\n"
+        "S0101-01012019000100003,,test/v1n1/1806-0013-test-01-01-0003.xml,,,test,v1n1,en\n"
     )
 
 
@@ -63,7 +66,8 @@ class TestBuildSPSPackageBase(TestCase):
              '',
              '',
              'test',
-             'v1n1'],
+             'v1n1',
+             'pt'],
             ['S0101-01012019000100002',
              'S0101-01012019005000001',
              'test/v1n1/1806-0013-test-01-01-0002.xml',
@@ -71,7 +75,8 @@ class TestBuildSPSPackageBase(TestCase):
              '20190115',
              '20190507',
              'test',
-             'v1n1'],
+             'v1n1',
+             'es'],
             ['S0101-01012019000100003',
              '',
              'test/v1n1/1806-0013-test-01-01-0003.xml',
@@ -79,7 +84,8 @@ class TestBuildSPSPackageBase(TestCase):
              '',
              '',
              'test',
-             'v1n1'],
+             'v1n1',
+             'en'],
         ]
         self.xml = """<article xmlns:xlink="http://www.w3.org/1999/xlink"><body>
         <sec>
@@ -190,7 +196,7 @@ class TestBuildSPSPackagePIDUpdade(TestBuildSPSPackageBase):
         mk_sps_package = mock.Mock(spec=SPS_Package)
         mock_getattr.side_effect = [None, None]
         pack_name = "1806-0013-test-01-01-0001"
-        row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,test,v1n1,".split(",")
+        row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,test,v1n1,en,".split(",")
         result = self.builder._update_sps_package_obj(
             mk_sps_package, pack_name, row, pack_name + ".xml"
         )
@@ -202,7 +208,7 @@ class TestBuildSPSPackagePIDUpdade(TestBuildSPSPackageBase):
             spec=SPS_Package, scielo_pid_v2="S0101-01012019000100999")
         mock_getattr.side_effect = ["S0101-01012019000100999", None]
 
-        row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,test,v1n1,".split(",")
+        row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,test,v1n1,pt,".split(",")
         pack_name = "1806-0013-test-01-01-0001"
         result = self.builder._update_sps_package_obj(
             mk_sps_package, pack_name, row, pack_name + ".xml"

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -272,6 +272,41 @@ class TestBuildSPSPackageAOPPubDate(TestBuildSPSPackageBase):
         mk_sps_package.documents_bundle_pubdate.assert_not_called()
 
 
+class TestBuildSPSPackageLang(TestBuildSPSPackageBase):
+
+    def test__update_sps_package_obj_does_not_update_lang_if_it_is_set(self):
+        mk_sps_package = mock.Mock(
+            spec=SPS_Package,
+            aop_pid=None,
+            scielo_pid_v2="S0101-01012019000100003",
+            is_ahead_of_print=False,
+            original_language="pt",
+            documents_bundle_pubdate=("2012", "01", "15",),
+            document_pubdate=("", "", "",),
+        )
+        pack_name = "1806-0013-test-01-01-0003"
+        result = self.builder._update_sps_package_obj(
+            mk_sps_package, pack_name, self.rows[2], pack_name + ".xml"
+        )
+        self.assertEqual(result.original_language, "pt")
+
+    def test__update_sps_package_obj_updates_lang_if_it_is_not_set(self):
+        mk_sps_package = mock.Mock(
+            spec=SPS_Package,
+            aop_pid=None,
+            scielo_pid_v2="S0101-01012019000100003",
+            is_ahead_of_print=False,
+            original_language=None,
+            documents_bundle_pubdate=("2012", "01", "15",),
+            document_pubdate=("", "", "",),
+        )
+        pack_name = "1806-0013-test-01-01-0003"
+        result = self.builder._update_sps_package_obj(
+            mk_sps_package, pack_name, self.rows[2], pack_name + ".xml"
+        )
+        self.assertEqual(result.original_language, "en")
+
+
 class TestBuildSPSPackageRollingPassDocumentPubDate(TestBuildSPSPackageBase):
 
     def setUp(self):

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -194,7 +194,7 @@ class TestBuildSPSPackagePIDUpdade(TestBuildSPSPackageBase):
     @mock.patch("documentstore_migracao.utils.build_ps_package.getattr")
     def test__update_sps_package_obj_updates_pid_if_it_is_none(self, mock_getattr):
         mk_sps_package = mock.Mock(spec=SPS_Package)
-        mock_getattr.side_effect = [None, None]
+        mock_getattr.side_effect = [None, None, None]
         pack_name = "1806-0013-test-01-01-0001"
         row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,test,v1n1,en,".split(",")
         result = self.builder._update_sps_package_obj(
@@ -206,7 +206,7 @@ class TestBuildSPSPackagePIDUpdade(TestBuildSPSPackageBase):
     def test__update_sps_package_obj_does_not_update_pid_if_it_is_not_none(self, mock_getattr):
         mk_sps_package = mock.Mock(
             spec=SPS_Package, scielo_pid_v2="S0101-01012019000100999")
-        mock_getattr.side_effect = ["S0101-01012019000100999", None]
+        mock_getattr.side_effect = ["S0101-01012019000100999", None, None]
 
         row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,test,v1n1,pt,".split(",")
         pack_name = "1806-0013-test-01-01-0001"
@@ -222,7 +222,7 @@ class TestBuildSPSPackageAOPPIDUpdade(TestBuildSPSPackageBase):
     def test__update_sps_package_obj_updates_aop_pid_if_pid_is_none(self, mock_getattr):
         mk_sps_package = mock.Mock(spec=SPS_Package, aop_pid=None, scielo_pid_v2=None)
         pack_name = "1806-0013-test-01-01-0002"
-        mock_getattr.side_effect = [None, None]
+        mock_getattr.side_effect = [None, None, None]
         result = self.builder._update_sps_package_obj(
             mk_sps_package, pack_name, self.rows[1], pack_name + ".xml"
         )
@@ -230,7 +230,7 @@ class TestBuildSPSPackageAOPPIDUpdade(TestBuildSPSPackageBase):
 
     @mock.patch("documentstore_migracao.utils.build_ps_package.getattr")
     def test__update_sps_package_obj_updates_aop_pid_if_pid_is_found(self, mock_getattr):
-        mock_getattr.side_effect = ["S0101-01012019000100002", None]
+        mock_getattr.side_effect = ["S0101-01012019000100002", None, None]
         mk_sps_package = mock.Mock(
             spec=SPS_Package, aop_pid=None, scielo_pid_v2="S0101-01012019000100002"
         )
@@ -242,7 +242,7 @@ class TestBuildSPSPackageAOPPIDUpdade(TestBuildSPSPackageBase):
 
     @mock.patch("documentstore_migracao.utils.build_ps_package.getattr")
     def test__update_sps_package_obj_does_not_update_aop_pid_if_it_is_not_aop(self, mock_getattr):
-        mock_getattr.side_effect = ["S0101-01012019000100002", None]
+        mock_getattr.side_effect = ["S0101-01012019000100002", None, None]
         mk_sps_package = mock.Mock(
             spec=SPS_Package, aop_pid=None, scielo_pid_v2="S0101-01012019000100002"
         )
@@ -257,7 +257,7 @@ class TestBuildSPSPackageAOPPubDate(TestBuildSPSPackageBase):
 
     @mock.patch("documentstore_migracao.utils.build_ps_package.getattr")
     def test__update_sps_package_obj_does_not_update_pubdate_if_it_is_aop(self, mock_getattr):
-        mock_getattr.side_effect = ["S0101-01012019000100003", None]
+        mock_getattr.side_effect = ["S0101-01012019000100003", None, None]
         mk_sps_package = mock.Mock(
             spec=SPS_Package,
             aop_pid=None,
@@ -317,7 +317,8 @@ class TestBuildSPSPackageRollingPassDocumentPubDate(TestBuildSPSPackageBase):
             aop_pid=None,
             scielo_pid_v2="S0101-01012019000100002",
             is_ahead_of_print=False,
-            document_pubdate=("2012", "01", "15",)
+            document_pubdate=("2012", "01", "15",),
+            original_language="es",
         )
 
     def test__update_sps_package_obj_completes_documents_bundle_pubdate(self):
@@ -345,6 +346,7 @@ class TestBuildSPSPackageDocumentInRegularIssuePubDate(TestBuildSPSPackageBase):
             aop_pid=None,
             scielo_pid_v2="S0101-01012019000100002",
             is_ahead_of_print=False,
+            original_language="es",
         )
 
     def test__update_sps_package_obj_completes_document_pubdate(self):

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -1801,6 +1801,35 @@ class TestCompletePubDate(unittest.TestCase):
         self.assertEqual(xml_sps.documents_bundle_pubdate, ("1997", "03", ""))
 
 
+class TestOriginalLanguage(unittest.TestCase):
+    def setUp(self):
+        self.xml = """{article_tag}<article-meta>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0074-02761962000200006</article-id>
+        </article-meta></article>"""
+
+    def test_returns_none_if_lang_attr_not_set(self):
+        article_tag = '<article specific-use="sps-1.9">'
+        xml_txt = self.xml.format(article_tag=article_tag)
+        xmltree = etree.fromstring(xml_txt)
+        xml_sps = SPS_Package(xmltree)
+        self.assertIsNone(xml_sps.original_language)
+
+    def test_returns_lang_if_it_is_set(self):
+        article_tag = '<article specific-use="sps-1.9" xml:lang="pt">'
+        xml_txt = self.xml.format(article_tag=article_tag)
+        xmltree = etree.fromstring(xml_txt)
+        xml_sps = SPS_Package(xmltree)
+        self.assertEqual(xml_sps.original_language, "pt")
+
+    def test_sets_value(self):
+        article_tag = '<article specific-use="sps-1.9">'
+        xml_txt = self.xml.format(article_tag=article_tag)
+        xmltree = etree.fromstring(xml_txt)
+        xml_sps = SPS_Package(xmltree)
+        xml_sps.original_language = "en"
+        self.assertEqual(xml_sps.original_language, "en")
+
+
 class TestMoveAppendixFromBodyToBack(unittest.TestCase):
     def setUp(self):
         self.xml = """<article specific-use="sps-1.9" xmlns:xlink="http://www.w3.org/1999/xlink">


### PR DESCRIPTION
#### O que esse PR faz?
Este PR tenta resolver problema da falta do idioma original do documento em XML nativo através de dado presente na base ISIS, lido do CSV que é usado para o empacotamento. Este dado somente será inserido no XML caso não esteja no documento.

#### Onde a revisão poderia começar?
Em `documentstore_migracao/utils/build_ps_package.py`, L139-L144.

#### Como este poderia ser testado manualmente?
Com CSV contendo documentos em XML nativo:
- Execute o comando para o empacotamento `ds_migracao pack_from_site`
- Para documentos XML que não possuíam o idioma original na tag `article`, este agora deve estar presente
- Verifique se todos os pacotes foram criados com seus respectivos `manifest.json`

#### Anexos
[1] - [CSV com documentos sem idioma](https://github.com/scieloorg/document-store-migracao/files/4691754/nativos-issue-329.txt)

#### Algum cenário de contexto que queira dar?
Este problema foi detectado durante o `import` ao Kernel mas, por se tratar de um problema no documento empacotado, foi decidido corrigir na etapa anterior para garantir a integridade do XML.

### Screenshots
n/a

#### Quais são tickets relevantes?
#329

### Referências
.