### PR TITLE
[FASE 4] Adiciona comando para desfazer import para o Kernel

### DIFF
--- a/documentstore_migracao/exceptions.py
+++ b/documentstore_migracao/exceptions.py
@@ -19,3 +19,7 @@ class NoJournalInWebsiteError(Exception):
     """Não há periódicos no site para migração dos logos. É necessário que a migração
     dos periódicos seja feita antes da migração dos logos.
     """
+
+
+class RollbackError(Exception):
+    """ Rollback command error."""

--- a/documentstore_migracao/processing/rollback.py
+++ b/documentstore_migracao/processing/rollback.py
@@ -152,6 +152,11 @@ def rollback_document(
         # Rollback Document
         session.documents.rollback(pid_v3)
 
+        # Rollback DocumentsBundle
+        rollback_bundle(doc_info, session, journals)
+
+        return {"pid_v3": doc_info["pid_v3"], "status": "ROLLEDBACK"}
+
 
 def rollback_kernel_documents(
     extracted_title_path: str,

--- a/documentstore_migracao/processing/rollback.py
+++ b/documentstore_migracao/processing/rollback.py
@@ -1,6 +1,7 @@
 """ module to rollback imported data """
 import json
 import logging
+from datetime import datetime
 
 import pymongo
 from documentstore import adapters as ds_adapters
@@ -191,7 +192,11 @@ def rollback_document(
         # Rollback Document
         session.documents.rollback(pid_v3)
 
-        _rolledback_result = {"pid_v3": doc_info["pid_v3"], "status": "ROLLEDBACK"}
+        _rolledback_result = {
+            "pid_v3": doc_info["pid_v3"],
+            "status": "ROLLEDBACK",
+            "timestamp": datetime.utcnow().isoformat(),
+        }
 
         # Rollback DocumentsBundle
         _rolledback_bundle_id = rollback_bundle(doc_info, session, journals)
@@ -241,10 +246,11 @@ def rollback_kernel_documents(
                 exception,
             )
 
+        # Manter como max_workers=1 até que o controle transacional seja implementado
         DoJobsConcurrently(
             rollback_document,
             jobs=jobs,
-            max_workers=int(config.get("PROCESSPOOL_MAX_WORKERS")),
+            max_workers=1,
             success_callback=write_result_to_file,
             exception_callback=exception_callback,
             update_bar=update_bar,

--- a/documentstore_migracao/processing/rollback.py
+++ b/documentstore_migracao/processing/rollback.py
@@ -1,10 +1,19 @@
 """ module to rollback imported data """
 import json
+import logging
 
 import pymongo
 from documentstore import adapters as ds_adapters
 from documentstore import exceptions as ds_exceptions
 from xylose.scielodocument import Journal
+
+from documentstore_migracao import exceptions, config
+from documentstore_migracao.utils import (
+    scielo_ids_generator,
+)
+
+
+logger = logging.getLogger(__name__)
 
 
 class DSMBaseStore(ds_adapters.BaseStore):
@@ -73,6 +82,52 @@ def get_journals_from_json(journals_file_path: str) -> dict:
             if o_journal.scielo_issn:
                 data_journal[o_journal.scielo_issn] = o_journal.scielo_issn
         return data_journal
+
+
+def get_issn_by_document(journals: dict, document: dict):
+    for issn_type in ("eissn", "pissn", "issn"):
+        if document.get(issn_type) is not None:
+            issn_value = document[issn_type].strip()
+            if journals.get(issn_value) is not None:
+                logger.debug(
+                    'Document "%s" published in ISSN "%s"',
+                    document["pid_v3"],
+                    journals[issn_value],
+                )
+                return journals[issn_value]
+
+
+def get_bundle_id(issn_id: str, doc_info: dict) -> None:
+    if doc_info.get("volume") or doc_info.get("number"):
+        return scielo_ids_generator.issue_id(
+            issn_id,
+            doc_info.get("year"),
+            doc_info.get("volume"),
+            doc_info.get("number"),
+            doc_info.get("supplement"),
+        )
+
+    return scielo_ids_generator.aops_bundle_id(issn_id)
+
+
+def rollback_bundle(doc_info: dict, session: object, journals: dict):
+    _issn_id = get_issn_by_document(journals, doc_info)
+    if not _issn_id:
+        raise exceptions.RollbackError(
+            f'could not get journal for document "{doc_info["pid_v3"]}"'
+        )
+
+    _bundle_id = get_bundle_id(_issn_id, doc_info)
+    try:
+        _bundle = session.documents_bundles.fetch(_bundle_id)
+    except ds_exceptions.DoesNotExist:
+        raise exceptions.RollbackError(f'could not get bundle id "{_bundle_id}"')
+    else:
+        logger.debug(
+            'Removing document "%s" from bundle "%s"', doc_info["pid_v3"], _bundle_id
+        )
+        _bundle.remove_document(doc_info["pid_v3"])
+        session.documents_bundles.update(_bundle)
 
 
 def rollback_document(

--- a/documentstore_migracao/processing/rollback.py
+++ b/documentstore_migracao/processing/rollback.py
@@ -234,7 +234,7 @@ def rollback_kernel_documents(
                 f.write(json.dumps(result) + "\n")
 
         def exception_callback(exception, job, logger=logger):
-            logger.error(
+            logger.exception(
                 "Could not roll back document '%s'. The following exception "
                 "was raised: '%s'.",
                 job["doc_info"].get("pid_v3"),

--- a/documentstore_migracao/processing/rollback.py
+++ b/documentstore_migracao/processing/rollback.py
@@ -1,0 +1,58 @@
+""" module to rollback imported data """
+import pymongo
+from documentstore import adapters as ds_adapters
+from documentstore import exceptions as ds_exceptions
+
+
+class DSMBaseStore(ds_adapters.BaseStore):
+
+    def __init__(self, collection):
+        self._collection = collection
+
+    def _execute_delete(self, delete_func: callable, filter: dict) -> None:
+        try:
+            _result = delete_func(filter)
+        except pymongo.errors.PyMongoError as exc:
+            raise ds_exceptions.DoesNotExist(
+                f'Could not remove data with "{filter}": {exc}'
+            ) from None
+        else:
+            if not _result.deleted_count > 0:
+                raise ds_exceptions.DoesNotExist(
+                    f'Could not remove data with "{filter}": '
+                    f'delete command returned "{_result.deleted_count}"'
+                )
+
+    def delete_one(self, filter: dict) -> None:
+        self._execute_delete(self._collection.delete_one, filter)
+
+    def delete_many(self, filter: dict) -> None:
+        self._execute_delete(self._collection.delete_many, filter)
+
+
+class DocumentStore(DSMBaseStore):
+
+    def rollback(self, id: str) -> None:
+        """Delela documento com o ID informado."""
+        self.delete_one({"_id": id})
+
+
+class ChangesStore(DSMBaseStore):
+
+    def rollback(self, id: str) -> None:
+        """Deleta todos os registros de mudança registrados para o ID informado."""
+        self.delete_many({"id": id})
+
+
+class RollbackSession(ds_adapters.Session):
+    """Extensão de `documentstore.adapters.Session` para manuteção dos dados no banco de
+    dados do Kernel."""
+
+    @property
+    def documents(self):
+        return DocumentStore(self._mongodb_client.documents)
+
+    @property
+    def changes(self):
+        return ChangesStore(self._mongodb_client.changes)
+

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from unittest.mock import Mock, MagicMock, patch
+from datetime import datetime
 
 import pymongo
 from documentstore import exceptions as ds_exceptions
@@ -254,14 +255,20 @@ class TestRollbackDocument(TestCase):
         _result = rollback.rollback_document(
             self.doc_info, self.session, self.fake_journals
         )
-        self.assertEqual(_result, {"pid_v3": "document-id", "status": "ROLLEDBACK"})
+        self.assertEqual(_result.get("pid_v3"), "document-id")
+        self.assertEqual(_result.get("status"), "ROLLEDBACK")
+        self.assertIsInstance(
+            datetime.fromisoformat(_result.get("timestamp")), datetime
+        )
 
     def test_return_with_bundle(self, mock_rollback_bundle):
         mock_rollback_bundle.return_value = "bundle-id"
         _result = rollback.rollback_document(
             self.doc_info, self.session, self.fake_journals
         )
-        self.assertEqual(
-            _result,
-            {"pid_v3": "document-id", "bundle": "bundle-id", "status": "ROLLEDBACK"}
+        self.assertEqual(_result.get("pid_v3"), "document-id")
+        self.assertEqual(_result.get("bundle"), "bundle-id")
+        self.assertEqual(_result.get("status"), "ROLLEDBACK")
+        self.assertIsInstance(
+            datetime.fromisoformat(_result.get("timestamp")), datetime
         )

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -1,0 +1,86 @@
+from unittest import TestCase
+from unittest.mock import Mock, MagicMock
+
+import pymongo
+from documentstore import exceptions as ds_exceptions
+
+from documentstore_migracao.processing import rollback
+
+
+class TestDocumentStore(TestCase):
+    def setUp(self):
+        self.DBCollectionMock = MagicMock()
+
+    def test_rollback_does_not_exist(self):
+        self.DBCollectionMock.delete_one.side_effect = pymongo.errors.PyMongoError
+        _document_store = rollback.DocumentStore(self.DBCollectionMock)
+        with self.assertRaises(ds_exceptions.DoesNotExist) as exc_info:
+            _document_store.rollback("document-id")
+        self.assertIn(
+            'Could not remove data with "{\'_id\': \'document-id\'}": ',
+            str(exc_info.exception)
+        )
+
+    def test_rollback_deletion_failed(self):
+        _command_result = Mock(deleted_count=0)
+        self.DBCollectionMock.delete_one.return_value = _command_result
+        _document_store = rollback.DocumentStore(self.DBCollectionMock)
+        with self.assertRaises(ds_exceptions.DoesNotExist) as exc_info:
+            _document_store.rollback("document-id")
+        self.assertIn(
+            'Could not remove data with "{\'_id\': \'document-id\'}": ',
+            str(exc_info.exception)
+        )
+
+    def test_rollback_ok(self):
+        _command_result = Mock(deleted_count=1)
+        self.DBCollectionMock.delete_one.return_value = _command_result
+        _document_store = rollback.DocumentStore(self.DBCollectionMock)
+        _document_store.rollback("document-id")
+        self.DBCollectionMock.delete_one.assert_called_once_with({"_id": "document-id"})
+
+
+class TestChangesStore(TestCase):
+    def setUp(self):
+        self.DBCollectionMock = MagicMock()
+
+    def test_rollback_does_not_exist(self):
+        self.DBCollectionMock.delete_many.side_effect = pymongo.errors.PyMongoError
+        _change_store = rollback.ChangesStore(self.DBCollectionMock)
+        with self.assertRaises(ds_exceptions.DoesNotExist) as exc_info:
+            _change_store.rollback("document-id")
+        self.assertIn(
+            'Could not remove data with "{\'id\': \'document-id\'}": ',
+            str(exc_info.exception)
+        )
+
+    def test_rollback_deletion_failed(self):
+        _command_result = Mock(deleted_count=0)
+        self.DBCollectionMock.delete_many.return_value = _command_result
+        _change_store = rollback.ChangesStore(self.DBCollectionMock)
+        with self.assertRaises(ds_exceptions.DoesNotExist) as exc_info:
+            _change_store.rollback("document-id")
+        self.assertIn(
+            'Could not remove data with "{\'id\': \'document-id\'}": ',
+            str(exc_info.exception)
+        )
+
+    def test_rollback_ok(self):
+        _command_result = Mock(deleted_count=1)
+        self.DBCollectionMock.delete_many.return_value = _command_result
+        _change_store = rollback.ChangesStore(self.DBCollectionMock)
+        _change_store.rollback("document-id")
+        self.DBCollectionMock.delete_many.assert_called_once_with({"id": "document-id"})
+
+
+class TestRollbackSession(TestCase):
+
+    def setUp(self):
+        self.mongo_client = Mock()
+        self.session = rollback.RollbackSession(self.mongo_client)
+
+    def test_changes(self):
+        self.assertIsInstance(self.session.changes, rollback.ChangesStore)
+
+    def test_documents(self):
+        self.assertIsInstance(self.session.documents, rollback.DocumentStore)


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona comando para reverter operação de rollback nos documentos importados para o Kernel, além das relações com os bundles e os registros de mudança.
Este comando executa o rollback baseado no documento resultante do comando `ds_migracao import`.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commit. Inicie por 939f53c.

#### Como este poderia ser testado manualmente?
- Execute o comando `mongoexport` na base do Kernel de produção para obter os dados do banco e `mongoimport` para um MongoDB de teste OU execute o comando `ds_migracao import` de alguns pacotes de documentos
- Obtenha o arquivo JSON produzido pela importação dos documentos para o Kernel
- Execute o comando `ds_migracao rollback --help`
- Verifique as instruções do comando
- Execute o comando conforme instruções do help, informando os dados para a conexão com o MongoDB de teste e os arquivos JSON
- Ao final da execução, verifique:
  - os documentos do arquivo JSON produzido pela importação não devem mais existir na collection `documents` do Kernel
  - não devem mais registros de mudança na collection `changes` do Kernel com `id` dos documentos
  - os bundles não devem mais conter os documentos

#### Algum cenário de contexto que queira dar?
Este comando visa facilitar para que importações sejam feitas novamente, tendo em vista que o DS Migração não tem a capacidade de atualizar o Kernel com correções.

### Screenshots
N/A

#### Quais são tickets relevantes?
#353 

### Referências
.