### PR TITLE
Corrige bug na atualização de datas durante o empacotamento de XMLs nativos

### DIFF
--- a/documentstore_migracao/utils/manifest.py
+++ b/documentstore_migracao/utils/manifest.py
@@ -21,7 +21,7 @@ def get_document_manifest(
         raise ValueError("A creation date is required") from None
 
     _creation_date = parse_date(
-        "-".join([date_part for date_part in date if date_part])
+        "-".join([date_part for date_part in date])
     )
 
     _renditions = []

--- a/documentstore_migracao/utils/xylose_converter.py
+++ b/documentstore_migracao/utils/xylose_converter.py
@@ -19,22 +19,67 @@ def parse_date(date: str) -> str:
 
     _date = None
 
-    try:
-        _date = (
-            datetime.strptime(date, "%Y-%m-%d").isoformat(timespec="microseconds") + "Z"
-        )
-    except ValueError:
+    def limit_month_range(date):
+        """Remove o segundo mês da data limitando o intervalo de criaçã
+        >>> limit_month_range("2018-Oct-Dec")
+        >>> "2018-Dec"
+        """
+        parts = [part for part in date.split("-") if len(part.strip()) > 0]
+        return "-".join([parts[0], parts[-1]])
+
+    def remove_invalid_date_parts(date):
+        """Remove partes inválidas de datas e retorna uma data válida
+
+        >>> remove_invalid_date_parts("2019-12-100")
+        >>> "2019-12"
+        >>> remove_invalid_date_parts("2019-20-01")
+        >>> "2019" # Não faz sentido utilizar o dia válido após um mês inválido
+        """
+        date = date.split("-")
+        _date = []
+
+        for index, part in enumerate(date):
+            if len(part) == 0 or part == "00" or part == "0":
+                break
+            elif index == 1 and part.isnumeric() and int(part) > 12:
+                break
+            elif index == 2 and part.isnumeric() and int(part) > 31:
+                break
+            elif part.isdigit():
+                part = str(int(part))
+            _date.append(part)
+
+        return "-".join(_date)
+
+    formats = [
+        ("%Y-%m-%d", lambda x: x),
+        ("%Y-%m", lambda x: x),
+        ("%Y", lambda x: x),
+        ("%Y-%b-%d", lambda x: x),
+        ("%Y-%b", lambda x: x),
+        ("%Y-%B", lambda x: x),
+        ("%Y-%B-%d", lambda x: x),
+        ("%Y-%B", remove_invalid_date_parts),
+        ("%Y-%b", limit_month_range),
+        ("%Y-%m-%d", remove_invalid_date_parts),
+        ("%Y-%m", remove_invalid_date_parts),
+        ("%Y", remove_invalid_date_parts),
+    ]
+
+    for template, func in formats:
         try:
             _date = (
-                datetime.strptime(date, "%Y-%m").isoformat(timespec="microseconds")
+                datetime.strptime(func(date.strip()), template).isoformat(
+                    timespec="microseconds"
+                )
                 + "Z"
             )
         except ValueError:
-            _date = (
-                datetime.strptime(date, "%Y").isoformat(timespec="microseconds") + "Z"
-            )
+            continue
+        else:
+            return _date
 
-    return _date
+    raise ValueError("Could not transform date '%s' to ISO format" % date) from None
 
 
 def set_metadata(date: str, data: any) -> List[List]:

--- a/tests/test_xylose_converter.py
+++ b/tests/test_xylose_converter.py
@@ -34,6 +34,23 @@ class TestXyloseDateConverter(unittest.TestCase):
     def test_only_year_case(self):
         self.assertEqual("2019-01-01T00:00:00.000000Z", parse_date("2019"))
 
+    def test_parse_date_should_convert_month_locales_abbreviated_name(self):
+        self.assertEqual("2020-06-03T00:00:00.000000Z", parse_date("2020-Jun-03"))
+
+    def test_parse_date_should_convert_month_locales_full_name(self):
+        self.assertEqual("2020-07-03T00:00:00.000000Z", parse_date("2020-July-03"))
+
+    def test_parse_date_should_use_the_last_month_when_it_is_a_range_of_months(self):
+        self.assertEqual("2020-12-01T00:00:00.000000Z", parse_date("2020-Oct-Dec"))
+
+    def test_date_parse_should_discart_invalid_day(self):
+        self.assertEqual("2020-06-01T00:00:00.000000Z", parse_date("2020-06-40"))
+
+    def test_date_parse_should_use_only_the_year_if_month_is_invalid_and_day_is_not(
+        self,
+    ):
+        self.assertEqual("2020-01-01T00:00:00.000000Z", parse_date("2020-30-03"))
+
 
 class TestXyloseJournalConverter(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request corrige a atualização de datas durante o empacotamento de XMLs nativos. Também melhora a função que faz o _parser_ de strings para datas e também corrige um bug na atualização do elemento `pub-date` do xml evitando duplicidades.

#### Onde a revisão poderia começar?
- `documentstore_migracao/export/sps_package.py`

#### Como este poderia ser testado manualmente?
Para testar este pull request manualmente, deve-se:
- Baixar a lista de documentos a serem empacotados [1];
- Realizar o empacotamento da lista [1];
- Realizar o _"import"_ dos documentos no kernel;
- Verificar que os documentos com datas válidas foram importados;

#### Algum cenário de contexto que queira dar?
O comportamento de decisão sobre quando atualizar ou não as datas deve ser questionado.

### Screenshots
N/A

#### Quais são tickets relevantes?

#328

### Anexos
[[1] - issue-328-documentos.txt](https://github.com/scieloorg/document-store-migracao/files/4698046/issue-328-documentos.txt)

### Referências
N/A

