### PR TITLE
Atualiza versão do Packtools que trata exceção do Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ minio==4.0.16
 more-itertools==6.0.0
 nose==1.3.7
 numpy==1.16.3
-packtools==2.6.3
+packtools==2.6.4
 paginate==0.5.6
 PasteDeploy==2.0.1
 pathlib2==2.3.3


### PR DESCRIPTION
#### O que esse PR faz?
Este PR atualiza o Packtools para a versão que trata exceção `DecompressionBombError`. O Pillow trata abertura de arquivos de imagem que passam do limite de resolução pré estabelecido como um "potencial ataque DOS". Esta
versão do Packtools trata a exceção lançada e emite uma exceção apropriadamente, permitindo que esta aplicação já trate-a adequadamente.
O impacto final na aplicação é que o erro seja informado de forma adequada e que a otimização do pacote SPS não seja interrompida.

#### Onde a revisão poderia começar?
Em `requirements.txt`

#### Como este poderia ser testado manualmente?
Com CSV em anexo [1]:
- Execute comando `ds_migracao pack_from_site` para empacotamento de XMLs Nativos
- Verifique os pacotes criados e, com exceção das imagens com a resolução maior, os pacotes devem conter as imagens que os compõem.
- O empacotamento deve finalizar sem problemas.

#### Algum cenário de contexto que queira dar?
Este problema foi encontrado durante teste de migração realizado no ambiente de testes de desenvolvimento (DSTeste).

### Anexos
[1] - [pack_from_site-errorimageoptimisation-csv](https://gist.github.com/patymori/d01cf4f9dd9f73f702854f0fb6c0d9ec#file-pack_from_site-errorimageoptimisation-csv)

### Screenshots
n/a

#### Quais são tickets relevantes?
#326

### Referências
Documentação do Pillow falando sobre a exceção: https://pillow.readthedocs.io/en/5.1.x/reference/Image.html#PIL.Image.open.
