### PR TITLE
Obtém os dados de rendition do próprio XML no lugar de consultar o AM

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -384,12 +384,13 @@ class SPS_Package:
     def get_renditions_metadata(self):
         renditions = []
         metadata = {}
-        obj_article = article.get_article(self.scielo_pid_v2)
-        if obj_article:
-            metadata = obj_article.fulltexts().get("pdf", {})
-            for lang, url in metadata.items():
+        if self.article_meta is not None:
+            for node in self.article_meta.findall(".//self-uri"):
+                url = node.get("{http://www.w3.org/1999/xlink}href")
+                lang = node.get("{http://www.w3.org/XML/1998/namespace}lang")
                 filename, ext = files.extract_filename_ext_by_path(url)
                 renditions.append((url, filename))
+                metadata[lang] = url
         return renditions, metadata
 
     @property

--- a/tests/samples/S0044-59672003000300002_sps_completo.xml
+++ b/tests/samples/S0044-59672003000300002_sps_completo.xml
@@ -304,7 +304,8 @@
  
 			</permissions>
 			
- 
+ <self-uri xlink:href="http://www.scielo.br/pdf/aa/v33n3/v33n3a02.pdf" xml:lang="pt">Texto completo somente em PDF (PT)</self-uri>
+
 			<abstract>
 				
  

--- a/tests/samples/S0044-59672003000300002_sps_incompleto.xml
+++ b/tests/samples/S0044-59672003000300002_sps_incompleto.xml
@@ -304,7 +304,8 @@
  
 			</permissions>
 			
- 
+ <self-uri xlink:href="http://www.scielo.br/pdf/aa/v33n3/v33n3a02.pdf" xml:lang="pt">Texto completo somente em PDF (PT)</self-uri>
+
 			<abstract>
 				
  

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -267,13 +267,13 @@ class Test_SPS_package(unittest.TestCase):
 class Test_SPS_Package(unittest.TestCase):
     def setUp(self):
         article_xml = """<root xmlns:xlink="http://www.w3.org/1999/xlink">
-                <inline-graphic xlink:href="a01tab01.gif"/>
-                <graphic xlink:href="a01f01.gif"/>
-                <ext-link xlink:href="a01tab02.gif"/>
-                <ext-link xlink:href="mailto:a01f02.gif"/>
-                <inline-supplementary-material xlink:href="a01tab03.gif"/>
-                <supplementary-material xlink:href="a01tab04.gif"/>
-                <media xlink:href="a01tab04.gif"/>
+            <inline-graphic xlink:href="a01tab01.gif"/>
+            <graphic xlink:href="a01f01.gif"/>
+            <ext-link xlink:href="a01tab02.gif"/>
+            <ext-link xlink:href="mailto:a01f02.gif"/>
+            <inline-supplementary-material xlink:href="a01tab03.gif"/>
+            <supplementary-material xlink:href="a01tab04.gif"/>
+            <media xlink:href="a01tab04.gif"/>
             </root>
             """
         self.sps_package = SPS_Package(etree.fromstring(article_xml), "a01")
@@ -312,46 +312,42 @@ class Test_SPS_Package(unittest.TestCase):
                 self.assertEqual(expected[i][0], item[0])
                 self.assertEqual(expected[i][1], item[1])
 
-    @mock.patch("documentstore_migracao.export.sps_package.article.get_article")
-    def test_get_renditions_metadata_no_renditions(self, mk_get_article):
-        mk_article = mock.Mock()
-        mk_article.fulltexts.return_value = {}
-        mk_get_article.return_value = mk_article
+    def test_get_renditions_metadata_no_renditions(self):
         renditions, renditions_metadata = self.sps_package.get_renditions_metadata()
         self.assertEqual(renditions, [])
         self.assertEqual(renditions_metadata, {})
 
-    @mock.patch("documentstore_migracao.export.sps_package.article.get_article")
-    def test_get_renditions_metadata(self, mk_get_article):
-        fulltexts = {
-            "pdf": {
-                "en": "http://www.scielo.br/pdf/aa/v1n1/a01.pdf",
-                "pt": "http://www.scielo.br/pdf/aa/v1n1/pt_a01.pdf",
-            },
-            "html": {
-                "en": "http://www.scielo.br/scielo.php?script=sci_arttext&tlng=en",
-                "pt": "http://www.scielo.br/scielo.php?script=sci_arttext&tlng=pt",
-            },
-        }
-        mk_article = mock.Mock()
-        mk_article.fulltexts.return_value = fulltexts
-        mk_get_article.return_value = mk_article
+    def test_get_renditions_metadata(self):
+        article_xml = """<root xmlns:xlink="http://www.w3.org/1999/xlink">
+            <article-meta>
+                <self-uri xlink:href="http://www.scielo.br/pdf/aa/v1n1/a01.pdf" xml:lang="en">Texto completo somente em PDF (EN)</self-uri>
+                <self-uri xlink:href="http://www.scielo.br/pdf/aa/v1n1/pt_a01.pdf" xml:lang="pt">Texto completo somente em PDF (PT)</self-uri>
+            </article-meta>
+            <inline-graphic xlink:href="a01tab01.gif"/>
+            <graphic xlink:href="a01f01.gif"/>
+            <ext-link xlink:href="a01tab02.gif"/>
+            <ext-link xlink:href="mailto:a01f02.gif"/>
+            <inline-supplementary-material xlink:href="a01tab03.gif"/>
+            <supplementary-material xlink:href="a01tab04.gif"/>
+            <media xlink:href="a01tab04.gif"/>
+            </root>
+            """
+        self.sps_package = SPS_Package(etree.fromstring(article_xml), "a01")
         renditions, renditions_metadata = self.sps_package.get_renditions_metadata()
-        for lang, link in fulltexts.get("pdf"):
-            self.assertEqual(
-                renditions,
-                [
-                    ('http://www.scielo.br/pdf/aa/v1n1/a01.pdf', 'a01'),
-                    ('http://www.scielo.br/pdf/aa/v1n1/pt_a01.pdf', 'pt_a01'),
-                ]
-            )
-            self.assertEqual(
-                renditions_metadata,
-                {
-                    'en': 'http://www.scielo.br/pdf/aa/v1n1/a01.pdf',
-                    'pt': 'http://www.scielo.br/pdf/aa/v1n1/pt_a01.pdf',
-                }
-            )
+        self.assertEqual(
+            renditions,
+            [
+                ('http://www.scielo.br/pdf/aa/v1n1/a01.pdf', 'a01'),
+                ('http://www.scielo.br/pdf/aa/v1n1/pt_a01.pdf', 'pt_a01'),
+            ]
+        )
+        self.assertEqual(
+            renditions_metadata,
+            {
+                'en': 'http://www.scielo.br/pdf/aa/v1n1/a01.pdf',
+                'pt': 'http://www.scielo.br/pdf/aa/v1n1/pt_a01.pdf',
+            }
+        )
 
 
 class Test_SPS_Package_No_Metadata(unittest.TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Obtém os dados de rendition do próprio XML no lugar de consultar o AM

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando o `pack` (do html)

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#385 

### Referências
n/a
