### PR TITLE
Adiciona a analise do arquivo do log para o passo da importação (import). 

### DIFF
--- a/scripts/loggeranalyzer.py
+++ b/scripts/loggeranalyzer.py
@@ -127,7 +127,7 @@ class LoggerAnalyzer(object):
 
     @classmethod
     def formatters(cls) -> Optional[Dict]:
-        return {"jsonl": cls.jsonl_formatter}
+        return {"jsonl": cls.json_formatter}
 
     def logformat_regex(self) -> (List[str], re.Pattern):
         """
@@ -171,6 +171,7 @@ class LoggerAnalyzer(object):
         """
         Realiza a leitura do conteúdo do arquivo.
         """
+
         if isinstance(self.in_file, IOBase):
             self.content = self.in_file.readlines()
 
@@ -224,7 +225,6 @@ class LoggerAnalyzer(object):
             Não lança exceções.
 
         """
-
         match = regex.match(line)
 
         if match is None:
@@ -252,7 +252,7 @@ class LoggerAnalyzer(object):
         utilizado para atualizar o XML em questão.
 
         Exemplo de uso desta função:
-        >>> parse_pack_from_site_errors([
+        >>> tokenize([
                 "2020-05-08 11:43:38 ERROR [documentstore_migracao.utils.build_ps_package] "
                 "[S1981-38212017000200203] - Could not find asset 'imagem.tif' during packing XML "
                 "'/1981-3821-bpsr-1981-3821201700020001.xml'"
@@ -305,7 +305,7 @@ class LoggerAnalyzer(object):
             else:
                 # Linha que não foi identificada como erro de empacotamento
                 LOGGER.debug(
-                    "Não foi possível analisar a linha '%s', talves seja necessário especificar um analisador.",
+                    "Não foi possível analisar a linha '%s', talvez seja necessário especificar um analisador.",
                     line,
                 )
 
@@ -330,17 +330,16 @@ class LoggerAnalyzer(object):
             self.out_file.write(line)
             self.out_file.write("\n")
 
-    def jsonl_formatter(self, errors: List[Optional[Dict]]) -> List[str]:
+    def json_formatter(self, errors: List[Optional[Dict]]) -> List[str]:
         """Imprime linha a linha da lista de entrada, convertendo o conteúdo para
-        JSON. É esperado então que uma lista de dados seja transformada no formato
-        JSONL.
+        JSON.
 
         Args:
             errors: Lista de dicionários contendo os erro semânticamente identificado.
 
         Retornos:
 
-            Retorna um JSONL correspondente a cada dicionário do argumento errors,
+            Retorna um JSON correspondente a cada dicionário do argumento errors,
             example:
 
             {"uri": "jbn/nahead/2175-8239-jbn-2019-0218.xml", "error": "xml-not-found"}
@@ -360,7 +359,7 @@ class LoggerAnalyzer(object):
         return result
 
     def set_formatter(self, format) -> formatters:
-        return LoggerAnalyzer.formatters().get(format, self.jsonl_formatter)
+        return LoggerAnalyzer.formatters().get(format, self.json_formatter)
 
 
 @click.command()

--- a/scripts/loggeranalyzer.py
+++ b/scripts/loggeranalyzer.py
@@ -309,17 +309,6 @@ def main(input, formatter, output, loglevel):
     parser = LoggerAnalyzer(input, output)
     parser.parse()
 
-    # lines = input.readlines()
-
-    # formatter = FORMATTERS.get(formatter)
-    # parsed_errors = parse_pack_from_site_errors(lines)
-    # formatted_errors = formatter(parsed_errors)
-
-    # if output is not None:
-    #     output_lines_to(formatted_errors, output)
-    # else:
-    #     output_lines_to(formatted_errors, sys.stdout)
-
 
 if __name__ == "__main__":
     main()

--- a/scripts/loggeranalyzer.py
+++ b/scripts/loggeranalyzer.py
@@ -129,7 +129,7 @@ class LoggerAnalyzer(object):
     def formatters(cls) -> Optional[Dict]:
         return {"jsonl": cls.jsonl_formatter}
 
-    def logformat_regex(self):
+    def logformat_regex(self) -> (List[str], re.Pattern):
         """
         Método responsável por criar uma expressão regular para dividir as
         menssagens de log semanticamente.

--- a/scripts/loggeranalyzer.py
+++ b/scripts/loggeranalyzer.py
@@ -270,37 +270,38 @@ class LoggerAnalyzer(object):
 
             match = regex.match(line)
 
-            format_dict = match.groupdict()
+            if match:
+                format_dict = match.groupdict()
 
-            for params in extra_parsers:
+                for params in extra_parsers:
 
-                data = self.parser(format_dict['message'], **params)
+                    data = self.parser(format_dict['message'], **params)
 
-                if data is not None:
-                    pid: Optional[str] = data.get("pid")
-                    error: ErrorEnum = data.get("error")
-                    uri: Optional[str] = data.get("uri")
-                    level: Optional[str] = format_dict.get("level")
-                    time: Optional[str] = format_dict.get("time")
-                    date: Optional[str] = format_dict.get("date")
-                    exception: Optional[str] = format_dict.get("exception")
-                    group = data.pop("group", error)
+                    if data is not None:
+                        pid: Optional[str] = data.get("pid")
+                        error: ErrorEnum = data.get("error")
+                        uri: Optional[str] = data.get("uri")
+                        level: Optional[str] = format_dict.get("level")
+                        time: Optional[str] = format_dict.get("time")
+                        date: Optional[str] = format_dict.get("date")
+                        exception: Optional[str] = format_dict.get("exception")
+                        group = data.pop("group", error)
 
-                    if pid is not None:
-                        documents_errors.setdefault(pid, {})
-                        documents_errors[pid].setdefault(group, [])
-                        documents_errors[pid][group].append(uri)
-                        documents_errors[pid]["pid"] = pid
-                        documents_errors[pid]["error"] = error
-                        documents_errors[pid]["level"] = level
-                        documents_errors[pid]["time"] = time
-                        documents_errors[pid]["date"] = date
-                    elif error != ErrorEnum.RESOURCE_NOT_FOUND:
-                        data["level"] = level
-                        data["time"] = time
-                        data["date"] = date
-                        errors.append(data)
-                    break
+                        if pid is not None:
+                            documents_errors.setdefault(pid, {})
+                            documents_errors[pid].setdefault(group, [])
+                            documents_errors[pid][group].append(uri)
+                            documents_errors[pid]["pid"] = pid
+                            documents_errors[pid]["error"] = error
+                            documents_errors[pid]["level"] = level
+                            documents_errors[pid]["time"] = time
+                            documents_errors[pid]["date"] = date
+                        elif error != ErrorEnum.RESOURCE_NOT_FOUND:
+                            data["level"] = level
+                            data["time"] = time
+                            data["date"] = date
+                            errors.append(data)
+                        break
             else:
                 # Linha que não foi identificada como erro de empacotamento
                 LOGGER.debug(

--- a/scripts/loggeranalyzer.py
+++ b/scripts/loggeranalyzer.py
@@ -83,11 +83,11 @@ PACK_FROM_SITE_PARSERS_PARAMS = [{
 
 class LoggerAnalyzer(object):
 
-    def __init__(self, in_file, out_file=None, log_format=None):
+    def __init__(self, in_file, out_file=None, out_format=None):
         self.in_file = in_file
         self.out_file = out_file
         self.content = ""
-        self.format = LoggerAnalyzer.formatters()
+        self.format = self.set_formatter(out_format)
 
     @classmethod
     def formatters(cls) -> Optional[Dict]:
@@ -270,7 +270,7 @@ class LoggerAnalyzer(object):
         return result
 
     def set_formatter(self, format) -> formatters:
-        return self.format.get(format, self.jsonl_formatter)
+        return LoggerAnalyzer.formatters().get(format, self.jsonl_formatter)
 
 
 @click.command()
@@ -306,7 +306,7 @@ def main(input, formatter, output, loglevel):
     if not output:
         output = sys.stdout
 
-    parser = LoggerAnalyzer(input, output)
+    parser = LoggerAnalyzer(input, output, formatter)
     parser.parse()
 
 

--- a/scripts/loggeranalyzer.py
+++ b/scripts/loggeranalyzer.py
@@ -10,7 +10,7 @@ import logging
 import re
 import sys
 from enum import Enum
-from io import TextIOWrapper
+from io import TextIOWrapper, IOBase
 from typing import Callable, Dict, List, Optional, Union
 
 import click
@@ -41,59 +41,6 @@ XML_MISSING_METADATA_REGEX = re.compile(
 )
 
 
-def jsonl_formatter(errors: List[Optional[Dict]]) -> List[str]:
-    """Imprime linha a linha da lista de entrada, convertendo o conteúdo para
-    JSON. É esperado então que uma lista de dados seja transformada no formato
-    JSONL.
-
-    Args:
-        errors: Lista de dicionários contendo os erro semânticamente identificado.
-
-    Retornos:
-
-        Retorna um JSONL correspondente a cada dicionário do argumento errors,
-        example:
-
-        {"uri": "jbn/nahead/2175-8239-jbn-2019-0218.xml", "error": "xml-not-found"}
-        {"uri": "jbn/nahead/2175-8239-jbn-2020-0025.xml", "error": "xml-not-found"}
-        {"uri": "jbn/nahead/2175-8239-jbn-2019-0236.xml", "error": "xml-not-found"}
-        {"uri": "jbn/nahead/2175-8239-jbn-2020-0050.xml", "error": "xml-not-found"}
-        {"uri": "jbn/nahead/2175-8239-jbn-2020-0014.xml", "error": "xml-not-found"}
-
-    Exceções:
-        Não lança exceções.
-    """
-
-    result = []
-    for error in errors:
-        result.append(json.dumps(error))
-
-    return result
-
-
-FORMATTERS = {"jsonl": jsonl_formatter}
-
-
-def output_lines_to(lines: List[str], stream: TextIOWrapper) -> None:
-    """Escreve resultado do parser em um arquivo caminho determinado.
-    A sequência de caracteres de dados deve implementar a interface TextIOWrapper
-
-    Args:
-        lines: Lista de linhas contento sequência de caracteres.
-        stream: Uma sequência de caracteres, deve implementar a interface textIOWrapper
-    Retornos:
-        Não há retorno
-
-    Exceções:
-        Não lança exceções.
-
-    """
-
-    for line in lines:
-        stream.write(line)
-        stream.write("\n")
-
-
 class ErrorEnum(Enum):
     """Enumerador para agrupar nomes de erros utilizados na saída.
 
@@ -109,143 +56,221 @@ class ErrorEnum(Enum):
     MISSING_METADATA = "missing-metadata"
 
 
-def general_parser(
-    line: str, regex: re.Pattern, error: ErrorEnum, group: str = None
-) -> Optional[Dict]:
-    """Analise do formato utilizado para verificar padrões por meio
-    de expressões regulares. Retorna o tipo de formato especificado na chamada.
-
-    Args:
-        line: Linha a ser analisada.
-        regex: Expressão regular que será utilizada.
-        error: Um enumerador, instância de classe ErroEnum, para qualificar o erro.
-        group: Um classificador para o erro.
-
-    Retorno:
-        Um dicionário contendo a analise da linha com um seperação semântica.
-
-        Exemplo:
-
-            {
-             'pid': 'S0066-782X2020000500001',
-             'uri': 'bases/pdf/abc/v114n4s1/pt_0066-782X-abc-20180130.pdf',
-             'xml': '0066-782X-abc-20180130.xml',
-             'error': 'resource-not-found',
-             'group': 'renditions'
-            }
-
-    Exceções:
-        Não lança exceções.
-
-    """
-
-    match = regex.match(line)
-
-    if match is None:
-        return None
-
-    return dict(match.groupdict(), **{"error": error.value, "group": group})
-
-
-parse_asset_error = functools.partial(
-    general_parser,
-    regex=ASSET_NOT_FOUND_REGEX,
-    error=ErrorEnum.RESOURCE_NOT_FOUND,
-    group="assets",
-)
-
-parse_rendition_error = functools.partial(
-    general_parser,
-    regex=RENDITION_NOT_FOUND_REGEX,
-    error=ErrorEnum.RESOURCE_NOT_FOUND,
-    group="renditions",
-)
-
-parse_xml_update_error = functools.partial(
-    general_parser, regex=XML_NOT_UPDATED_REGEX, error=ErrorEnum.NOT_UPDATED
-)
-
-parse_xml_not_found_error = functools.partial(
-    general_parser, regex=XML_NOT_FOUND_REGEX, error=ErrorEnum.XML_NOT_FOUND
-)
-
-parse_missing_metadata_error = functools.partial(
-    general_parser,
-    regex=XML_MISSING_METADATA_REGEX,
-    error=ErrorEnum.MISSING_METADATA,
-)
-
-PACK_FROM_SITE_PARSERS: List[Callable] = [
-    parse_asset_error,
-    parse_rendition_error,
-    parse_xml_not_found_error,
-    parse_xml_update_error,
-    parse_missing_metadata_error,
+PACK_FROM_SITE_PARSERS_PARAMS = [{
+    'regex': ASSET_NOT_FOUND_REGEX,
+    'error': ErrorEnum.RESOURCE_NOT_FOUND,
+    'group': "renditions",
+    },
+    {
+    'regex': RENDITION_NOT_FOUND_REGEX,
+    'error': ErrorEnum.RESOURCE_NOT_FOUND,
+    'group': "renditions",
+    },
+    {
+    'regex': XML_NOT_UPDATED_REGEX,
+    'error': ErrorEnum.NOT_UPDATED
+    },
+    {
+    'regex': XML_NOT_FOUND_REGEX,
+    'error': ErrorEnum.XML_NOT_FOUND
+    },
+    {
+    'regex': XML_MISSING_METADATA_REGEX,
+    'error': ErrorEnum.MISSING_METADATA
+    }
 ]
 
 
-def parse_pack_from_site_errors(
-    lines: list, parsers: List[Callable] = PACK_FROM_SITE_PARSERS
-) -> List[Optional[Dict]]:
-    """Fachada que realiza o parser do arquivo de log do processo de
-    empacotamento de xml nativos do utilitário `document-store-migracao`.
+class LoggerAnalyzer(object):
 
-    Dado um arquivo de formato conhecido, esta função produz uma lista
-    de dicionários. Os dicionários comportam ao menos quatro tipos de erros
-    registrados no LOG, são eles:
+    def __init__(self, in_file, out_file=None, log_format=None):
+        self.in_file = in_file
+        self.out_file = out_file
+        self.content = ""
+        self.format = LoggerAnalyzer.formatters()
 
-    1) `resource-not-found`: Quando algum asset ou rendition não é encontrado
-    durante o empacotamento.
-    2) `xml-not-found`: Quando um documento XML não é encontrado durante o
-    empacotamento.
-    3) `xml-update`: Quando um algum erro acontece durante a atualização do
-    xml em questão. Geralmente são erros ligados ao LXML.
-    4) `missing-metadata`: Quando algum metadado não existe no arquivo CSV
-    utilizado para atualizar o XML em questão.
+    @classmethod
+    def formatters(cls) -> Optional[Dict]:
+        return {"jsonl": cls.jsonl_formatter}
 
-    Exemplo de uso desta função:
-    >>> parse_pack_from_site_errors([
-            "2020-05-08 11:43:38 ERROR [documentstore_migracao.utils.build_ps_package] "
-            "[S1981-38212017000200203] - Could not find asset 'imagem.tif' during packing XML "
-            "'/1981-3821-bpsr-1981-3821201700020001.xml'"
-        ])
-    >>> [{'assets': ['imagem.tif'], 'pid': 'S1981-38212017000200203', 'error': 'resource'}]
-    """
+    def load(self) -> None:
+        """
+        Realiza a leitura do conteúdo do arquivo.
 
-    errors: List[Optional[Dict]] = []
-    documents_errors: Dict[str, Dict] = {}
+        Talves esse método deva lançar uma exceção.
+        """
+        if isinstance(self.in_file, IOBase):
+            self.content = self.in_file.readlines()
 
-    for line in lines:
-        line = line.strip()
+    def parse(self, format=None) -> None:
+        """
+        Método realiza a análise.
 
-        for parser in parsers:
-            data = parser(line)
+        Args:
+            format: formato de saída que será utilizado.
 
-            if data is not None:
-                pid: Optional[str] = data.get("pid")
-                error: ErrorEnum = data.get("error")
-                uri: Optional[str] = data.get("uri")
-                group = data.pop("group", error)
+        Retornos:
+            Não há retorno
 
-                if pid is not None:
-                    documents_errors.setdefault(pid, {})
-                    documents_errors[pid].setdefault(group, [])
-                    documents_errors[pid][group].append(uri)
-                    documents_errors[pid]["pid"] = pid
-                    documents_errors[pid]["error"] = error
-                elif error != ErrorEnum.RESOURCE_NOT_FOUND:
-                    errors.append(data)
-                break
-        else:
-            # Linha que não foi identificada como erro de empacotamento
-            LOGGER.debug(
-                "Não foi possível analisar a linha '%s', talvés seja necessário especificar um analisador.",
-                line,
-            )
+        Exceções:
+            Não lança exceções.
 
-    documents_errors_values = list(documents_errors.values())
-    errors.extend(documents_errors_values)
-    return errors
+        """
+        self.load()
+        formatter = self.set_formatter(format)
+        tokenized_lines = self.tokenize()
+        lines = formatter(tokenized_lines)
+        self.dump(lines)
+
+    def parser(
+        self, line: str, regex: re.Pattern, error: ErrorEnum, group: str = None
+    ) -> Optional[Dict]:
+        """Analise do formato utilizado para verificar padrões por meio
+        de expressões regulares. Retorna o tipo de formato especificado na chamada.
+
+        Args:
+            line: Linha a ser analisada.
+            regex: Expressão regular que será utilizada.
+            error: Um enumerador, instância de classe ErroEnum, para qualificar o erro.
+            group: Um classificador para o erro.
+
+        Retorno:
+            Um dicionário contendo a analise da linha com um seperação semântica.
+
+            Exemplo:
+
+                {
+                 'pid': 'S0066-782X2020000500001',
+                 'uri': 'bases/pdf/abc/v114n4s1/pt_0066-782X-abc-20180130.pdf',
+                 'xml': '0066-782X-abc-20180130.xml',
+                 'error': 'resource-not-found',
+                 'group': 'renditions'
+                }
+
+        Exceções:
+            Não lança exceções.
+
+        """
+
+        match = regex.match(line)
+
+        if match is None:
+            return None
+
+        return dict(match.groupdict(), **{"error": error.value, "group": group})
+
+    def tokenize(
+        self, parsers: List[Callable] = PACK_FROM_SITE_PARSERS_PARAMS
+    ) -> List[Optional[Dict]]:
+        """Fachada que realiza o parser do arquivo de log do processo de
+        empacotamento de xml nativos do utilitário `document-store-migracao`.
+
+        Dado um arquivo de formato conhecido, esta função produz uma lista
+        de dicionários. Os dicionários comportam ao menos quatro tipos de erros
+        registrados no LOG, são eles:
+
+        1) `resource-not-found`: Quando algum asset ou rendition não é encontrado
+        durante o empacotamento.
+        2) `xml-not-found`: Quando um documento XML não é encontrado durante o
+        empacotamento.
+        3) `xml-update`: Quando um algum erro acontece durante a atualização do
+        xml em questão. Geralmente são erros ligados ao LXML.
+        4) `missing-metadata`: Quando algum metadado não existe no arquivo CSV
+        utilizado para atualizar o XML em questão.
+
+        Exemplo de uso desta função:
+        >>> parse_pack_from_site_errors([
+                "2020-05-08 11:43:38 ERROR [documentstore_migracao.utils.build_ps_package] "
+                "[S1981-38212017000200203] - Could not find asset 'imagem.tif' during packing XML "
+                "'/1981-3821-bpsr-1981-3821201700020001.xml'"
+            ])
+        >>> [{'assets': ['imagem.tif'], 'pid': 'S1981-38212017000200203', 'error': 'resource'}]
+        """
+
+        errors: List[Optional[Dict]] = []
+        documents_errors: Dict[str, Dict] = {}
+
+        for line in self.content:
+            line = line.strip()
+
+            for params in PACK_FROM_SITE_PARSERS_PARAMS:
+
+                data = self.parser(line, **params)
+
+                if data is not None:
+                    pid: Optional[str] = data.get("pid")
+                    error: ErrorEnum = data.get("error")
+                    uri: Optional[str] = data.get("uri")
+                    group = data.pop("group", error)
+
+                    if pid is not None:
+                        documents_errors.setdefault(pid, {})
+                        documents_errors[pid].setdefault(group, [])
+                        documents_errors[pid][group].append(uri)
+                        documents_errors[pid]["pid"] = pid
+                        documents_errors[pid]["error"] = error
+                    elif error != ErrorEnum.RESOURCE_NOT_FOUND:
+                        errors.append(data)
+                    break
+            else:
+                # Linha que não foi identificada como erro de empacotamento
+                LOGGER.debug(
+                    "Não foi possível analisar a linha '%s', talvés seja necessário especificar um analisador.",
+                    line,
+                )
+
+        documents_errors_values = list(documents_errors.values())
+        errors.extend(documents_errors_values)
+        return errors
+
+    def dump(self, lines) -> None:
+        """Escreve resultado do parser em um arquivo caminho determinado.
+        A sequência de caracteres de dados deve implementar a interface TextIOWrapper
+
+        Args:
+            lines: Lista de linhas contento sequência de caracteres.
+        Retornos:
+            Não há retorno
+
+        Exceções:
+            Não lança exceções.
+        """
+
+        for line in lines:
+            self.out_file.write(line)
+            self.out_file.write("\n")
+
+    def jsonl_formatter(self, errors: List[Optional[Dict]]) -> List[str]:
+        """Imprime linha a linha da lista de entrada, convertendo o conteúdo para
+        JSON. É esperado então que uma lista de dados seja transformada no formato
+        JSONL.
+
+        Args:
+            errors: Lista de dicionários contendo os erro semânticamente identificado.
+
+        Retornos:
+
+            Retorna um JSONL correspondente a cada dicionário do argumento errors,
+            example:
+
+            {"uri": "jbn/nahead/2175-8239-jbn-2019-0218.xml", "error": "xml-not-found"}
+            {"uri": "jbn/nahead/2175-8239-jbn-2020-0025.xml", "error": "xml-not-found"}
+            {"uri": "jbn/nahead/2175-8239-jbn-2019-0236.xml", "error": "xml-not-found"}
+            {"uri": "jbn/nahead/2175-8239-jbn-2020-0050.xml", "error": "xml-not-found"}
+            {"uri": "jbn/nahead/2175-8239-jbn-2020-0014.xml", "error": "xml-not-found"}
+
+        Exceções:
+            Não lança exceções.
+        """
+
+        result = []
+        for error in errors:
+            result.append(json.dumps(error))
+
+        return result
+
+    def set_formatter(self, format) -> formatters:
+        return self.format.get(format, self.jsonl_formatter)
 
 
 @click.command()
@@ -254,7 +279,7 @@ def parse_pack_from_site_errors(
     "-f",
     "--formatter",
     default="jsonl",
-    type=click.Choice(FORMATTERS.keys()),
+    type=click.Choice(LoggerAnalyzer.formatters().keys()),
     help="Escolha um formato de conversão para o analisador",
 )
 @click.option(
@@ -277,15 +302,23 @@ def main(input, formatter, output, loglevel):
     """
 
     logging.basicConfig(format=LOGGER_FORMAT, level=getattr(logging, loglevel.upper()))
-    lines = input.readlines()
-    formatter = FORMATTERS.get(formatter)
-    parsed_errors = parse_pack_from_site_errors(lines)
-    formatted_errors = formatter(parsed_errors)
 
-    if output is not None:
-        output_lines_to(formatted_errors, output)
-    else:
-        output_lines_to(formatted_errors, sys.stdout)
+    if not output:
+        output = sys.stdout
+
+    parser = LoggerAnalyzer(input, output)
+    parser.parse()
+
+    # lines = input.readlines()
+
+    # formatter = FORMATTERS.get(formatter)
+    # parsed_errors = parse_pack_from_site_errors(lines)
+    # formatted_errors = formatter(parsed_errors)
+
+    # if output is not None:
+    #     output_lines_to(formatted_errors, output)
+    # else:
+    #     output_lines_to(formatted_errors, sys.stdout)
 
 
 if __name__ == "__main__":

--- a/scripts/loggeranalyzer.py
+++ b/scripts/loggeranalyzer.py
@@ -60,7 +60,7 @@ class ErrorEnum(Enum):
     XML_PARSER_ERROR = "xml-parser-error"
     BUNDLE_NOT_FOUND = "bundle-not-found"
     ISSN_NOT_FOUND = "issn-not-found"
-    PACKAGE_NOT_IMPORT = "package-not-import"
+    PACKAGE_NOT_IMPORTED = "package-not-import"
 
 
 class LoggerAnalyzer(object):
@@ -81,7 +81,7 @@ class LoggerAnalyzer(object):
     def logformat_regex(self) -> (List[str], re.Pattern):
         """
         Método responsável por criar uma expressão regular para dividir as
-        menssagens de log semânticamente.
+        menssagens de log semanticamente.
 
         Args:
             format: formato de saída que será utilizado.
@@ -323,7 +323,7 @@ class AnalyzerImport(LoggerAnalyzer):
         r".*No ISSN in document '(?P<pid>[^']+)'",
         re.IGNORECASE,
     )
-    package_not_import = re.compile(
+    package_not_imported = re.compile(
         r".*Could not import package '(?P<package_path>[^']+).*'",
         re.IGNORECASE,
     )
@@ -349,7 +349,7 @@ class AnalyzerImport(LoggerAnalyzer):
             {"regex": self.xml_parser_error, "error": ErrorEnum.XML_PARSER_ERROR},
             {"regex": self.bundle_not_found, "error": ErrorEnum.BUNDLE_NOT_FOUND},
             {"regex": self.issn_not_found, "error": ErrorEnum.ISSN_NOT_FOUND},
-            {"regex": self.package_not_import, "error": ErrorEnum.PACKAGE_NOT_IMPORT},
+            {"regex": self.package_not_imported, "error": ErrorEnum.PACKAGE_NOT_IMPORTED},
         ]
 
         self.load()

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ requires = [
     "opac_schema",
     "sqlalchemy",
     "psycopg2-binary~=2.8",
+    "click==7.1.1",
 ]
 
 tests_require = [

--- a/tests/scripts/test_loggeranalyzer.py
+++ b/tests/scripts/test_loggeranalyzer.py
@@ -1,0 +1,142 @@
+import io
+import re
+import json
+import unittest
+
+from scripts import loggeranalyzer
+
+
+class TestLoggerAnalyzer(unittest.TestCase):
+
+    def setUp(self):
+        self.log_file = io.StringIO()
+        self.out_file = io.StringIO()
+
+    def tearDown(self):
+        self.log_file.close()
+        self.out_file.close()
+
+    def test_is_instance_loggeranalyzer(self):
+        """
+        Testa a instanciação.
+        """
+        parser = loggeranalyzer.LoggerAnalyzer(self.log_file)
+
+        self.assertIsInstance(parser, loggeranalyzer.LoggerAnalyzer)
+
+    def test_json_formatter_return_expect_list(self):
+        """
+        Testa se o retorno do método LoggerAnalyzer.json_formatter é uma lista.
+        """
+        errors = [{'uri': 'cadbto/nahead/2526-8910-cadbto-2526-8910ctoAO1930.xml', 'error': 'xml-not-found', 'level': 'ERROR', 'time': '14:49:55', 'date': '2020-08-26'},
+                  {'renditions': ['bases/pdf/abc/v114n4s1/pt_0066-782X-abc-20180130.pdf'], 'pid': 'S0066-782X2020000500001', 'error': 'resource-not-found', 'level': 'ERROR', 'time': '13:46:05', 'date': '2020-08-26'},
+                  {'renditions': ['bases/pdf/esa/v25n3/1809-4457-esa-s1413-41522020137661.pdf'], 'pid': 'S1413-41522020000300451', 'error': 'resource-not-found', 'level': 'ERROR', 'time': '13:57:25', 'date': '2020-08-26'},
+                  {'renditions': ['htdocs/img/revistas/jbpneu/v46n6/1806-3713-jbpneu-46-6-e20190272-suppl01-en'], 'pid': 'S1806-37132020000600204', 'error': 'resource-not-found', 'level': 'ERROR', 'time': '14:03:13', 'date': '2020-08-26'},
+                  {'renditions': ['htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig02.tif', 'htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig01.tif', 'htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig06.tif',
+                                  'htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig03.tif', 'htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig07.tif'], 'pid': 'S0102-77862020000100089', 'error': 'resource-not-found', 'level': 'ERROR', 'time': '14:22:50', 'date': '2020-08-26'}]
+
+        parser = loggeranalyzer.LoggerAnalyzer(self.log_file)
+
+        self.assertIsInstance(parser.json_formatter(errors), list)
+
+    def test_json_formatter_if_each_is_json_unserialized(self):
+        """
+        Testa se o retorno do método LoggerAnalyzer.json_formatter é um deserializável
+        """
+        errors = [{'uri': 'cadbto/nahead/2526-8910-cadbto-2526-8910ctoAO1930.xml', 'error': 'xml-not-found', 'level': 'ERROR', 'time': '14:49:55', 'date': '2020-08-26'},
+                  {'renditions': ['bases/pdf/abc/v114n4s1/pt_0066-782X-abc-20180130.pdf'], 'pid': 'S0066-782X2020000500001', 'error': 'resource-not-found', 'level': 'ERROR', 'time': '13:46:05', 'date': '2020-08-26'},
+                  {'renditions': ['bases/pdf/esa/v25n3/1809-4457-esa-s1413-41522020137661.pdf'], 'pid': 'S1413-41522020000300451', 'error': 'resource-not-found', 'level': 'ERROR', 'time': '13:57:25', 'date': '2020-08-26'},
+                  {'renditions': ['htdocs/img/revistas/jbpneu/v46n6/1806-3713-jbpneu-46-6-e20190272-suppl01-en'], 'pid': 'S1806-37132020000600204', 'error': 'resource-not-found', 'level': 'ERROR', 'time': '14:03:13', 'date': '2020-08-26'},
+                  {'renditions': ['htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig02.tif', 'htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig01.tif', 'htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig06.tif',
+                                  'htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig03.tif', 'htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig07.tif'], 'pid': 'S0102-77862020000100089', 'error': 'resource-not-found', 'level': 'ERROR', 'time': '14:22:50', 'date': '2020-08-26'}]
+
+        parser = loggeranalyzer.LoggerAnalyzer(self.log_file)
+        for log_line in parser.json_formatter(errors):
+            self.assertIsInstance(json.loads(log_line), dict)
+
+    def test_dump_write_line_in_out_file_atribute(self):
+        """
+        Testa se o método dump escreve linhas no atributo out_file e garante que
+        cada linha contém o caracter de retorno ``\n``"
+        """
+
+        lines = ['{"uri": "alea/nahead/1807-0299-alea-22-01-9-errata.xml", "error": "xml-not-found", "level": "ERROR", "time": "13:42:29", "date": "2020-08-26"}',
+                 '{"uri": "alea/nahead/1807-0299-alea-22-01-15-errata.xml", "error": "xml-not-found", "level": "ERROR", "time": "13:42:30", "date": "2020-08-26"}',
+                 '{"uri": "abc/nahead/0066-782X-abc-20190243.xml", "error": "xml-not-found", "level": "ERROR", "time": "13:46:09", "date": "2020-08-26"}',
+                 '{"uri": "abc/nahead/0066-782X-abc-2020023.xml", "error": "xml-not-found", "level": "ERROR", "time": "13:46:09", "date": "2020-08-26"}',
+                 '{"uri": "abc/nahead/0066-782X-abc-20190331.xml", "error": "xml-not-found", "level": "ERROR", "time": "13:46:09", "date": "2020-08-26"}',
+                 '{"uri": "abc/nahead/0066-782X-abc-20190867.xml", "error": "xml-not-found", "level": "ERROR", "time": "13:46:09", "date": "2020-08-26"}',
+                 '{"uri": "abc/nahead/0066-782X-abc-20190053.xml", "error": "xml-not-found", "level": "ERROR", "time": "13:46:10", "date": "2020-08-26"}']
+
+        parser = loggeranalyzer.LoggerAnalyzer(self.log_file, self.out_file)
+
+        parser.dump(lines)
+
+        parser.out_file.seek(0)
+
+        for i, line in enumerate(parser.out_file.readlines()):
+            self.assertEqual('%s\n' % lines[i], line)
+
+    def test_logformat_regex(self):
+        """
+        Testa se o método retorna uma expressão regular a partir de um formato e
+        um cabeçalho do formato do log.
+
+        """
+
+        parser = loggeranalyzer.LoggerAnalyzer(self.log_file, self.out_file,
+                                               "<date> <time> <level> <module> <message>")
+
+        header, regex = parser.logformat_regex()
+
+        self.assertTrue(header, ['date', 'time', 'level', 'module', 'message'])
+        self.assertTrue(regex, re.compile('^(?P<date>.*?)\\s+(?P<time>.*?)\\s+(?P<level>.*?)\\s+(?P<module>.*?)\\s+(?P<message>.*?)$'))
+
+    def test_load_set_content_atribute(self):
+        """
+        Testa se o método LoggerAnalyzer.load atribui as linhas à LoggerAnalyzer.content.
+        """
+        self.log_file.write("22020-08-17 14:17:25 ERROR [documentstore_migracao.processing.inserting] Could not import package 'path/S0100-39842010000300012'. The following exception was raised: '(sqlite3.OperationalError) unable to open database")
+        self.log_file.seek(0)
+
+        parser = loggeranalyzer.LoggerAnalyzer(self.log_file)
+
+        parser.load()
+
+        self.assertEqual(parser.content, ["22020-08-17 14:17:25 ERROR [documentstore_migracao.processing.inserting] Could not import package 'path/S0100-39842010000300012'. The following exception was raised: '(sqlite3.OperationalError) unable to open database"])
+
+    def test_parser_return_expect_dict(self):
+        """
+        Testa se o método parser retorna um dicionário contendo conteúdo
+        correspondente os errors.
+        """
+        line = "No ISSN in document 'JwqGdMDrdcV3Z7MFHgtKvVk'"
+        self.log_file.write(line)
+        self.log_file.seek(0)
+
+        _ = loggeranalyzer.LoggerAnalyzer(self.log_file)
+
+        parsed = _.parser(line, **loggeranalyzer.IMPORT_PARSERS_PARAMS[-2])
+
+        self.assertEqual(parsed, {'pid': 'JwqGdMDrdcV3Z7MFHgtKvVk', 'error': 'issn-not-found', 'group': None})
+
+    def test_tokenize_return_expect_list(self):
+        """
+        Testa se o retorno do método tokenize é o esperado.
+        """
+
+        lines = ["2020-09-11 08:35:56 ERROR [documentstore_migracao.processing.inserting] The bundle '0036-3634-2009-v45-n4' was not updated. During executions this following exception was raised 'Nenhum documents_bundle encontrado 0036-3634-2009-v45-n4'.\n",
+                 "2020-09-11 08:35:56 ERROR [documentstore_migracao.processing.inserting] The bundle '0036-3634-2009-v45-n4' was not updated. During executions this following exception was raised 'Nenhum documents_bundle encontrado 0036-3634-2009-v45-n4'.\n",
+                 "2020-09-11 08:35:56 ERROR [documentstore_migracao.processing.inserting] No ISSN in document 'JwqGdMDrdcV3Z7MFHgtKvVk'\n", ]
+
+        self.log_file.writelines(lines)
+        self.log_file.seek(0)
+
+        parsed = loggeranalyzer.LoggerAnalyzer(self.log_file)
+
+        parsed.load()
+        tokenized_lines = parsed.tokenize(loggeranalyzer.IMPORT_PARSERS_PARAMS)
+
+        self.assertEqual(tokenized_lines, [{'bundle': '0036-3634-2009-v45-n4', 'error': 'bundle-not-found', 'level': 'ERROR', 'time': '08:35:56', 'date': '2020-09-11'},
+                                           {'bundle': '0036-3634-2009-v45-n4', 'error': 'bundle-not-found', 'level': 'ERROR', 'time': '08:35:56', 'date': '2020-09-11'},
+                                           {None: [None], 'pid': 'JwqGdMDrdcV3Z7MFHgtKvVk', 'error': 'issn-not-found', 'level': 'ERROR', 'time': '08:35:56', 'date': '2020-09-11'}])

--- a/tests/scripts/test_loggeranalyzer.py
+++ b/tests/scripts/test_loggeranalyzer.py
@@ -38,6 +38,12 @@ class TestLoggerAnalyzer(unittest.TestCase):
         parser = loggeranalyzer.LoggerAnalyzer(self.log_file)
 
         self.assertIsInstance(parser.json_formatter(errors), list)
+        expected_list = ['{"uri": "cadbto/nahead/2526-8910-cadbto-2526-8910ctoAO1930.xml", "error": "xml-not-found", "level": "ERROR", "time": "14:49:55", "date": "2020-08-26"}',
+                         '{"renditions": ["bases/pdf/abc/v114n4s1/pt_0066-782X-abc-20180130.pdf"], "pid": "S0066-782X2020000500001", "error": "resource-not-found", "level": "ERROR", "time": "13:46:05", "date": "2020-08-26"}',
+                         '{"renditions": ["bases/pdf/esa/v25n3/1809-4457-esa-s1413-41522020137661.pdf"], "pid": "S1413-41522020000300451", "error": "resource-not-found", "level": "ERROR", "time": "13:57:25", "date": "2020-08-26"}',
+                         '{"renditions": ["htdocs/img/revistas/jbpneu/v46n6/1806-3713-jbpneu-46-6-e20190272-suppl01-en"], "pid": "S1806-37132020000600204", "error": "resource-not-found", "level": "ERROR", "time": "14:03:13", "date": "2020-08-26"}',
+                         '{"renditions": ["htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig02.tif", "htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig01.tif", "htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig06.tif", "htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig03.tif", "htdocs/img/revistas/rbmet/v35n1/0102-7786-rbmet-35-01-0004-fig07.tif"], "pid": "S0102-77862020000100089", "error": "resource-not-found", "level": "ERROR", "time": "14:22:50", "date": "2020-08-26"}']
+        self.assertEqual(parser.json_formatter(errors), expected_list)
 
     def test_json_formatter_if_each_is_json_unserialized(self):
         """

--- a/tests/scripts/test_loggeranalyzer.py
+++ b/tests/scripts/test_loggeranalyzer.py
@@ -7,12 +7,21 @@ from scripts import loggeranalyzer
 
 
 class TestLoggerAnalyzer(unittest.TestCase):
+    """
+    Testa class LoggerAnalyser
+    """
 
     def setUp(self):
+        """
+        Cria um arquivo de entrada e de saída.
+        """
         self.log_file = io.StringIO()
         self.out_file = io.StringIO()
 
     def tearDown(self):
+        """
+        Fecha os arquivos de entrada e saída.
+        """
         self.log_file.close()
         self.out_file.close()
 
@@ -113,8 +122,8 @@ class TestLoggerAnalyzer(unittest.TestCase):
 
     def test_parser_return_expect_dict(self):
         """
-        Testa se o método parser retorna um dicionário contendo conteúdo
-        correspondente os errors.
+        Testa se o método parser retorna um dicionário contendo o conteúdo
+        correspondente aos errors.
         """
         line = "No ISSN in document 'JwqGdMDrdcV3Z7MFHgtKvVk'"
         self.log_file.write(line)
@@ -122,7 +131,9 @@ class TestLoggerAnalyzer(unittest.TestCase):
 
         _ = loggeranalyzer.LoggerAnalyzer(self.log_file)
 
-        parsed = _.parser(line, **loggeranalyzer.IMPORT_PARSERS_PARAMS[-2])
+        params = {"regex": re.compile(r".*No ISSN in document '(?P<pid>[^']+)'", re.IGNORECASE), "error": loggeranalyzer.ErrorEnum.ISSN_NOT_FOUND}
+
+        parsed = _.parser(line, **params)
 
         self.assertEqual(parsed, {'pid': 'JwqGdMDrdcV3Z7MFHgtKvVk', 'error': 'issn-not-found', 'group': None})
 
@@ -130,6 +141,14 @@ class TestLoggerAnalyzer(unittest.TestCase):
         """
         Testa se o retorno do método tokenize é o esperado.
         """
+        PARSERS = [
+            {"regex": re.compile(r".*No such file or directory: '(?P<file_path>[^']+)'", re.IGNORECASE), "error": loggeranalyzer.ErrorEnum.RESOURCE_NOT_FOUND},
+            {"regex": re.compile(r".*There is no XML file into package '(?P<package_path>[^']+)", re.IGNORECASE), "error": loggeranalyzer.ErrorEnum.XML_NOT_FOUND},
+            {"regex": re.compile(r".*Could not parse the '(?P<file_path>[^']+)' file", re.IGNORECASE), "error": loggeranalyzer.ErrorEnum.XML_PARSER_ERROR},
+            {"regex": re.compile(r".*The bundle '(?P<bundle>[^']+)' was not updated.", re.IGNORECASE), "error": loggeranalyzer.ErrorEnum.BUNDLE_NOT_FOUND},
+            {"regex": re.compile(r".*No ISSN in document '(?P<pid>[^']+)'", re.IGNORECASE), "error": loggeranalyzer.ErrorEnum.ISSN_NOT_FOUND},
+            {"regex": re.compile(r".*Could not import package '(?P<package_path>[^']+).*'", re.IGNORECASE), "error": loggeranalyzer.ErrorEnum.PACKAGE_NOT_IMPORT},
+          ]
 
         lines = ["2020-09-11 08:35:56 ERROR [documentstore_migracao.processing.inserting] The bundle '0036-3634-2009-v45-n4' was not updated. During executions this following exception was raised 'Nenhum documents_bundle encontrado 0036-3634-2009-v45-n4'.\n",
                  "2020-09-11 08:35:56 ERROR [documentstore_migracao.processing.inserting] The bundle '0036-3634-2009-v45-n4' was not updated. During executions this following exception was raised 'Nenhum documents_bundle encontrado 0036-3634-2009-v45-n4'.\n",
@@ -141,8 +160,76 @@ class TestLoggerAnalyzer(unittest.TestCase):
         parsed = loggeranalyzer.LoggerAnalyzer(self.log_file)
 
         parsed.load()
-        tokenized_lines = parsed.tokenize(loggeranalyzer.IMPORT_PARSERS_PARAMS)
+        tokenized_lines = parsed.tokenize(PARSERS)
 
         self.assertEqual(tokenized_lines, [{'bundle': '0036-3634-2009-v45-n4', 'error': 'bundle-not-found', 'level': 'ERROR', 'time': '08:35:56', 'date': '2020-09-11'},
                                            {'bundle': '0036-3634-2009-v45-n4', 'error': 'bundle-not-found', 'level': 'ERROR', 'time': '08:35:56', 'date': '2020-09-11'},
                                            {None: [None], 'pid': 'JwqGdMDrdcV3Z7MFHgtKvVk', 'error': 'issn-not-found', 'level': 'ERROR', 'time': '08:35:56', 'date': '2020-09-11'}])
+
+
+class TestAnalyzerImport(unittest.TestCase):
+
+    def setUp(self):
+        """
+        Cria um arquivo de entrada e de saída.
+        """
+        self.log_file = io.StringIO()
+        self.out_file = io.StringIO()
+
+    def tearDown(self):
+        """
+        Fecha os arquivos de entrada e saída.
+        """
+        self.log_file.close()
+        self.out_file.close()
+
+    def test_parse_with_diference_import_lines(self):
+        """
+        Testa entradas em um arquivo de log da fase de importação e a saída em JSONL.
+        """
+        self.log_file.write("2020-10-19 19:01:41 ERROR [documentstore_migracao.processing.inserting] Could not import package '/mnt/vol_dsteste/migracao/xml/site_sps_packages/xml_2017_2/sssoc/n130/0101-6628-sssoc-130-0564'. The following exception was raised: 'RequestTimeTooSkewed: message: The difference between the request time and the server's time is too large.'.\n")
+        self.log_file.write("2020-10-19 19:24:19 ERROR [documentstore_migracao.processing.inserting] Could not import package '/mnt/vol_dsteste/migracao/xml/site_sps_packages/xml_2017_2/cflo/v27n3/1980-5098-cflo-27-03-01061'. The following exception was raised: '(psycopg2.DatabaseError) could not receive data from server: Connection timed out\n")
+        self.log_file.write("2020-10-19 19:37:23 ERROR [documentstore_migracao.processing.inserting] Could not import package '/mnt/vol_dsteste/migracao/xml/site_sps_packages/xml_2017_2/rbort/v52s1/1982-4378-rbort-52-s1-0046'. The following exception was raised: 'RequestTimeTooSkewed: message: The difference between the request time and the server's time is too large.'.\n")
+        self.log_file.write("2020-10-19 19:45:44 ERROR [documentstore_migracao.processing.inserting] Could not import package '/mnt/vol_dsteste/migracao/xml/site_sps_packages/xml_2017_2/jatm/v9n3/2175-9146-jatm-v9i3707'. The following exception was raised: 'RequestTimeTooSkewed: message: The difference between the request time and the server's time is too large.'.\n")
+
+        self.log_file.seek(0)
+
+        parser = loggeranalyzer.AnalyzerImport(self.log_file, out_file=self.out_file)
+
+        for line in parser.out_file.readlines():
+            self.assertIn(parser.parse(), line)
+
+
+class TestAnalyzerPack(unittest.TestCase):
+
+    def setUp(self):
+        """
+        Cria um arquivo de entrada e de saída.
+        """
+        self.log_file = io.StringIO()
+        self.out_file = io.StringIO()
+
+    def tearDown(self):
+        """
+        Fecha os arquivos de entrada e saída.
+        """
+        self.log_file.close()
+        self.out_file.close()
+
+    def test_parse_with_diference_pack_lines(self):
+        """
+        Testa entradas em um arquivo de log da fase de pack e a saída em JSONL.
+        """
+
+        self.log_file.write("2020-10-08 14:17:23 ERROR [documentstore_migracao.utils.build_ps_package] [S0006-87052018000200283] - Could not find asset '/mnt/vol_dsteste/migracao/htdocs/img/revistas/brag/v77n2/0006-8705-brag-1678-44992017043-e02.tif' during packing XML '/mnt/vol_dsteste/migracao/xml/site_sps_packages/xml_2018_1/brag/v77n2/0006-8705-brag-1678-44992017043/0006-8705-brag-1678-44992017043.xml'.")
+        self.log_file.write("2020-10-08 14:17:25 ERROR [documentstore_migracao.utils.build_ps_package] [S0006-87052018000200221] - Could not find asset '/mnt/vol_dsteste/migracao/htdocs/img/revistas/brag/v77n2/0006-8705-brag-1678-44992017106-e04.tif' during packing XML '/mnt/vol_dsteste/migracao/xml/site_sps_packages/xml_2018_1/brag/v77n2/0006-8705-brag-1678-44992017106/0006-8705-brag-1678-44992017106.xml'.")
+        self.log_file.write("2020-10-08 14:24:49 ERROR [documentstore_migracao.utils.build_ps_package] [S0104-530X2018000400777] - Could not find asset '/mnt/vol_dsteste/migracao/htdocs/img/revistas/gp/v25n4/0104-530X-gp-0104-530X1877-18-tab05.JPG' during packing XML '/mnt/vol_dsteste/migracao/xml/site_sps_packages/xml_2018_1/gp/v25n4/0104-530X-gp-0104-530X1877-18/0104-530X-gp-0104-530X1877-18.xml'.")
+        self.log_file.write("2020-10-08 14:25:12 ERROR [documentstore_migracao.utils.build_ps_package] [S0102-05362018005001101] Could not find the XML file 'hb/nahead/1806-9991-hb-s0102-053620180401.xml'.")
+        self.log_file.write("2020-10-08 14:29:11 ERROR [documentstore_migracao.utils.build_ps_package] [S0100-512X2018005001101] Could not find the XML file 'kr/nahead/1981-5336-kr-10159020170580138e001.xml'.")
+
+        self.log_file.seek(0)
+
+        parser = loggeranalyzer.AnalyzerPack(self.log_file, out_file=self.out_file)
+
+        for line in parser.out_file.readlines():
+            self.assertIn(parser.parse(), line)


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR adiciona novas expressões regulares para o script loggeranalyzer.py, com o objetivo de estruturarmos o log do processamento da fase de pack e importação, para realizarmos consultas com **jq**.

#### Onde a revisão poderia começar?

Olhando a história dos commits e olhando o script `loggeranalyzer.py`

#### Como este poderia ser testado manualmente?

- Baixe o arquivo de log: 
[migracao.log.zip](https://github.com/scieloorg/document-store-migracao/files/5201469/migracao.log.zip)
- Execute `python scripts/loggeranalyzer.py path-para-arquivo-de-log -s import`;
- Visualize as saídas em formato JSON indicando:
    - Arquivo de Manifest não encontrado
    - Arquivo XML não encontrado
    - Erro de analise no XML
    - Bundle não encontrado 
    - Fascículo não encontrado
    - Erro de importação de pacote

#### Algum cenário de contexto que queira dar?

Esse script esta atualmente analisando os logs da fase de empacotamento do site e os logs da fase de importação, a idéia é melhorar para que possa realizar a analise dos logs de todas as fase isso justifica algumas alterações realizadas.

### Screenshots

A saída do comando em JSONL:

<img width="1810" alt="Screen Shot 2020-09-10 at 09 12 45" src="https://user-images.githubusercontent.com/373745/92727692-e6e0b300-f345-11ea-96ee-20f3c3d4e4ae.png">


#### Quais são tickets relevantes?

O tíquete relacionado a esse PR é: https://github.com/scieloorg/document-store-migracao/issues/348

### Referências
Um repositório de analise de logs bastante interessante:  https://github.com/logpai/awesome-log-analysis

