### PR TITLE
[FASE 4] Corrige a formação do nome do PDF durante o empacotamento para XML nativos

### DIFF
--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -150,7 +150,7 @@ class TestBuildSPSPackage(TestBuildSPSPackageBase):
         mock_copy.assert_called_once_with(
             "/data/pdfs/abc/v1n1/bla.pdf", "/data/output/abc/v1n1/bla"
         )
-        self.assertEqual(result, [("pt", "bla.pdf")])
+        self.assertEqual(result, {"pt": "bla.pdf"})
 
     @mock.patch("documentstore_migracao.utils.build_ps_package.shutil.copy")
     def test_collect_renditions_for_document_with_translations_in_en_and_es(self, mock_copy):
@@ -174,12 +174,23 @@ class TestBuildSPSPackage(TestBuildSPSPackageBase):
             ),
         ]
         self.assertEqual(
-            result,
-            [
-                ("pt", "bla.pdf"),
-                ("en", "bla-en.pdf"),
-                ("es", "bla-es.pdf"),
-            ]
+            result, {"pt": "bla.pdf", "en": "en_bla.pdf", "es": "es_bla.pdf"}
+        )
+
+    @mock.patch("documentstore_migracao.utils.build_ps_package.shutil.copy")
+    def test_collect_renditions_for_document_with_translation_using_prefix(self, mock_copy):
+        mock_copy.side_effect = [None, FileNotFoundError, None]
+        result = self.builder.collect_renditions(
+            "/data/output/abc/v1n1/bla",
+            "abc",
+            "v1n1",
+            "bla",
+            ["pt", "en"],
+            "S0101-02022020000010001",
+        )
+
+        self.assertEqual(
+            result, {"pt": "bla.pdf", "en": "bla-en.pdf"}
         )
 
     @mock.patch("documentstore_migracao.utils.build_ps_package.open")


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request corrige a primeira parte do problema relacionado com a identificação das manifestações dos XMLs nativos. A partir deste ponto, a cópia dos `pdfs` passará pela seguinte precedência

1) Nome do pdf com prefixo;
2) Nome do pdf  com sufixo;

Os artigos que não possuírem tradução não serão afetados.

#### Onde a revisão poderia começar?
- `documentstore_migracao/utils/build_ps_package.py` L `243`

#### Como este poderia ser testado manualmente?
- Execute o empacotamento para o seguinte documento:
```csv
S0103-05822021000100401,,rpp/v39/1984-0462-rpp-39-e2019097.xml,20210000,20200618,20200618,RPP,v39,en
```
- Verifique os pdfs;
- Verifique o arquivo de manifest;
- Observe que os nomes dos pdfs copiados e de dentro do arquivo `manifest` estão compatíveis;

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#354

### Referências
N/A

