### PR TITLE
Atualiza a versão do JPype para 1.0.1 permitindo o uso de versões do python > 3.8.X

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,5 +69,5 @@ SQLAlchemy==1.3.13
 click==7.1.1
 construct==2.10.56
 ioisis==0.3.0
-JPype1==0.7.2
+JPype1==1.0.1
 ujson==2.0.3


### PR DESCRIPTION
#### O que esse PR faz?

Atualiza a versão do JPype para a versão 1.0.1

#### Onde a revisão poderia começar?

No arquivo de requirements.txt

#### Como este poderia ser testado manualmente?

Em ambiente python 3.8.X, realize a instalação do document-store-migracao e execute alguns dos comandos para migração as base de dados title ou issue.

Por exemplo: 

```
migrate_isis extract issue.mst --output ./issue.json 
```

Repare que não é levantado qualquer exceção! 

#### Algum cenário de contexto que queira dar?

Durante minha re-instalação do projeto localmente me deparei com o seguinte erro: 

![Screen Shot 2020-08-06 at 13 49 05](https://user-images.githubusercontent.com/373745/89560274-2539fe00-d7ed-11ea-8e4c-7bea4e54ebce.png)

