### PR TITLE
Corrige o valor do "order" no XML

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -419,6 +419,31 @@ class SPS_Package:
         return True
 
     @property
+    def fpage(self):
+        try:
+            return self.article_meta.findtext("fpage")
+        except AttributeError:
+            return None
+
+    @property
+    def article_id_which_id_type_is_other(self):
+        try:
+            return self.article_meta.xpath(
+                "article-id[@pub-id-type='other']")[0].text
+        except (AttributeError, IndexError):
+            return None
+
+    @property
+    def order(self):
+        for item in (
+                len(self.scielo_pid_v2 or "") == 23 and self.scielo_pid_v2[-5:],
+                self.article_id_which_id_type_is_other,
+                self.fpage,
+                ):
+            if item and item.isdigit() and len(item) <= 5:
+                return item.zfill(5)
+
+    @property
     def is_ahead_of_print(self):
         if not bool(self.volume) and not bool(self.number):
             return True
@@ -748,7 +773,7 @@ class DocumentsSorter:
             "volume": pkg.volume,
             "number": pkg.number,
             "supplement": pkg.supplement,
-            "order": format(data.get("other")) or format(data.get("fpage")),
+            "order": pkg.order,
         }
 
     def insert_documents(self, documents):

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -419,27 +419,6 @@ class SPS_Package:
         return True
 
     @property
-    def order_meta(self):
-        def format(value):
-            if value and value.isdigit():
-                return value.zfill(5)
-            return value or ""
-
-        data = dict(self.parse_article_meta)
-        return (
-            ("other", format(data.get("other"))),
-            ("fpage", format(data.get("fpage"))),
-            ("lpage", format(data.get("lpage"))),
-            ("documents_bundle_pubdate", self.documents_bundle_pubdate),
-            ("document_pubdate", self.document_pubdate),
-            ("elocation-id", data.get("elocation-id", "")),
-        )
-
-    @property
-    def order(self):
-        return tuple(item[1] for item in self.order_meta)
-
-    @property
     def is_ahead_of_print(self):
         if not bool(self.volume) and not bool(self.number):
             return True

--- a/documentstore_migracao/main/migrate_articlemeta.py
+++ b/documentstore_migracao/main/migrate_articlemeta.py
@@ -316,12 +316,14 @@ def migrate_articlemeta_parser(sargs):
             )
 
     elif args.command == "pack":
+        # pack HTML
         if args.packFile:
             packing.pack_article_xml(args.packFile)
         else:
             packing.pack_article_ALLxml()
 
     elif args.command == "pack_from_site":
+        # pack XML
         build_ps = BuildPSPackage(
             args.xml_folder,
             args.img_folder,

--- a/documentstore_migracao/processing/inserting.py
+++ b/documentstore_migracao/processing/inserting.py
@@ -169,15 +169,8 @@ def get_article_result_dict(sps: SPS_Package) -> dict:
         ("volume", sps.volume),
         ("number", sps.number),
         ("supplement", sps.supplement),
-        (
-            "order",
-            str(
-                _format_str(article_meta.get("other"))
-                or _format_str(article_meta.get("fpage"))
-            ),
-        ),
+        ("order", sps.order),
     )
-
     for key, value in attributes:
         if value is not None:
             article_metadata[key] = "%s" % value

--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -16,7 +16,10 @@ logger = logging.getLogger(__name__)
 
 
 def pack_article_xml(file_xml_path, poison_pill=PoisonPill()):
-
+    """
+    Cria pacotes XML a partir dos documentos inseridos em HTML, ou seja,
+    metodologia clássica
+    """
     if poison_pill.poisoned:
         return
 

--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -88,6 +88,16 @@ class BuildPSPackage(object):
         except errors.ResourceNotFound as e:
             logger.error(e)
 
+        def _fix_pid(_sps_package, attr_name, attr_value):
+            try:
+                _sps_package.fix(attr_name, attr_value)
+                logger.debug('Updating document with PID "%s"', attr_value)
+            except NotAllowedtoChangeAttributeValueError:
+                pass
+            except InvalidAttributeValueError:
+                logger.error('Missing PID V2')
+
+
     def _update_sps_package_obj(self, sps_package, pack_name, row, xml_target_path) -> SPS_Package:
         """
         Atualiza instancia SPS_Package com os dados de artigos do arquivo
@@ -119,13 +129,7 @@ class BuildPSPackage(object):
         _sps_package = deepcopy(sps_package)
         f_pid, f_pid_aop, f_file, f_dt_collection, f_dt_created, f_dt_updated, __, __, f_lang = row
         # Verificar se tem PID
-        try:
-            _sps_package.fix("scielo_pid_v2", f_pid)
-            logger.debug('Updating document with PID "%s"', f_pid)
-        except NotAllowedtoChangeAttributeValueError:
-            pass
-        except InvalidAttributeValueError:
-            logger.error('Missing PID V2')
+        _fix_pid(_sps_package, "scielo_pid_v2", f_pid)
 
         try:
             _sps_package.fix("aop_pid", f_pid_aop)

--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -88,24 +88,6 @@ class BuildPSPackage(object):
         except errors.ResourceNotFound as e:
             logger.error(e)
 
-        def _fix_pid(_sps_package, attr_name, attr_value):
-            try:
-                _sps_package.fix(attr_name, attr_value)
-                logger.debug('Updating document with PID "%s"', attr_value)
-            except NotAllowedtoChangeAttributeValueError:
-                pass
-            except InvalidAttributeValueError:
-                logger.error('Missing PID V2')
-
-        def _fix_attr(_sps_package, attr_name, attr_value, f_pid, label):
-            try:
-                _sps_package.fix(attr_name, attr_value)
-                logger.debug('Updating document "%s" with %s "%s"', f_pid, label, attr_value)
-            except NotAllowedtoChangeAttributeValueError:
-                pass
-            except InvalidAttributeValueError:
-                logger.debug('No %s for document PID "%s"', label, f_pid)
-
     def _update_sps_package_obj(self, sps_package, pack_name, row, xml_target_path) -> SPS_Package:
         """
         Atualiza instancia SPS_Package com os dados de artigos do arquivo
@@ -133,6 +115,24 @@ class BuildPSPackage(object):
                 return _parse_date(date_value)
             else:
                 logger.debug('Missing "%s" into XML file "%s".', date_label, xml_target_path)
+
+        def _fix_pid(_sps_package, attr_name, attr_value):
+            try:
+                _sps_package.fix(attr_name, attr_value)
+                logger.debug('Updating document with PID "%s"', attr_value)
+            except NotAllowedtoChangeAttributeValueError:
+                pass
+            except InvalidAttributeValueError:
+                logger.error('Missing PID V2')
+
+        def _fix_attr(_sps_package, attr_name, attr_value, f_pid, label):
+            try:
+                _sps_package.fix(attr_name, attr_value)
+                logger.debug('Updating document "%s" with %s "%s"', f_pid, label, attr_value)
+            except NotAllowedtoChangeAttributeValueError:
+                pass
+            except InvalidAttributeValueError:
+                logger.debug('No %s for document PID "%s"', label, f_pid)
 
         _sps_package = deepcopy(sps_package)
         f_pid, f_pid_aop, f_file, f_dt_collection, f_dt_created, f_dt_updated, __, __, f_lang = row

--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -97,6 +97,14 @@ class BuildPSPackage(object):
             except InvalidAttributeValueError:
                 logger.error('Missing PID V2')
 
+        def _fix_attr(_sps_package, attr_name, attr_value, f_pid, label):
+            try:
+                _sps_package.fix(attr_name, attr_value)
+                logger.debug('Updating document "%s" with %s "%s"', f_pid, label, attr_value)
+            except NotAllowedtoChangeAttributeValueError:
+                pass
+            except InvalidAttributeValueError:
+                logger.debug('No %s for document PID "%s"', label, f_pid)
 
     def _update_sps_package_obj(self, sps_package, pack_name, row, xml_target_path) -> SPS_Package:
         """
@@ -130,22 +138,8 @@ class BuildPSPackage(object):
         f_pid, f_pid_aop, f_file, f_dt_collection, f_dt_created, f_dt_updated, __, __, f_lang = row
         # Verificar se tem PID
         _fix_pid(_sps_package, "scielo_pid_v2", f_pid)
-
-        try:
-            _sps_package.fix("aop_pid", f_pid_aop)
-            logger.debug('Updating document "%s" with AOP PID "%s"', f_pid, f_pid_aop)
-        except NotAllowedtoChangeAttributeValueError:
-            pass
-        except InvalidAttributeValueError:
-            logger.debug('No AOP PID for document PID "%s"', f_pid)
-
-        try:
-            _sps_package.fix("original_language", f_lang)
-            logger.debug('Updating document "%s" with original language "%s"', f_pid, f_lang)
-        except NotAllowedtoChangeAttributeValueError:
-            pass
-        except InvalidAttributeValueError:
-            logger.debug('No original language for document PID "%s"', f_pid)
+        _fix_attr(_sps_package, "aop_pid", f_pid_aop, f_pid, "AOP PID")
+        _fix_attr(_sps_package, "original_language", f_lang, f_pid, "original language")
 
         if _sps_package.is_ahead_of_print:
             return _sps_package

--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -140,6 +140,10 @@ class BuildPSPackage(object):
         _fix_pid(_sps_package, "scielo_pid_v2", f_pid)
         _fix_attr(_sps_package, "aop_pid", f_pid_aop, f_pid, "AOP PID")
         _fix_attr(_sps_package, "original_language", f_lang, f_pid, "original language")
+        _fix_attr(
+            _sps_package, "article_id_which_id_type_is_other",
+            _sps_package.order, f_pid, "article-id[@pub-id-type='other']"
+        )
 
         if _sps_package.is_ahead_of_print:
             return _sps_package

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -114,9 +114,12 @@ class TestBuildSPSPackageBase(TestCase):
             </article>
         """
 
-    def get_sps_package(self, article_meta=""):
-        return SPS_Package(
-            etree.fromstring(self.article_meta_xml.format(article_meta)))
+    def get_sps_package(self, article_meta="", lang=""):
+        tree = etree.fromstring(self.article_meta_xml.format(article_meta))
+        if lang:
+            tree.find(".").set(
+                "{http://www.w3.org/XML/1998/namespace}lang", lang)
+        return SPS_Package(tree)
 
 
 class TestBuildSPSPackage(TestBuildSPSPackageBase):
@@ -289,14 +292,9 @@ class TestBuildSPSPackageAOPPubDate(TestBuildSPSPackageBase):
 class TestBuildSPSPackageLang(TestBuildSPSPackageBase):
 
     def test__update_sps_package_obj_does_not_update_lang_if_it_is_set(self):
-        mk_sps_package = mock.Mock(
-            spec=SPS_Package,
-            aop_pid=None,
-            scielo_pid_v2="S0101-01012019000100003",
-            is_ahead_of_print=False,
-            original_language="pt",
-            documents_bundle_pubdate=("2012", "01", "15",),
-            document_pubdate=("", "", "",),
+        mk_sps_package = self.get_sps_package(
+            "<article-id specific-use='scielo-v2' pub-id-type='publisher-id'>"
+            "S0101-01012019000100003</article-id>", "pt"
         )
         pack_name = "1806-0013-test-01-01-0003"
         result = self.builder._update_sps_package_obj(
@@ -305,14 +303,9 @@ class TestBuildSPSPackageLang(TestBuildSPSPackageBase):
         self.assertEqual(result.original_language, "pt")
 
     def test__update_sps_package_obj_updates_lang_if_it_is_not_set(self):
-        mk_sps_package = mock.Mock(
-            spec=SPS_Package,
-            aop_pid=None,
-            scielo_pid_v2="S0101-01012019000100003",
-            is_ahead_of_print=False,
-            original_language=None,
-            documents_bundle_pubdate=("2012", "01", "15",),
-            document_pubdate=("", "", "",),
+        mk_sps_package = self.get_sps_package(
+            "<article-id specific-use='scielo-v2' pub-id-type='publisher-id'>"
+            "S0101-01012019000100003</article-id>", ""
         )
         pack_name = "1806-0013-test-01-01-0003"
         result = self.builder._update_sps_package_obj(

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -314,6 +314,52 @@ class TestBuildSPSPackageLang(TestBuildSPSPackageBase):
         self.assertEqual(result.original_language, "en")
 
 
+class TestBuildSPSPackageOrder(TestBuildSPSPackageBase):
+
+    def test__update_sps_package_obj_does_not_update_order_if_it_is_set(self):
+        mk_sps_package = self.get_sps_package(
+            "<article-id specific-use='scielo-v2' pub-id-type='publisher-id'>"
+            "S0101-01012019000100003</article-id>"
+            "<article-id pub-id-type='other'>00003</article-id>"
+        )
+        pack_name = "1806-0013-test-01-01-0003"
+        result = self.builder._update_sps_package_obj(
+            mk_sps_package, pack_name, self.rows[2], pack_name + ".xml"
+        )
+        self.assertEqual(result.order, "00003")
+        self.assertEqual(result.article_id_which_id_type_is_other, "00003")
+
+    def test__update_sps_package_obj_does_not_update_order_if_fpage_is_number(self):
+        mk_sps_package = self.get_sps_package(
+            "<article-id specific-use='scielo-v2' pub-id-type='publisher-id'>"
+            "S0101-01012019000100003</article-id>"
+            "<fpage>3</fpage>"
+        )
+        pack_name = "1806-0013-test-01-01-0003"
+        result = self.builder._update_sps_package_obj(
+            mk_sps_package, pack_name, self.rows[2], pack_name + ".xml"
+        )
+        self.assertEqual(result.order, "00003")
+        self.assertIsNone(result.article_id_which_id_type_is_other)
+
+    def test__update_sps_package_obj_updates_order_if_fpage_is_not_number_and_other_is_none(self):
+        mk_sps_package = self.get_sps_package(
+            "<article-id specific-use='scielo-v2' pub-id-type='publisher-id'>"
+            "S0101-01012019000100003</article-id>"
+            "<fpage>3A</fpage>"
+        )
+        pack_name = "1806-0013-test-01-01-0003"
+        result = self.builder._update_sps_package_obj(
+            mk_sps_package, pack_name, self.rows[2], pack_name + ".xml"
+        )
+        self.assertEqual(result.order, "00003")
+        self.assertEqual(result.article_id_which_id_type_is_other, "00003")
+        self.assertIn(
+            '<article-id pub-id-type="other">00003</article-id>',
+            etree.tostring(result.xmltree).decode("utf-8")
+        )
+
+
 class TestBuildSPSPackageUpdateDates(TestBuildSPSPackageBase):
 
     def setUp(self):

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -234,33 +234,31 @@ class TestBuildSPSPackagePIDUpdade(TestBuildSPSPackageBase):
 
 class TestBuildSPSPackageAOPPIDUpdade(TestBuildSPSPackageBase):
 
-    @mock.patch("documentstore_migracao.utils.build_ps_package.getattr")
-    def test__update_sps_package_obj_updates_aop_pid_if_pid_is_none(self, mock_getattr):
-        mk_sps_package = mock.Mock(spec=SPS_Package, aop_pid=None, scielo_pid_v2=None)
-        pack_name = "1806-0013-test-01-01-0002"
-        mock_getattr.side_effect = [None, None, None]
-        result = self.builder._update_sps_package_obj(
-            mk_sps_package, pack_name, self.rows[1], pack_name + ".xml"
-        )
-        self.assertEqual(result.aop_pid, "S0101-01012019005000001")
-
-    @mock.patch("documentstore_migracao.utils.build_ps_package.getattr")
-    def test__update_sps_package_obj_updates_aop_pid_if_pid_is_found(self, mock_getattr):
-        mock_getattr.side_effect = ["S0101-01012019000100002", None, None]
-        mk_sps_package = mock.Mock(
-            spec=SPS_Package, aop_pid=None, scielo_pid_v2="S0101-01012019000100002"
-        )
+    def test__update_sps_package_obj_updates_aop_pid_if_pid_is_none(self):
+        mk_sps_package = self.get_sps_package("")
         pack_name = "1806-0013-test-01-01-0002"
         result = self.builder._update_sps_package_obj(
             mk_sps_package, pack_name, self.rows[1], pack_name + ".xml"
         )
         self.assertEqual(result.aop_pid, "S0101-01012019005000001")
 
-    @mock.patch("documentstore_migracao.utils.build_ps_package.getattr")
-    def test__update_sps_package_obj_does_not_update_aop_pid_if_it_is_not_aop(self, mock_getattr):
-        mock_getattr.side_effect = ["S0101-01012019000100002", None, None]
-        mk_sps_package = mock.Mock(
-            spec=SPS_Package, aop_pid=None, scielo_pid_v2="S0101-01012019000100002"
+    def test__update_sps_package_obj_updates_aop_pid_if_pid_is_found(self):
+        mk_sps_package = self.get_sps_package(
+            "<article-id specific-use='scielo-v2' pub-id-type='publisher-id'>"
+            "S0101-01012019000100002</article-id>"
+            "<article-id specific-use='previous-pid' pub-id-type='publisher-id'>"
+            "S0101-01012019005000001</article-id>"
+        )
+        pack_name = "1806-0013-test-01-01-0002"
+        result = self.builder._update_sps_package_obj(
+            mk_sps_package, pack_name, self.rows[1], pack_name + ".xml"
+        )
+        self.assertEqual(result.aop_pid, "S0101-01012019005000001")
+
+    def test__update_sps_package_obj_does_not_update_aop_pid_if_it_is_not_aop(self):
+        mk_sps_package = self.get_sps_package(
+            "<article-id specific-use='scielo-v2' pub-id-type='publisher-id'>"
+            "S0101-01012019000100002</article-id>"
         )
         pack_name = "1806-0013-test-01-01-0001"
         result = self.builder._update_sps_package_obj(

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -108,6 +108,15 @@ class TestBuildSPSPackageBase(TestCase):
         </fig>
         <p>We also used an ... based on the equation:<inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e04.tif"/>.</p>
         </body></article>"""
+        self.article_meta_xml = """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink">
+            <article-meta>{}</article-meta>
+            </article>
+        """
+
+    def get_sps_package(self, article_meta=""):
+        return SPS_Package(
+            etree.fromstring(self.article_meta_xml.format(article_meta)))
 
 
 class TestBuildSPSPackage(TestBuildSPSPackageBase):
@@ -202,27 +211,23 @@ class TestBuildSPSPackage(TestBuildSPSPackageBase):
 
 class TestBuildSPSPackagePIDUpdade(TestBuildSPSPackageBase):
 
-    @mock.patch("documentstore_migracao.utils.build_ps_package.getattr")
-    def test__update_sps_package_obj_updates_pid_if_it_is_none(self, mock_getattr):
-        mk_sps_package = mock.Mock(spec=SPS_Package)
-        mock_getattr.side_effect = [None, None, None]
+    def test__update_sps_package_obj_updates_pid_if_it_is_none(self):
+        sps_package = self.get_sps_package("")
         pack_name = "1806-0013-test-01-01-0001"
         row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,test,v1n1,en,".split(",")
         result = self.builder._update_sps_package_obj(
-            mk_sps_package, pack_name, row, pack_name + ".xml"
+            sps_package, pack_name, row, pack_name + ".xml"
         )
         self.assertEqual(result.scielo_pid_v2, "S0101-01012019000100001")
 
-    @mock.patch("documentstore_migracao.utils.build_ps_package.getattr")
-    def test__update_sps_package_obj_does_not_update_pid_if_it_is_not_none(self, mock_getattr):
-        mk_sps_package = mock.Mock(
-            spec=SPS_Package, scielo_pid_v2="S0101-01012019000100999")
-        mock_getattr.side_effect = ["S0101-01012019000100999", None, None]
-
-        row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,test,v1n1,pt,".split(",")
+    def test__update_sps_package_obj_does_not_update_pid_if_it_is_not_none(self):
+        sps_package = self.get_sps_package(
+            "<article-id specific-use='scielo-v2' pub-id-type='publisher-id'>"
+            "S0101-01012019000100999</article-id>")
         pack_name = "1806-0013-test-01-01-0001"
+        row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,test,v1n1,en,".split(",")
         result = self.builder._update_sps_package_obj(
-            mk_sps_package, pack_name, row, pack_name + ".xml"
+            sps_package, pack_name, row, pack_name + ".xml"
         )
         self.assertEqual(result.scielo_pid_v2, "S0101-01012019000100999")
 

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -444,25 +444,6 @@ class Test_SPS_Package_VolNumFpageLpage(unittest.TestCase):
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, False)
 
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", "fpage"),
-                ("lpage", "lpage"),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", ""),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
-        )
-
     def test_is_ahead_of_print_false(self):
         self.assertFalse(self.sps_package.is_ahead_of_print)
 
@@ -497,25 +478,6 @@ class Test_SPS_Package_VolFpageLpage(unittest.TestCase):
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, False)
 
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", "fpage"),
-                ("lpage", "lpage"),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", ""),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
-        )
-
     def test_is_ahead_of_print_false(self):
         self.assertFalse(self.sps_package.is_ahead_of_print)
 
@@ -549,25 +511,6 @@ class Test_SPS_Package_NumFpageLpage(unittest.TestCase):
 
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, False)
-
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", "fpage"),
-                ("lpage", "lpage"),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", ""),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
-        )
 
     def test_is_ahead_of_print_false(self):
         self.assertFalse(self.sps_package.is_ahead_of_print)
@@ -611,25 +554,6 @@ class Test_SPS_Package_VolNumSpeFpageLpage(unittest.TestCase):
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, False)
 
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", "fpage"),
-                ("lpage", "lpage"),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", ""),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
-        )
-
     def test_is_ahead_of_print_false(self):
         self.assertFalse(self.sps_package.is_ahead_of_print)
 
@@ -669,25 +593,6 @@ class Test_SPS_Package_VolSpeNumFpageLpage(unittest.TestCase):
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, False)
 
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", "fpage"),
-                ("lpage", "lpage"),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", ""),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
-        )
-
     def test_is_ahead_of_print_false(self):
         self.assertFalse(self.sps_package.is_ahead_of_print)
 
@@ -723,25 +628,6 @@ class Test_SPS_Package_VolSpeFpageLpage(unittest.TestCase):
 
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, False)
-
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", "fpage"),
-                ("lpage", "lpage"),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", ""),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
-        )
 
     def test_is_ahead_of_print_false(self):
         self.assertFalse(self.sps_package.is_ahead_of_print)
@@ -785,25 +671,6 @@ class Test_SPS_Package_VolSuplFpageLpage(unittest.TestCase):
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, False)
 
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", "fpage"),
-                ("lpage", "lpage"),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", ""),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
-        )
-
     def test_is_ahead_of_print_false(self):
         self.assertFalse(self.sps_package.is_ahead_of_print)
 
@@ -845,25 +712,6 @@ class Test_SPS_Package_VolSuplAFpageLpage(unittest.TestCase):
 
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, False)
-
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", "fpage"),
-                ("lpage", "lpage"),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", ""),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
-        )
 
     def test_is_ahead_of_print_false(self):
         self.assertFalse(self.sps_package.is_ahead_of_print)
@@ -907,25 +755,6 @@ class Test_SPS_Package_VolSuplSpeFpageLpage(unittest.TestCase):
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, False)
 
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", "fpage"),
-                ("lpage", "lpage"),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", ""),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
-        )
-
     def test_is_ahead_of_print_false(self):
         self.assertFalse(self.sps_package.is_ahead_of_print)
 
@@ -968,25 +797,6 @@ class Test_SPS_Package_VolNumSuplFpageLpage(unittest.TestCase):
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, False)
 
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", "fpage"),
-                ("lpage", "lpage"),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", ""),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
-        )
-
     def test_is_ahead_of_print_false(self):
         self.assertFalse(self.sps_package.is_ahead_of_print)
 
@@ -1028,24 +838,6 @@ class Test_SPS_Package_Vol2SuplAFpageLpage(unittest.TestCase):
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, False)
 
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", "fpage"),
-                ("lpage", "lpage"),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", ""),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "fpage", "lpage", ("2010", "", ""), ("", "", ""), ""),
-        )
 
     def test_is_ahead_of_print_false(self):
         self.assertFalse(self.sps_package.is_ahead_of_print)
@@ -1080,24 +872,6 @@ class Test_SPS_Package_Vol5Elocation(unittest.TestCase):
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, True)
 
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", ""),
-                ("lpage", ""),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", "elocation"),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "", "", ("2010", "", ""), ("", "", ""), "elocation"),
-        )
 
     def test_is_ahead_of_print_false(self):
         self.assertFalse(self.sps_package.is_ahead_of_print)
@@ -1135,25 +909,6 @@ class Test_SPS_Package_VolElocation(unittest.TestCase):
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, True)
 
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", ""),
-                ("lpage", ""),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", "elocation"),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "", "", ("2010", "", ""), ("", "", ""), "elocation"),
-        )
-
     def test_is_ahead_of_print_false(self):
         self.assertFalse(self.sps_package.is_ahead_of_print)
 
@@ -1181,25 +936,6 @@ class Test_SPS_Package_Aop_HTML(unittest.TestCase):
 
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, True)
-
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", ""),
-                ("lpage", ""),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", ""),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "", "", ("2010", "", ""), ("", "", ""), ""),
-        )
 
     def test_is_ahead_of_print_true(self):
         self.assertTrue(self.sps_package.is_ahead_of_print)
@@ -1231,25 +967,6 @@ class Test_SPS_Package_Aop_XML(unittest.TestCase):
 
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, True)
-
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", ""),
-                ("lpage", ""),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", ""),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "", "", ("2010", "", ""), ("", "", ""), ""),
-        )
 
     def test_is_ahead_of_print_true(self):
         self.assertTrue(self.sps_package.is_ahead_of_print)
@@ -1288,25 +1005,6 @@ class Test_SPS_Package_Article_HTML(unittest.TestCase):
 
     def test_is_only_online_publication(self):
         self.assertEqual(self.sps_package.is_only_online_publication, False)
-
-    def test_order_meta(self):
-        self.assertEqual(
-            self.sps_package.order_meta,
-            (
-                ("other", "00006"),
-                ("fpage", ""),
-                ("lpage", ""),
-                ("documents_bundle_pubdate", ("2010", "", "")),
-                ("document_pubdate", ("", "", "")),
-                ("elocation-id", ""),
-            ),
-        )
-
-    def test_order(self):
-        self.assertEqual(
-            self.sps_package.order,
-            ("00006", "", "", ("2010", "", ""), ("", "", ""), ""),
-        )
 
     def test_is_ahead_of_print_false(self):
         self.assertFalse(self.sps_package.is_ahead_of_print)


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o valor do "order" no XML

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Crie um XML que contenha:
- pid v2 com formato válido, ou seja, 23 digitos, sendo os últimos 5, numéricos.
- fpage com valor alfanumérico
- ausência de `<article-id pub-id-type="other"/>`

Exemplo real: S0104-14282017000100000

Execute os procedimentos da migração: pack e import, então verifique que no XML e no JSON criou "order": "00000", no lugar de "000E1".

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#365 

### Referências
n/a
