### PR TITLE
Altera BuildPSPackage.get_existing_xml_path p/ verificar file_path

### DIFF
--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -194,13 +194,27 @@ class BuildPSPackage(object):
         return sps_package
 
     def get_existing_xml_path(self, file_path, f_acron, f_volnum):
+        """
+        Verifica se ``file_path`` informado existe no diretório ``self.xml_folder`` e
+        retorna-o em caso positivo. Caso contrário, monta caminho relativo usando dados
+        f_acron e f_volnum para montar o path do XML.
+        """
         if file_path.find("\\") >= 0:
             # It is a Windows Path
-            xml_basename = pathlib.PureWindowsPath(file_path).name
+            xml_path = pathlib.PureWindowsPath(file_path)
         else:
             # It is a Posix Path
-            xml_basename = pathlib.PurePosixPath(file_path).name
-        xml_relative_path = pathlib.Path(f_acron.lower()) / f_volnum / xml_basename
+            xml_path = pathlib.PurePosixPath(file_path)
+
+        csv_file_path = pathlib.Path(self.xml_folder) / xml_path
+        if csv_file_path.is_file():
+            return str(file_path)
+
+        logger.debug(
+            "Filepath %s not found in %s. Trying to find path using CSV data.",
+            file_path, self.xml_folder
+        )
+        xml_relative_path = pathlib.Path(f_acron.lower()) / f_volnum / xml_path.name
         return str(xml_relative_path)
 
     def get_target_path(self, xml_relative_path):

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -787,6 +787,20 @@ class TestBuildSPSPackageCollectAssetAlternatives(TestBuildSPSPackageBase):
 class TestBuildSPSPackageGetExistingXMLPath(TestBuildSPSPackageBase):
     def setUp(self):
         super().setUp()
+        self.source_path = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.source_path)
+
+    def test_file_path_exists(self):
+        self.builder.xml_folder = self.source_path
+        test_xml_path = pathlib.Path(self.source_path) / "acron/v1n1/existing_doc.xml"
+        test_xml_path.parent.mkdir(parents=True)
+        test_xml_path.write_text("<article></article>")
+        result = self.builder.get_existing_xml_path(
+            "acron/v1n1/existing_doc.xml", "ACRON", "v1n1"
+        )
+        self.assertEqual(result, "acron/v1n1/existing_doc.xml")
 
     def test_file_path_ok(self):
         result = self.builder.get_existing_xml_path(


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera o empacotador de XMLs nativos para verificar se o caminho registrado no CSV extraído da base ISIS existe no diretório fonte de XMLs, informado no parâmetro `-Xfolder`. Se este caminho existir, utiliza-o para o empacotamento. Caso contrário, utiliza os dados do CSV para montar o caminho relativo do XML.

#### Onde a revisão poderia começar?
Commit c1e8b3f.

#### Como este poderia ser testado manualmente?

1. Execute o comando de empacotamento de XMLs nativos para /mnt/vol_dsteste/migracao/2014_native_xml.csv.
2. Os arquivos com erro apontados no issue #368 devem ser localizados e empacotados.
3. Os erros registrados anteriormente no log, apontados no issue #368, não devem ser mais registrados.

#### Algum cenário de contexto que queira dar?
.

### Screenshots
N/A

#### Quais são tickets relevantes?
Closes #368.

### Referências
.
