### PR TITLE
[dsm][html] Atualiza os XML com a tag `<article-id pub-id-type="other"/>` usando os 5 últimos dígitos de PID v2

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -79,7 +79,7 @@ def is_valid_value_for_order(value):
             raise ValueError
     except (ValueError, TypeError):
         raise InvalidValueForOrderError(
-            "Invalid value for 'order': %s",
+            "Invalid value for 'order': %s" %
             value
         )
     else:
@@ -870,8 +870,8 @@ class SPS_Package:
             # então não permitir atualização
             raise NotAllowedtoChangeAttributeValueError(
                 "Not allowed to update %s (%s) with %s, "
-                "because current is valid",
-                attr_name, curr_value, attr_new_value)
+                "because current is valid" %
+                (attr_name, curr_value, attr_new_value))
         try:
             # valida o valor novo para o atributo
             validate_function(attr_new_value)
@@ -879,8 +879,8 @@ class SPS_Package:
             # o valor novo é inválido, então não permitir atualização
             raise InvalidAttributeValueError(
                 "Not allowed to update %s (%s) with %s, "
-                "because new value is invalid",
-                attr_name, curr_value, attr_new_value)
+                "because new value is invalid" %
+                (attr_name, curr_value, attr_new_value))
         else:
             # o valor novo é válido, então não permitir atualização
             return True

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -470,11 +470,7 @@ class SPS_Package:
 
     @article_id_which_id_type_is_other.setter
     def article_id_which_id_type_is_other(self, value):
-        v = int(value)
-        if v > 99999:
-            raise ValueError(
-                "Not allowed to set article_id_which_id_type_is_other"
-                " with %s" % value)
+        is_valid_value_for_order(value)
         value = value.zfill(5)
         node = self.article_meta.find(
             './/article-id[@publisher-id="other"]'
@@ -784,17 +780,13 @@ class SPS_Package:
 
         return updated
 
-    def is_incorrect(self, attr_name):
+    def _fixme(self, attr_name):
         if attr_name == "article_id_which_id_type_is_other":
-
             try:
-                order = int(self.article_id_which_id_type_is_other or self.fpage)
-                if order > 99999:
-                    raise ValueError(
-                        "%s is invalid value for 'SPS_Package.order'" % order
-                        )
+                order = self.article_id_which_id_type_is_other or self.fpage
+                is_valid_value_for_order(order)
                 return False
-            except (ValueError, TypeError):
+            except InvalidValueForOrderError:
                 return True
 
         if attr_name in ("scielo_pid_v2", "aop_pid", ):
@@ -805,7 +797,7 @@ class SPS_Package:
         return False
 
     def fix(self, attr_name, attr_new_value):
-        if not self.is_incorrect(attr_name):
+        if not self._fixme(attr_name):
             raise NotAllowedtoChangeAttributeValueError(
                 "%s is correct. Not allowed to change its value", attr_name
             )

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -493,7 +493,9 @@ class SPS_Package:
 
     @article_id_which_id_type_is_other.setter
     def article_id_which_id_type_is_other(self, value):
-        is_valid_value_for_order(value)
+        if not self._is_allowed_to_update(
+                "article_id_which_id_type_is_other", value):
+            return
         value = value.zfill(5)
         node = self.article_meta.find(
             './/article-id[@publisher-id="other"]'
@@ -861,7 +863,7 @@ class SPS_Package:
             raise NotAllowedtoChangeAttributeValueError(
                 "Not allowed to update %s (%s) with %s, "
                 "because current is valid",
-                attr_name, curr_value, attr_new_value, curr_value)
+                attr_name, curr_value, attr_new_value)
         try:
             # valida o valor novo para o atributo
             validate_function(attr_new_value)

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -457,8 +457,11 @@ class SPS_Package:
                 self.article_id_which_id_type_is_other,
                 self.fpage,
                 ):
-            if item and item.isdigit() and len(item) <= 5:
-                return item.zfill(5)
+            try:
+                if is_valid_value_for_order(item):
+                    return item.zfill(5)
+            except InvalidValueForOrderError:
+                continue
 
     @property
     def article_id_which_id_type_is_other(self):

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -24,6 +24,10 @@ class InvalidAttributeValueError(Exception):
     pass
 
 
+class InvalidValueForOrderError(Exception):
+    pass
+
+
 def parse_date(_date):
     def format(value):
         if value and value.isdigit():
@@ -67,6 +71,19 @@ def is_asset_href(href):
         and not href.startswith("www")
         and not href.startswith("http")
     )
+
+
+def is_valid_value_for_order(value):
+    try:
+        if not (0 < int(value) <= 99999):
+            raise ValueError
+    except (ValueError, TypeError):
+        raise InvalidValueForOrderError(
+            "Invalid value for 'order': %s",
+            value
+        )
+    else:
+        return True
 
 
 class SPS_Package:
@@ -769,6 +786,7 @@ class SPS_Package:
 
     def is_incorrect(self, attr_name):
         if attr_name == "article_id_which_id_type_is_other":
+
             try:
                 order = int(self.article_id_which_id_type_is_other or self.fpage)
                 if order > 99999:

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -849,10 +849,7 @@ class SPS_Package:
             # não há nenhuma validação, então é permitido fazer a atualização
             return True
 
-        if attr_name == "article_id_which_id_type_is_other":
-            curr_value = self.article_id_which_id_type_is_other or self.fpage
-        else:
-            curr_value = getattr(self, attr_name)
+        curr_value = getattr(self, attr_name)
 
         if attr_new_value == curr_value:
             # desnecessario atualizar

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -825,11 +825,6 @@ class DocumentsSorter:
     def insert_document(self, document_id, document_xml):
         pkg = SPS_Package(document_xml, "none")
 
-        def format(value):
-            if value and value.isdigit():
-                return value.zfill(5)
-            return value or ""
-
         data = dict(pkg.parse_article_meta)
         self._documents_bundles[document_id] = {
             "eissn": dict(pkg.journal_meta).get("eissn"),

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -811,20 +811,6 @@ class SPS_Package:
 
         return updated
 
-    def _fixme(self, attr_name):
-        if attr_name == "article_id_which_id_type_is_other":
-            try:
-                order = self.article_id_which_id_type_is_other or self.fpage
-                is_valid_value_for_order(order)
-                return False
-            except InvalidValueForOrderError:
-                return True
-        if attr_name in ("scielo_pid_v2", "aop_pid", ):
-            return len(getattr(self, attr_name) or "") != 23
-        if attr_name in ("original_language", ):
-            return len(getattr(self, attr_name) or "") != 2
-        return False
-
     def fix(self, attr_name, attr_new_value, silently=False):
         """
         Conserta valor de atributo e silencia as exceções

--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -34,7 +34,7 @@ def pack_article_xml(file_xml_path, poison_pill=PoisonPill()):
     sps_package = SPS_Package(obj_xml, original_filename)
     sps_package.fix(
         "article_id_which_id_type_is_other",
-        sps_package.scielo_pid_v2[-5:],
+        sps_package.scielo_pid_v2 and sps_package.scielo_pid_v2[-5:],
         silently=True
     )
 

--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -8,7 +8,11 @@ from requests.compat import urljoin
 from lxml import etree
 from documentstore_migracao.utils import files, request, xml
 from documentstore_migracao import config
-from documentstore_migracao.export.sps_package import SPS_Package
+from documentstore_migracao.export.sps_package import (
+    SPS_Package,
+    NotAllowedtoChangeAttributeValueError,
+    InvalidAttributeValueError
+)
 from documentstore_migracao.processing.extracted import PoisonPill, DoJobsConcurrently
 
 

--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -32,6 +32,11 @@ def pack_article_xml(file_xml_path, poison_pill=PoisonPill()):
     obj_xml = xml.file2objXML(file_xml_path)
 
     sps_package = SPS_Package(obj_xml, original_filename)
+    sps_package.fix(
+        "article_id_which_id_type_is_other",
+        sps_package.scielo_pid_v2[-5:],
+        silently=True
+    )
 
     SPS_PKG_PATH = config.get("SPS_PKG_PATH")
     INCOMPLETE_SPS_PKG_PATH = config.get("INCOMPLETE_SPS_PKG_PATH")

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -340,7 +340,7 @@ class TestBuildSPSPackageOrder(TestBuildSPSPackageBase):
             mk_sps_package, pack_name, self.rows[2], pack_name + ".xml"
         )
         self.assertEqual(result.order, "00003")
-        self.assertIsNone(result.article_id_which_id_type_is_other)
+        self.assertEqual(result.article_id_which_id_type_is_other, "00003")
 
     def test__update_sps_package_obj_updates_order_if_fpage_is_not_number_and_other_is_none(self):
         mk_sps_package = self.get_sps_package(

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -2370,11 +2370,11 @@ class TestIsAllowedToUpdate_article_id_which_id_type_is_other(unittest.TestCase)
             sps_package._is_allowed_to_update(
                 "article_id_which_id_type_is_other", "222")
         expected = (
-            "'Not allowed to update %s (%s) with %s, "
-            "because current is valid', "
-            "'article_id_which_id_type_is_other', '1234', '222'"
+            "Not allowed to update article_id_which_id_type_is_other "
+            "(1234) with 222, "
+            "because current is valid"
         )
-        self.assertIn(expected, str(exc.exception))
+        self.assertEqual(expected, str(exc.exception))
 
     def test_returns_raise_exception_because_new_value_is_invalid(self):
         sps_package = self._get_sps_package(other=None, fpage="vii")
@@ -2382,11 +2382,11 @@ class TestIsAllowedToUpdate_article_id_which_id_type_is_other(unittest.TestCase)
             sps_package._is_allowed_to_update(
                 "article_id_which_id_type_is_other", "vIII")
         expected = (
-            "'Not allowed to update %s (%s) with %s, "
-            "because new value is invalid', "
-            "'article_id_which_id_type_is_other', 'vii', 'vIII'"
+            "Not allowed to update article_id_which_id_type_is_other "
+            "(None) with vIII, "
+            "because new value is invalid"
         )
-        self.assertIn(expected, str(exc.exception))
+        self.assertEqual(expected, str(exc.exception))
 
 
 class TestIsAllowedToUpdate_scielo_pid_v2(unittest.TestCase):
@@ -2427,22 +2427,22 @@ class TestIsAllowedToUpdate_scielo_pid_v2(unittest.TestCase):
         with self.assertRaises(NotAllowedtoChangeAttributeValueError) as exc:
             sps_package._is_allowed_to_update("scielo_pid_v2", "222")
         expected = (
-            "'Not allowed to update %s (%s) with %s, "
-            "because current is valid', "
-            "'scielo_pid_v2', 'S0000-00002019000512345', '222'"
+            "Not allowed to update scielo_pid_v2 "
+            "(S0000-00002019000512345) with 222, "
+            "because current is valid"
         )
-        self.assertIn(expected, str(exc.exception))
+        self.assertEqual(expected, str(exc.exception))
 
     def test_returns_raise_exception_because_new_value_is_invalid(self):
         sps_package = self._get_sps_package(None)
         with self.assertRaises(InvalidAttributeValueError) as exc:
             sps_package._is_allowed_to_update("scielo_pid_v2", "vIII")
         expected = (
-            "'Not allowed to update %s (%s) with %s, "
-            "because new value is invalid', "
-            "'scielo_pid_v2', None, 'vIII'"
+            "Not allowed to update scielo_pid_v2 "
+            "(None) with vIII, "
+            "because new value is invalid"
         )
-        self.assertIn(expected, str(exc.exception))
+        self.assertEqual(expected, str(exc.exception))
 
 
 class TestIsAllowedToUpdate_original_language(unittest.TestCase):
@@ -2479,22 +2479,22 @@ class TestIsAllowedToUpdate_original_language(unittest.TestCase):
         with self.assertRaises(NotAllowedtoChangeAttributeValueError) as exc:
             sps_package._is_allowed_to_update("original_language", "222")
         expected = (
-            "'Not allowed to update %s (%s) with %s, "
-            "because current is valid', "
-            "'original_language', 'pt', '222'"
+            "Not allowed to update original_language "
+            "(pt) with 222, "
+            "because current is valid"
         )
-        self.assertIn(expected, str(exc.exception))
+        self.assertEqual(expected, str(exc.exception))
 
     def test_returns_raise_exception_because_new_value_is_invalid(self):
         sps_package = self._get_sps_package(None)
         with self.assertRaises(InvalidAttributeValueError) as exc:
             sps_package._is_allowed_to_update("original_language", "espanhol")
         expected = (
-            "'Not allowed to update %s (%s) with %s, "
-            "because new value is invalid', "
-            "'original_language', 'None', 'espanhol'"
+            "Not allowed to update original_language "
+            "(None) with espanhol, "
+            "because new value is invalid"
         )
-        self.assertIn(expected, str(exc.exception))
+        self.assertEqual(expected, str(exc.exception))
 
 
 class Test_SPS_article_id_which_id_type_is_other(unittest.TestCase):
@@ -2539,11 +2539,11 @@ class Test_SPS_article_id_which_id_type_is_other(unittest.TestCase):
         with self.assertRaises(NotAllowedtoChangeAttributeValueError) as exc:
             sps_package.article_id_which_id_type_is_other = "222"
         expected = (
-            "'Not allowed to update %s (%s) with %s, "
-            "because current is valid', "
-            "'article_id_which_id_type_is_other', '1234', '222'"
+            "Not allowed to update article_id_which_id_type_is_other "
+            "(1234) with 222, "
+            "because current is valid"
         )
-        self.assertIn(expected, str(exc.exception))
+        self.assertEqual(expected, str(exc.exception))
 
     def test_raises_exception_because_new_value_is_invalid(self):
         sps_package = self._get_sps_package(other=None, fpage="vii")
@@ -2551,11 +2551,11 @@ class Test_SPS_article_id_which_id_type_is_other(unittest.TestCase):
             sps_package._is_allowed_to_update(
                 "article_id_which_id_type_is_other", "vIII")
         expected = (
-            "'Not allowed to update %s (%s) with %s, "
-            "because new value is invalid', "
-            "'article_id_which_id_type_is_other', 'vii', 'vIII'"
+            "Not allowed to update article_id_which_id_type_is_other "
+            "(None) with vIII, "
+            "because new value is invalid"
         )
-        self.assertIn(expected, str(exc.exception))
+        self.assertEqual(expected, str(exc.exception))
 
 
 class Test_SPS_Package_Fix_Silently(unittest.TestCase):

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -10,6 +10,8 @@ from documentstore_migracao.export.sps_package import (
     SPS_Package,
     NotAllowedtoChangeAttributeValueError,
     InvalidAttributeValueError,
+    InvalidValueForOrderError,
+    is_valid_value_for_order,
 )
 
 
@@ -2268,3 +2270,25 @@ class Test_SPS_Package_SetAttrIfRequired_Update_DATA(unittest.TestCase):
             'specific-use="sps-1.9" xml:lang="pt">',
             str(etree.tostring(self._sps_package.xmltree))
         )
+
+
+class Test_is_valid_value_for_order(unittest.TestCase):
+    def test_raises_exception_because_value_is_none(self):
+        with self.assertRaises(InvalidValueForOrderError):
+            is_valid_value_for_order(None)
+
+    def test_raises_exception_because_value_is_str(self):
+        with self.assertRaises(InvalidValueForOrderError):
+            is_valid_value_for_order("x")
+
+    def test_raises_exception_because_value_is_zero(self):
+        with self.assertRaises(InvalidValueForOrderError):
+            is_valid_value_for_order("0")
+
+    def test_raises_exception_because_value_is_outofrange(self):
+        with self.assertRaises(InvalidValueForOrderError):
+            is_valid_value_for_order("999999")
+
+    def test_returns_true(self):
+        result = is_valid_value_for_order("6")
+        self.assertTrue(result)


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza os XML provenientes do HTML com a tag `<article-id pub-id-type="other"/>` usando os 5 últimos dígitos de PID v2.
Nota: para os XML nativos, a tag é opcional porque na sua ausência vale o valor de `fpage`, mas nos HTML, o valor de `order` era sempre fornecido na marcação e não era assumido o valor de `fpage`, por este motivo, para manter a consistência, o ideal é sempre completar o XML (do html) com `<article-id pub-id-type="other"/>`.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Veja o issue #320 

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#320 

### Referências
n/a
