### PR TITLE
Adiciona tempo de expiração para conexões com o Mongo, Minio e Postgres.

### DIFF
--- a/documentstore_migracao/config.py
+++ b/documentstore_migracao/config.py
@@ -49,6 +49,12 @@ _default = dict(
     THREADPOOL_MAX_WORKERS=os.cpu_count() * 5,
     PROCESSPOOL_MAX_WORKERS=os.cpu_count(),
     PID_DATABASE_DSN="sqlite:///pid_manager_database.db",
+    MONGO_MAX_IDLE_TIME_MS=20000,
+    MONGO_SOCKET_TIMEOUT_MS=20000,
+    MONGO_CONNECT_TIMEOUT_MS=20000,
+    MINIO_TIMEOUT=20000,
+    POSTGRES_TIMEOUT=2000
+
 )
 
 

--- a/documentstore_migracao/object_store/minio.py
+++ b/documentstore_migracao/object_store/minio.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 class MinioStorage:
     def __init__(
-        self, minio_host, minio_access_key, minio_secret_key, minio_secure=True
+        self, minio_host, minio_access_key, minio_secret_key, minio_secure=True, minio_http_client=None
     ):
 
         self.bucket_name = "documentstore"
@@ -39,6 +39,7 @@ class MinioStorage:
         self.minio_access_key = minio_access_key
         self.minio_secret_key = minio_secret_key
         self.minio_secure = minio_secure
+        self.http_client = minio_http_client
         self._client_instance = None
 
     @property
@@ -53,6 +54,7 @@ class MinioStorage:
                 access_key=self.minio_access_key,
                 secret_key=self.minio_secret_key,
                 secure=self.minio_secure,
+                http_client=self.http_client
             )
             logger.debug(
                 "new Minio client created: <%s at %s>",

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,6 @@ requires = [
     "opac_schema",
     "sqlalchemy",
     "psycopg2-binary~=2.8",
-    "grequests==0.6.0",
-    "json-logging==1.2.8"
 ]
 
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ requires = [
     "opac_schema",
     "sqlalchemy",
     "psycopg2-binary~=2.8",
+    "grequests==0.6.0",
+    "json-logging==1.2.8"
 ]
 
 tests_require = [


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona tempo de expiração para conexões com o **Mongo**, **Minio** e **Postgres**.

#### Onde a revisão poderia começar?

Verificando os módulos: 

- documentstore_migracao/config.py
- documentstore_migracao/main/migrate_articlemeta.py
- documentstore_migracao/object_store/minio.py

#### Como este poderia ser testado manualmente?

Executando os testes unitários: `python setup.py test`

#### Algum cenário de contexto que queira dar?

Realizamos esse ajuste baseado em constantes paradas inesperadas na fase 1 do processamento de 2019.  



