### PR TITLE
[FASE 4] Tk335 - Adiciona capacidade de verificar o PID na versão 3 no banco de dados de PIDs do XC.

### DIFF
--- a/documentstore_migracao/config.py
+++ b/documentstore_migracao/config.py
@@ -48,7 +48,7 @@ _default = dict(
     VALIDATE_ALL="FALSE",
     THREADPOOL_MAX_WORKERS=os.cpu_count() * 5,
     PROCESSPOOL_MAX_WORKERS=os.cpu_count(),
-    XC_PID_DATABASE_DSN="sqlite:///pid_manager_database.db",
+    PID_DATABASE_DSN="sqlite:///pid_manager_database.db",
 )
 
 

--- a/documentstore_migracao/config.py
+++ b/documentstore_migracao/config.py
@@ -48,6 +48,7 @@ _default = dict(
     VALIDATE_ALL="FALSE",
     THREADPOOL_MAX_WORKERS=os.cpu_count() * 5,
     PROCESSPOOL_MAX_WORKERS=os.cpu_count(),
+    XC_PID_DATABASE_DSN="sqlite:///pid_manager_database.db",
 )
 
 

--- a/documentstore_migracao/main/migrate_articlemeta.py
+++ b/documentstore_migracao/main/migrate_articlemeta.py
@@ -19,6 +19,8 @@ from documentstore_migracao.processing import (
 from documentstore_migracao.object_store import minio
 from documentstore import adapters as ds_adapters
 
+from sqlalchemy import create_engine
+
 
 logger = logging.getLogger(__name__)
 
@@ -311,6 +313,8 @@ def migrate_articlemeta_parser(sargs):
         mongo = ds_adapters.MongoDB(uri=args.uri, dbname=args.db)
         DB_Session = ds_adapters.Session.partial(mongo)
 
+        xc_database_engine = create_engine(args.xc_pid_database_dsn)
+
         storage = minio.MinioStorage(
             minio_host=args.minio_host,
             minio_access_key=args.minio_access_key,
@@ -319,7 +323,8 @@ def migrate_articlemeta_parser(sargs):
         )
 
         inserting.import_documents_to_kernel(
-            session_db=DB_Session(), storage=storage, folder=args.folder, output_path=args.output
+            session_db=DB_Session(), xc_database_engine=xc_database_engine, storage=storage,
+            folder=args.folder, output_path=args.output
         )
 
     elif args.command == "link_documents_issues":

--- a/documentstore_migracao/main/migrate_articlemeta.py
+++ b/documentstore_migracao/main/migrate_articlemeta.py
@@ -1,4 +1,5 @@
-"""  """
+# coding: utf-8
+
 import logging
 import argparse
 
@@ -151,6 +152,15 @@ def migrate_articlemeta_parser(sargs):
         metavar="",
         help=f"""Entry path to import SPS packages. The default path
         is: {config.get("SPS_PKG_PATH")}""",
+    )
+
+    import_parser.add_argument(
+        "--xc_pid_database_dsn",
+        default=config.get("XC_PID_DATABASE_DSN"),
+        dest="xc_pid_database_dsn",
+        required=True,
+        help="""Adicionar o DSN para checagem do PID V3 na base de dados do XC, \
+        formatos de DSN suportados: https://docs.sqlalchemy.org/en/13/core/engines.html"""
     )
 
     import_parser.add_argument("--output", required=True, help="The output file path")

--- a/documentstore_migracao/main/migrate_articlemeta.py
+++ b/documentstore_migracao/main/migrate_articlemeta.py
@@ -157,9 +157,9 @@ def migrate_articlemeta_parser(sargs):
     )
 
     import_parser.add_argument(
-        "--xc_pid_database_dsn",
-        default=config.get("XC_PID_DATABASE_DSN"),
-        dest="xc_pid_database_dsn",
+        "--pid_database_dsn",
+        default=config.get("PID_DATABASE_DSN"),
+        dest="pid_database_dsn",
         required=True,
         help="""Adicionar o DSN para checagem do PID V3 na base de dados do XC, \
         formatos de DSN suportados: https://docs.sqlalchemy.org/en/13/core/engines.html"""
@@ -313,7 +313,7 @@ def migrate_articlemeta_parser(sargs):
         mongo = ds_adapters.MongoDB(uri=args.uri, dbname=args.db)
         DB_Session = ds_adapters.Session.partial(mongo)
 
-        xc_database_engine = create_engine(args.xc_pid_database_dsn)
+        pid_database_engine = create_engine(args.pid_database_dsn)
 
         storage = minio.MinioStorage(
             minio_host=args.minio_host,
@@ -323,7 +323,7 @@ def migrate_articlemeta_parser(sargs):
         )
 
         inserting.import_documents_to_kernel(
-            session_db=DB_Session(), xc_database_engine=xc_database_engine, storage=storage,
+            session_db=DB_Session(), pid_database_engine=pid_database_engine, storage=storage,
             folder=args.folder, output_path=args.output
         )
 

--- a/documentstore_migracao/processing/conversion.py
+++ b/documentstore_migracao/processing/conversion.py
@@ -88,9 +88,6 @@ def convert_article_xml(file_xml_path: str, poison_pill=PoisonPill()):
     document_pubdate, issue_pubdate = get_article_dates(article)
     xml_sps.complete_pub_date(document_pubdate, issue_pubdate)
 
-    # CONSTROI O SCIELO-id NO XML CONVERTIDO
-    xml_sps.create_scielo_id()
-
     # Remove a TAG <counts> do XML
     xml_sps.transform_article_meta_count()
 

--- a/documentstore_migracao/processing/inserting.py
+++ b/documentstore_migracao/processing/inserting.py
@@ -324,10 +324,13 @@ def import_documents_to_kernel(session_db, xc_database_engine, storage, folder, 
                 exception,
             )
 
+        # O param executor por padrão é concurrent.futures.ThreadPoolExecutor.
+        # É possível e ganhamos velocidade quando utilizamos concurrent.futures.Executor,
+        # porém é necessário saber dos por menores que envolve essa alteração, é possível
+        # verificar isso em: https://docs.python.org/3/library/concurrent.futures.html#processpoolexecutor
         DoJobsConcurrently(
             register_document,
             jobs=jobs,
-            executor=concurrent.futures.ProcessPoolExecutor,
             max_workers=int(config.get("PROCESSPOOL_MAX_WORKERS")),
             success_callback=write_result_to_file,
             exception_callback=exception_callback,

--- a/documentstore_migracao/processing/inserting.py
+++ b/documentstore_migracao/processing/inserting.py
@@ -205,7 +205,7 @@ def get_article_result_dict(sps: SPS_Package) -> dict:
     return dict(article_metadata)
 
 
-def register_document(folder: str, session, storage, xc_database_engine, poison_pill=PoisonPill()) -> None:
+def register_document(folder: str, session, storage, pid_database_engine, poison_pill=PoisonPill()) -> None:
     """Registra registra pacotes SPS em uma instância do Kernel e seus
     ativos digitais em um object storage."""
 
@@ -224,7 +224,7 @@ def register_document(folder: str, session, storage, xc_database_engine, poison_
         ) from None
 
     xml_path = os.path.join(folder, xmls[0])
-    constructor.article_xml_constructor(xml_path, folder, xc_database_engine, False)
+    constructor.article_xml_constructor(xml_path, folder, pid_database_engine, False)
 
     try:
         obj_xml = xml.loadToXML(xml_path)
@@ -297,12 +297,12 @@ def create_aop_bundle(session_db, issn):
     return session_db.documents_bundles.fetch(bundle.id())
 
 
-def import_documents_to_kernel(session_db, xc_database_engine, storage, folder, output_path) -> None:
+def import_documents_to_kernel(session_db, pid_database_engine, storage, folder, output_path) -> None:
     """Armazena os arquivos do pacote SPS em um object storage, registra o documento
     no banco de dados do Kernel e por fim associa-o ao seu `document bundle`"""
 
     jobs = [
-        {"folder": package_folder, "session": session_db, "storage": storage, "xc_database_engine": xc_database_engine}
+        {"folder": package_folder, "session": session_db, "storage": storage, "pid_database_engine": pid_database_engine}
         for package_folder, _, files in os.walk(folder)
         if files is not None and len(files) > 0
     ]

--- a/documentstore_migracao/processing/inserting.py
+++ b/documentstore_migracao/processing/inserting.py
@@ -205,7 +205,7 @@ def get_article_result_dict(sps: SPS_Package) -> dict:
     return dict(article_metadata)
 
 
-def register_document(folder: str, session, storage, poison_pill=PoisonPill()) -> None:
+def register_document(folder: str, session, storage, xc_database_engine, poison_pill=PoisonPill()) -> None:
     """Registra registra pacotes SPS em uma instância do Kernel e seus
     ativos digitais em um object storage."""
 
@@ -224,7 +224,7 @@ def register_document(folder: str, session, storage, poison_pill=PoisonPill()) -
         ) from None
 
     xml_path = os.path.join(folder, xmls[0])
-    constructor.article_xml_constructor(xml_path, folder, False)
+    constructor.article_xml_constructor(xml_path, folder, xc_database_engine, False)
 
     try:
         obj_xml = xml.loadToXML(xml_path)
@@ -297,12 +297,12 @@ def create_aop_bundle(session_db, issn):
     return session_db.documents_bundles.fetch(bundle.id())
 
 
-def import_documents_to_kernel(session_db, storage, folder, output_path) -> None:
+def import_documents_to_kernel(session_db, xc_database_engine, storage, folder, output_path) -> None:
     """Armazena os arquivos do pacote SPS em um object storage, registra o documento
     no banco de dados do Kernel e por fim associa-o ao seu `document bundle`"""
 
     jobs = [
-        {"folder": package_folder, "session": session_db, "storage": storage,}
+        {"folder": package_folder, "session": session_db, "storage": storage, "xc_database_engine": xc_database_engine}
         for package_folder, _, files in os.walk(folder)
         if files is not None and len(files) > 0
     ]

--- a/documentstore_migracao/tools/constructor.py
+++ b/documentstore_migracao/tools/constructor.py
@@ -14,12 +14,14 @@ from documentstore_migracao import config
 logger = logging.getLogger(__name__)
 
 
-def article_xml_constructor(file_xml_path: str, dest_path: str, in_place: bool) -> None:
+def article_xml_constructor(file_xml_path: str, dest_path: str, xc_database_engine, in_place: bool) -> None:
 
     logger.debug("file: %s", file_xml_path)
 
     parsed_xml = xml.loadToXML(file_xml_path)
     xml_sps = SPS_Package(parsed_xml)
+
+    # VERIFICA A EXISTÊNCIA DO PID V3 NO XC
 
     # CONSTROI O SCIELO-id NO XML CONVERTIDO
     xml_sps.create_scielo_id()

--- a/documentstore_migracao/tools/constructor.py
+++ b/documentstore_migracao/tools/constructor.py
@@ -14,7 +14,7 @@ from documentstore_migracao import config
 logger = logging.getLogger(__name__)
 
 
-def article_xml_constructor(file_xml_path: str, dest_path: str, xc_database_engine, in_place: bool) -> None:
+def article_xml_constructor(file_xml_path: str, dest_path: str, pid_database_engine, in_place: bool) -> None:
 
     logger.debug("file: %s", file_xml_path)
 
@@ -24,18 +24,18 @@ def article_xml_constructor(file_xml_path: str, dest_path: str, xc_database_engi
     pid_v2 = xml_sps.scielo_pid_v2
 
     # VERIFICA A EXISTÊNCIA DO PID V3 NO XC ATRAVES DO PID V2
-    if not pid_manager.check_pid_v3_by_v2(xc_database_engine, pid_v2):
+    if not pid_manager.check_pid_v3_by_v2(pid_database_engine, pid_v2):
 
         # CONSTROI O SCIELO-id NO XML CONVERTIDO
         xml_sps.create_scielo_id()
 
         # CRIA O PID V2 E V3 NA BASE DE DADOS DO XC
-        pid_manager.create_pid(xc_database_engine, pid_v2, xml_sps.scielo_pid_v3)
+        pid_manager.create_pid(pid_database_engine, pid_v2, xml_sps.scielo_pid_v3)
 
     else:
 
         # SE CASO EXISTA O PID NO VERSÃO 3 NA BASE DO XC É PRECISO ADICIONAR NO XML
-        pid_v3 = pid_manager.get_pid_v3_by_v2(xc_database_engine, pid_v2)
+        pid_v3 = pid_manager.get_pid_v3_by_v2(pid_database_engine, pid_v2)
 
         xml_sps.scielo_pid_v3(pid_v3)
 

--- a/documentstore_migracao/tools/constructor.py
+++ b/documentstore_migracao/tools/constructor.py
@@ -37,7 +37,7 @@ def article_xml_constructor(file_xml_path: str, dest_path: str, pid_database_eng
         # SE CASO EXISTA O PID NO VERSÃO 3 NA BASE DO XC É PRECISO ADICIONAR NO XML
         pid_v3 = pid_manager.get_pid_v3_by_v2(pid_database_engine, pid_v2)
 
-        xml_sps.scielo_pid_v3(pid_v3)
+        xml_sps.scielo_pid_v3 = pid_v3
 
     if in_place:
         new_file_xml_path = file_xml_path

--- a/documentstore_migracao/tools/constructor.py
+++ b/documentstore_migracao/tools/constructor.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 from fs import path
 from fs.walk import Walker
 
-from documentstore_migracao.utils import files, string, xml
+from documentstore_migracao.utils import files, string, xml, pid_manager
 from documentstore_migracao.export.sps_package import SPS_Package
 from documentstore_migracao import config
 
@@ -21,10 +21,23 @@ def article_xml_constructor(file_xml_path: str, dest_path: str, xc_database_engi
     parsed_xml = xml.loadToXML(file_xml_path)
     xml_sps = SPS_Package(parsed_xml)
 
-    # VERIFICA A EXISTÊNCIA DO PID V3 NO XC
+    pid_v2 = xml_sps.scielo_pid_v2
 
-    # CONSTROI O SCIELO-id NO XML CONVERTIDO
-    xml_sps.create_scielo_id()
+    # VERIFICA A EXISTÊNCIA DO PID V3 NO XC ATRAVES DO PID V2
+    if not pid_manager.check_pid_v3_by_v2(xc_database_engine, pid_v2):
+
+        # CONSTROI O SCIELO-id NO XML CONVERTIDO
+        xml_sps.create_scielo_id()
+
+        # CRIA O PID V2 E V3 NA BASE DE DADOS DO XC
+        pid_manager.create_pid(xc_database_engine, pid_v2, xml_sps.scielo_pid_v3)
+
+    else:
+
+        # SE CASO EXISTA O PID NO VERSÃO 3 NA BASE DO XC É PRECISO ADICIONAR NO XML
+        pid_v3 = pid_manager.get_pid_v3_by_v2(xc_database_engine, pid_v2)
+
+        xml_sps.scielo_pid_v3(pid_v3)
 
     if in_place:
         new_file_xml_path = file_xml_path

--- a/documentstore_migracao/utils/pid_manager.py
+++ b/documentstore_migracao/utils/pid_manager.py
@@ -3,7 +3,7 @@
 """
 Módulo responsável por obter dados de um banco de dados com a seguinte estrutura:
 
-    TABLE "pid_versions" (
+    CREATE TABLE "pid_versions" (
         "id"    INTEGER,
         "v2"    VARCHAR(23),
         "v3"    VARCHAR(255),
@@ -18,6 +18,8 @@ Reparem que existe uma unicidade entre as colunas v2 e v3.
 def get_conn(engine):
     """
     Cria um conexão com o banco de dados.
+
+    param: engine é uma instância de sqlachemy:create_engine
     """
     return engine.connect(close_with_result=True)
 
@@ -25,6 +27,10 @@ def get_conn(engine):
 def check_pid_v3_by_v2(engine, pid_v2):
     """
     Verifica a existência do pid na versão v3.
+
+    param: engine é uma instância de sqlachemy:create_engine
+
+    param: pid_v2 é uma string Ex: S0006-87051956000100002
     """
     conn = get_conn(engine)
 
@@ -41,6 +47,10 @@ def check_pid_v3_by_v2(engine, pid_v2):
 def get_pid_v3_by_v2(engine, pid_v2):
     """
     Obtém o pid da versão pid_v2.
+
+    param: engine é uma instância de sqlachemy:create_engine
+
+    param: pid_v2 é uma string Ex: S0006-87051956000100002
     """
     conn = get_conn(engine)
 
@@ -52,10 +62,11 @@ def get_pid_v3_by_v2(engine, pid_v2):
 def create_pid(engine, pid_v2, pid_v3):
     """
     Adiciona o pid_v2 e pid_v3 no tabela de pids.
+
+    param: pid_v2 é uma string Ex: S0006-87051956000100002
+
+    param: pid_v3 é uma string Ex: jNRgVj3SpLy8ML8Hy3kQ38R
     """
     conn = get_conn(engine)
 
-    with conn:
-        sqrs = conn.execute('INSERT INTO pid_versions (v2, v3) VALUES (%s, %s)' % (pid_v2, pid_v3))
-
-        return sqrs
+    conn.execute("INSERT INTO pid_versions (v2, v3) VALUES ('%s', '%s')" % (pid_v2, pid_v3))

--- a/documentstore_migracao/utils/pid_manager.py
+++ b/documentstore_migracao/utils/pid_manager.py
@@ -1,0 +1,61 @@
+# Coding: utf-8
+
+"""
+Módulo responsável por obter dados de um banco de dados com a seguinte estrutura:
+
+    TABLE "pid_versions" (
+        "id"    INTEGER,
+        "v2"    VARCHAR(23),
+        "v3"    VARCHAR(255),
+        PRIMARY KEY("id" AUTOINCREMENT),
+        UNIQUE("v2","v3")
+    );
+
+Reparem que existe uma unicidade entre as colunas v2 e v3.
+"""
+
+
+def get_conn(engine):
+    """
+    Cria um conexão com o banco de dados.
+    """
+    return engine.connect(close_with_result=True)
+
+
+def check_pid_v3_by_v2(engine, pid_v2):
+    """
+    Verifica a existência do pid na versão v3.
+    """
+    conn = get_conn(engine)
+
+    sqrs = conn.execute("SELECT * FROM pid_versions WHERE v2='%s'" % pid_v2)
+
+    row = sqrs.first()
+
+    if not row:
+        return False
+    else:
+        return bool(row[2])
+
+
+def get_pid_v3_by_v2(engine, pid_v2):
+    """
+    Obtém o pid da versão pid_v2.
+    """
+    conn = get_conn(engine)
+
+    sqrs = conn.execute("SELECT * FROM pid_versions WHERE v2='%s'" % pid_v2)
+
+    return sqrs.first()[2]
+
+
+def create_pid(engine, pid_v2, pid_v3):
+    """
+    Adiciona o pid_v2 e pid_v3 no tabela de pids.
+    """
+    conn = get_conn(engine)
+
+    with conn:
+        sqrs = conn.execute('INSERT INTO pid_versions (v2, v3) VALUES (%s, %s)' % (pid_v2, pid_v3))
+
+        return sqrs

--- a/tests/test_migrate_articlemeta.py
+++ b/tests/test_migrate_articlemeta.py
@@ -70,11 +70,13 @@ class TestMigrateProcess(unittest.TestCase):
                 "--minio_secret_key",
                 "minio123",
                 "--output",
-                "/tmp/docs.json"
+                "/tmp/docs.json",
+                "--xc_pid_database_dsn",
+                "sqlite:///pid_manager_database.db"
             ]
         )
         mk_import_documents_to_kernel.assert_called_once_with(
-            session_db=ANY, storage=ANY, folder=ANY, output_path=ANY
+            session_db=ANY, xc_database_engine=ANY, storage=ANY, folder=ANY, output_path=ANY
         )
 
     @patch("documentstore_migracao.processing.inserting.register_documents_in_documents_bundle")

--- a/tests/test_migrate_articlemeta.py
+++ b/tests/test_migrate_articlemeta.py
@@ -71,12 +71,12 @@ class TestMigrateProcess(unittest.TestCase):
                 "minio123",
                 "--output",
                 "/tmp/docs.json",
-                "--xc_pid_database_dsn",
+                "--pid_database_dsn",
                 "sqlite:///pid_manager_database.db"
             ]
         )
         mk_import_documents_to_kernel.assert_called_once_with(
-            session_db=ANY, xc_database_engine=ANY, storage=ANY, folder=ANY, output_path=ANY
+            session_db=ANY, pid_database_engine=ANY, storage=ANY, folder=ANY, output_path=ANY
         )
 
     @patch("documentstore_migracao.processing.inserting.register_documents_in_documents_bundle")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -25,10 +25,12 @@ class TestMainTools(unittest.TestCase):
 
 class TestProcessingConstructor(unittest.TestCase):
     @patch("documentstore_migracao.tools.constructor.xml.objXML2file")
-    def test_article_xml_constructor(self, mk_write_file):
+    @patch("documentstore_migracao.utils.pid_manager")
+    @patch("documentstore_migracao.export.sps_package.SPS_Package.scielo_pid_v3")
+    def test_article_xml_constructor(self, mk_xml_sps, mk_pid_manager, mk_write_file):
 
         constructor.article_xml_constructor(
-            os.path.join(SAMPLES_PATH, "S0044-59672003000300001.pt.xml"), "/tmp", False
+            os.path.join(SAMPLES_PATH, "S0044-59672003000300001.pt.xml"), "/tmp", mk_pid_manager,  False
         )
         mk_write_file.assert_called_with(
             "/tmp/S0044-59672003000300001.pt.xml", ANY, pretty=True


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR tem como objetivo adicionar a capacidade de verificar a existência do PID v3 na base de dados do PIDs do XC através do PID v2.

**IMPORTANTE**: Não é necessário que o tíquete https://github.com/scieloorg/prodtools/issues/5 tenha sido realizado para aprovação desse PR. 

#### Onde a revisão poderia começar?

Verifique os commit tive um cuidado em deixar os commits legíveis e cronologicamente de acordo com a evolução do desenvolvimento da tarefa, portanto é um bom começo !!! :-)

#### Como este poderia ser testado manualmente?

Bom para testar esse commit é necessário ter o grande parte do ambiente do SPF montado. Para isso é possível acessa um documento que tem como objetivo apoiar na tarefa de ter esse ambiente: https://docs.google.com/document/d/1W__CZoIXuOiFMYQGciBRtpM39Y0aMEBKupBWzCYxyRo/edit#

Se tudo der certo e logo o nosso parceiro @rafaelpezzuto nós presenteará com uma receita melhor :-)

Considere que é necessário ter até a fase de "**Carga no Kernel**" realizada e a partir daí é possível verificar as alterações que esse PR faz. 

Ao executar o comando: `ds_migracao import ` é possível verificar que há a exigência de um novo parâmetro `--xc_pid_database_dsn` esse parâmetro é justamente o valor de conexão com o banco de dados do XC, podendo ser qualquer um dos bancos de dados descritos na url: https://docs.sqlalchemy.org/en/13/core/engines.html

Ao executar esse comando e caso queira testar com **sqlite** segue o DSN: `sqlite:///pid_manager_database_scl.db` 

Verifique os dados do sqlite baixando o seguinte interface: https://sqlitebrowser.org/

Ao executar esse comando e caso queira testar com **postgres** segue o DSN: 
`postgresql://postgres:123@192.168.15.18:5432/pid_manager`, necessário instalar as dependências para o Postgres por exemplo.

Durante a execução e possível verificar a criação do pid na versão v2 e v3 na base de dados. 

Para criar a estrutura da base de dados no sqlite para efeito de teste é possível com a seguinte schema: 

```
    CREATE TABLE "pid_versions" (
        "id"    INTEGER,
        "v2"    VARCHAR(23),
        "v3"    VARCHAR(255),
        PRIMARY KEY("id" AUTOINCREMENT),
        UNIQUE("v2","v3")
    );
```
Em postgres seria:

```
CREATE TABLE public.pid_versions
(
    id integer NOT NULL DEFAULT nextval('pid_versions_id_seq'::regclass),
    v2 text COLLATE pg_catalog."default" NOT NULL,
    v3 text COLLATE pg_catalog."default" NOT NULL,
    CONSTRAINT pid_versions_pkey PRIMARY KEY (id)
)
```

Pessoal somente para esclarecer não estou utilizando no momento de escrita ao banco de dados contexto transacional para que possamos continuar dando suporte ao sqlite.

**IMPORTANTE**: O sqlite permite o uso de contexto transacional, porém como estamos utilizando MultiThreads optei por não aumentar a complexidade, veja mais sobre isso aqui: https://www.sqlite.org/lockingv3.html 

O documento de **Guia de migração dos dados para nova plataforma SPF** recebeu alterações com esse parâmetro, veja: https://docs.google.com/document/d/1W__CZoIXuOiFMYQGciBRtpM39Y0aMEBKupBWzCYxyRo/edit#

#### Algum cenário de contexto que queira dar?

Em conversa com a equipe foi comentado sobre problemas de arquitetura nesse projeto, em especifico, o fato de alterarmos o conteúdo do XML no momento de importação dos dados. 

Rapidamente foi descartado qualquer redesenho da arquitetura já que estamos com prazos vencidos, para que isso não seja esquecido, criei um tíquete que descreve alguns problemas na arquitetura e foi registrado com uma **dívida técnica**. 

https://github.com/scieloorg/document-store-migracao/issues/337

### Screenshots

Para ter noção do jeitão dos comandos segue alguns print de execução: 

![Screen Shot 2020-08-14 at 00 43 03](https://user-images.githubusercontent.com/373745/90211471-265bc400-ddc7-11ea-8241-944571ea510e.png)

![Screen Shot 2020-08-14 at 00 43 40](https://user-images.githubusercontent.com/373745/90211494-370c3a00-ddc7-11ea-88d1-948da74e615f.png)


![Screen Shot 2020-08-14 at 00 25 36](https://user-images.githubusercontent.com/373745/90210575-b1878a80-ddc4-11ea-8bdf-665c55aadc17.png)

#### Quais são tickets relevantes?

O tíquete referente a esse PR é: #335 

### Referências

https://leportella.com/tutorial-basico-sqlalchemy.html#engine-connection
https://docs.sqlalchemy.org/en/13/core/engines.html
https://docs.python.org/3/library/sqlite3.html
https://www.sqlite.org/threadsafe.html




