### PR TITLE
Instala o psycopg2 para possibilitar conexão com PostgreSQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.7-alpine
 RUN apk add --no-cache --virtual .build-deps \
         make gcc libxml2-dev libxslt-dev musl-dev g++ git openjdk8 \
         jpeg-dev zlib-dev freetype-dev lcms2-dev openjpeg-dev \
-        tiff-dev tk-dev tcl-dev \
+        tiff-dev tk-dev tcl-dev postgresql-dev \
     && apk add libxml2 libxslt \
     && pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir -r /app/requirements.txt \

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,3 +71,4 @@ construct==2.10.56
 ioisis==0.3.0
 JPype1==1.0.1
 ujson==2.0.3
+psycopg2-binary==2.8.5

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ requires = [
     "fs",
     "opac_schema",
     "sqlalchemy",
+    "psycopg2-binary~=2.8",
 ]
 
 tests_require = [


### PR DESCRIPTION
#### O que esse PR faz?
Este PR possibilita a conexão da aplicação com bancos de dados PostgreSQL. Adiciona `psycopg2-binary` como dependência da aplicação e `postgresql-dev` no Dockerfile para possibilitar a construção da imagem com a dependência.

#### Onde a revisão poderia começar?
Commit 9aa1cdf

#### Como este poderia ser testado manualmente?
- Extraia o anexo [1] na raíz do projeto
- Com uma instância de PostgreSQL e uma base de dados
- Execute o comando:
```
ds_migracao --loglevel DEBUG import --uri mongodb://0.0.0.0:27017/ --db document-store \
--minio_host 0.0.0.0:9000 --minio_access_key minio --minio_secret_key senha --folder xml/site_sps_packages_tk_349 --output json/nativos-issue-349.json --pid_database_dsn <DSN do PostgreSQL>
```
- Verifique se foi criado um registro com o PID V2 e V3 na tabela `pid_versions`

#### Algum cenário de contexto que queira dar?
.

### Screenshots
.

#### Anexos
- [1] - [Diretório teste do site - xml_site_sps_packages_tk_349.zip](https://github.com/scieloorg/document-store-migracao/files/5132719/xml_site_sps_packages_tk_349.zip)

#### Quais são tickets relevantes?
#349

### Referências
.