### PR TITLE
Corrige erro durante atualização das <mixed-citations> de artigos HTML

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -7,6 +7,7 @@ import os
 from lxml import etree
 
 from documentstore_migracao.processing.pipeline import update_articles_mixed_citations
+from documentstore_migracao.utils.xml import create_mixed_citation_element
 
 
 class TestUpdateMixedCitations(unittest.TestCase):
@@ -77,3 +78,20 @@ class TestUpdateMixedCitations(unittest.TestCase):
             b"of Biogeography 28</bold>: 1-11.</mixed-citation>",
             etree.tostring(tree),
         )
+
+    def test_should_not_unscape_forbidden_characters_during_mixed_citation_update(self):
+        string = (
+            'AgricResServ (2004) Available at: "'
+            '&lt;<a href="http://some.website.com" target="_blank">'
+            '"http://some.website.com</a>&gt;.    "'
+        )
+
+        expected = (
+            "<mixed-citation>AgricResServ (2004) Available at: "
+            '"&lt;<ext-link xmlns:ns0="http://www.w3.org/1999/xlink" ext-link-type="uri" '
+            'ns0:href="http://some.website.com">"http://some.website.com</ext-link>&gt;.    '
+            '"</mixed-citation>'
+        )
+        result = etree.tostring(create_mixed_citation_element(string)).decode()
+        self.assertEqual(result, expected)
+        self.assertNotIn(result, "<http:>")


### PR DESCRIPTION
### O que esse PR faz?


Este pull request corrige um problema percebido durante a atualização dos artigos em HTML. Algumas citações possuem caracteres como `&gt;`, estes não devem ser convertidos ('escapados') para a sua representação (`>`) afim de evitar a má formação do XML convertido.

#### Onde a revisão poderia começar?
- `documentstore_migracao/utils/xml.py` L:  `22`

#### Como este poderia ser testado manualmente?

Para testar este pull request manualmente, deve-se:
- Extraia e baixe os referenciados em [1];
- Busque pelos respectivos arquivos JSON de cada documento em `/mnt/vol_dsteste/migracao/html_migracao/paragraphs` no servidor `DSTESTE`;
- Atualize as citações por meio do comando `mixed-citations update`;
- Tente converte os arquivos recém atualizados;
- Os passos acima podem ser executados sem este PR para reproduzir os problemas.

#### Algum cenário de contexto que queira dar?

Esta função de _escape_ foi introduzida em algum outro software mas eu não me recordo qual, também testei durante uma atualização no próprio articlemeta e tudo funcionou como deveria.

### Anexos
[[1] - issue-mixed-citations-update.txt](https://github.com/scieloorg/document-store-migracao/files/5520226/issue-mixed-citations-update.txt)

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A

