### PR TITLE
[html][pack] Corrige o caminho do pdf considerando que é montado a partir de dados registrados no "issue"

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -962,3 +962,10 @@ class SourceJson:
             if wrong_folder in path:
                 fixed[lang] = path.replace(wrong_folder, expected_issue_folder)
         return fixed
+
+    def get_renditions_metadata(self):
+        renditions = []
+        for lang, url in self.fixed_renditions_metadata.items():
+            filename, ext = files.extract_filename_ext_by_path(url)
+            renditions.append((url, filename))
+        return renditions, self.fixed_renditions_metadata

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -1,6 +1,7 @@
 import os
 import itertools
 import logging
+import json
 from typing import Tuple
 
 from copy import deepcopy
@@ -918,3 +919,25 @@ class DocumentsSorter:
                 for k in sorted(docs_bundle["items"].keys(), reverse=self.reverse[dbid])
             ]
         return _documents_bundles
+
+
+class SourceJson:
+
+    def __init__(self, json_data):
+        self.json_data = json.loads(json_data)
+
+    @property
+    def issue_folder(self):
+        suffixes = [
+            ("v", "v31"),
+            ("s", "v131"),
+            ("n", "v32"),
+            ("s", "v132"),
+        ]
+        label_parts = []
+        article = self.json_data["article"]
+        for suffix, field in suffixes:
+            value = article.get(field)
+            if value:
+                label_parts.append(suffix + value[0]["_"])
+        return "".join(label_parts)

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -941,3 +941,10 @@ class SourceJson:
             if value:
                 label_parts.append(suffix + value[0]["_"])
         return "".join(label_parts)
+
+    @property
+    def renditions_metadata(self):
+        try:
+            return self.json_data["fulltexts"]["pdf"]
+        except KeyError:
+            return {}

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -948,3 +948,17 @@ class SourceJson:
             return self.json_data["fulltexts"]["pdf"]
         except KeyError:
             return {}
+
+    @property
+    def fixed_renditions_metadata(self):
+        fixed = {}
+        for lang, path in self.renditions_metadata.items():
+
+            expected_issue_folder = "/{}/".format(self.issue_folder)
+            if expected_issue_folder in path:
+                return self.renditions_metadata
+
+            wrong_folder = expected_issue_folder.lower()
+            if wrong_folder in path:
+                fixed[lang] = path.replace(wrong_folder, expected_issue_folder)
+        return fixed

--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -9,6 +9,7 @@ from documentstore_migracao.utils import files, xml
 from documentstore_migracao import config
 from documentstore_migracao.export.sps_package import (
     SPS_Package,
+    SourceJson,
     NotAllowedtoChangeAttributeValueError,
     InvalidAttributeValueError
 )
@@ -20,6 +21,14 @@ logger = logging.getLogger(__name__)
 
 class AssetNotFoundError(Exception):
     ...
+
+
+def get_source_json(scielo_pid_v2):
+    SOURCE_PATH = config.get("SOURCE_PATH")
+    file_json_path = os.path.join(SOURCE_PATH, scielo_pid_v2 + ".json")
+    with open(file_json_path, "r") as fp:
+        json_content = fp.read()
+    return SourceJson(json_content)
 
 
 def pack_article_xml(file_xml_path, poison_pill=PoisonPill()):
@@ -65,7 +74,8 @@ def pack_article_xml(file_xml_path, poison_pill=PoisonPill()):
     asset_replacements = list(set(sps_package.replace_assets_names()))
     logger.debug("%s possui %s ativos digitais", file_xml_path, len(asset_replacements))
 
-    renditions, renditions_metadata = sps_package.get_renditions_metadata()
+    source_json = get_source_json(sps_package.scielo_pid_v2)
+    renditions, renditions_metadata = source_json.get_renditions_metadata()
     logger.debug("%s possui %s renditions", file_xml_path, len(renditions))
 
     package_path = packing_assets(

--- a/tests/samples/S0044-59672003000300002.json
+++ b/tests/samples/S0044-59672003000300002.json
@@ -1,0 +1,22 @@
+{
+    "article": {
+        "v31": [
+            {
+                "_": "33"
+            }
+        ],
+        "v32": [
+            {
+                "_": "3"
+            }
+        ]
+    },
+    "fulltexts": {
+        "html": {
+            "es": "http://www.scielosp.org/scielo.php?script=sci_arttext&pid=S0036-36341997000100001&tlng=es"
+        },
+        "pdf": {
+            "es": "http://www.scielosp.org/pdf/aa/v33n3/v33n3a02.pdf"
+        }
+    }
+}

--- a/tests/test_processing_packing.py
+++ b/tests/test_processing_packing.py
@@ -12,6 +12,7 @@ class TestProcessingPacking(unittest.TestCase):
 
     def test_pack_article_xml_missing_media(self):
         with utils.environ(
+            SOURCE_PATH=SAMPLES_PATH,
             VALID_XML_PATH=SAMPLES_PATH,
             SPS_PKG_PATH=SAMPLES_PATH,
             INCOMPLETE_SPS_PKG_PATH=SAMPLES_PATH,
@@ -50,6 +51,7 @@ class TestProcessingPacking(unittest.TestCase):
 
     def test_pack_article_xml_has_media(self):
         with utils.environ(
+            SOURCE_PATH=SAMPLES_PATH,
             VALID_XML_PATH=SAMPLES_PATH,
             SPS_PKG_PATH=SAMPLES_PATH,
             INCOMPLETE_SPS_PKG_PATH=SAMPLES_PATH,
@@ -84,12 +86,13 @@ class TestProcessingPacking(unittest.TestCase):
             )
             self.assertEqual(12, len(files))
 
-    @patch("documentstore_migracao.processing.packing.SPS_Package.get_renditions_metadata")
+    @patch("documentstore_migracao.processing.packing.SourceJson.get_renditions_metadata")
     @patch("documentstore_migracao.processing.packing.get_asset")
     def test_pack_article_write_manifest_json_file_with_renditions(
         self, mk_get_asset, mk_get_renditions_metadata
     ):
         with utils.environ(
+            SOURCE_PATH=SAMPLES_PATH,
             VALID_XML_PATH=SAMPLES_PATH,
             SPS_PKG_PATH=SAMPLES_PATH,
             INCOMPLETE_SPS_PKG_PATH=SAMPLES_PATH,
@@ -119,12 +122,15 @@ class TestProcessingPacking(unittest.TestCase):
                     }
                 )
 
-    def test_pack_article_xml_has_no_media(self):
+    @patch("documentstore_migracao.processing.packing.get_source_json")
+    def test_pack_article_xml_has_no_media(self, mock_get_source_json):
         with utils.environ(
+            SOURCE_PATH=SAMPLES_PATH,
             VALID_XML_PATH=SAMPLES_PATH,
             SPS_PKG_PATH=SAMPLES_PATH,
             INCOMPLETE_SPS_PKG_PATH=SAMPLES_PATH,
         ):
+            mock_get_source_json.return_value = packing.SourceJson("{}")
             packing.pack_article_xml(os.path.join(SAMPLES_PATH, "any.xml"))
             files = set(os.listdir(os.path.join(SAMPLES_PATH, "any")))
             self.assertEqual({"any.xml", "manifest.json"}, files)

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -2648,7 +2648,8 @@ class TestSourceJson(unittest.TestCase):
                     "en": "http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0004-282X2002000200003&tlng=en"
                 },
                 "pdf": {
-                    "en": "http://www.scielo.br/pdf/anp/v60n2a/a03v60n2.pdf"
+                    "en": "http://www.scielo.br/pdf/anp/v60n2a/a03v60n2.pdf",
+                    "es": "http://www.scielo.br/pdf/anp/v60n2a/es_a03v60n2.pdf"
                 }
             }
         }"""
@@ -2660,13 +2661,15 @@ class TestSourceJson(unittest.TestCase):
     def test_renditions_metadata_returns(self):
         source = SourceJson(self._json_content)
         expected = {
-            "en": "http://www.scielo.br/pdf/anp/v60n2a/a03v60n2.pdf"
+            "en": "http://www.scielo.br/pdf/anp/v60n2a/a03v60n2.pdf",
+            "es": "http://www.scielo.br/pdf/anp/v60n2a/es_a03v60n2.pdf"
         }
         self.assertEqual(expected, source.renditions_metadata)
 
     def test_fixed_renditions_metadata_returns(self):
         source = SourceJson(self._json_content)
         expected = {
-            "en": "http://www.scielo.br/pdf/anp/v60n2A/a03v60n2.pdf"
+            "en": "http://www.scielo.br/pdf/anp/v60n2A/a03v60n2.pdf",
+            "es": "http://www.scielo.br/pdf/anp/v60n2A/es_a03v60n2.pdf"
         }
         self.assertEqual(expected, source.fixed_renditions_metadata)

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -2642,9 +2642,24 @@ class TestSourceJson(unittest.TestCase):
                         "_": "60"
                     }
                 ]
+            },
+            "fulltexts": {
+                "html": {
+                    "en": "http://www.scielo.br/scielo.php?script=sci_arttext&pid=S0004-282X2002000200003&tlng=en"
+                },
+                "pdf": {
+                    "en": "http://www.scielo.br/pdf/anp/v60n2a/a03v60n2.pdf"
+                }
             }
         }"""
 
     def test_issue_folder_returns(self):
         source = SourceJson(self._json_content)
         self.assertEqual("v60n2A", source.issue_folder)
+
+    def test_renditions_metadata_returns(self):
+        source = SourceJson(self._json_content)
+        expected = {
+            "en": "http://www.scielo.br/pdf/anp/v60n2a/a03v60n2.pdf"
+        }
+        self.assertEqual(expected, source.renditions_metadata)

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -12,6 +12,7 @@ from documentstore_migracao.export.sps_package import (
     InvalidAttributeValueError,
     InvalidValueForOrderError,
     is_valid_value_for_order,
+    SourceJson,
 )
 
 
@@ -2624,3 +2625,26 @@ class Test_SPS_Package_Fix_Silently(unittest.TestCase):
             str(etree.tostring(_sps_package.xmltree))
         )
 
+
+class TestSourceJson(unittest.TestCase):
+
+    @property
+    def _json_content(self):
+        return """{
+            "article": {
+                "v32": [
+                    {
+                        "_": "2A"
+                    }
+                ],
+                "v31": [
+                    {
+                        "_": "60"
+                    }
+                ]
+            }
+        }"""
+
+    def test_issue_folder_returns(self):
+        source = SourceJson(self._json_content)
+        self.assertEqual("v60n2A", source.issue_folder)

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -2673,3 +2673,16 @@ class TestSourceJson(unittest.TestCase):
             "es": "http://www.scielo.br/pdf/anp/v60n2A/es_a03v60n2.pdf"
         }
         self.assertEqual(expected, source.fixed_renditions_metadata)
+
+    def test_get_renditions_metadata_returns(self):
+        source = SourceJson(self._json_content)
+        metadata = {
+            "en": "http://www.scielo.br/pdf/anp/v60n2A/a03v60n2.pdf",
+            "es": "http://www.scielo.br/pdf/anp/v60n2A/es_a03v60n2.pdf"
+        }
+        renditions = [
+            ("http://www.scielo.br/pdf/anp/v60n2A/a03v60n2.pdf", "a03v60n2"),
+            ("http://www.scielo.br/pdf/anp/v60n2A/es_a03v60n2.pdf", "es_a03v60n2"),
+        ]
+        expected = (renditions, metadata)
+        self.assertEqual(expected, source.get_renditions_metadata())

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -2663,3 +2663,10 @@ class TestSourceJson(unittest.TestCase):
             "en": "http://www.scielo.br/pdf/anp/v60n2a/a03v60n2.pdf"
         }
         self.assertEqual(expected, source.renditions_metadata)
+
+    def test_fixed_renditions_metadata_returns(self):
+        source = SourceJson(self._json_content)
+        expected = {
+            "en": "http://www.scielo.br/pdf/anp/v60n2A/a03v60n2.pdf"
+        }
+        self.assertEqual(expected, source.fixed_renditions_metadata)


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o caminho do pdf considerando que é montado a partir de dados registrados no "issue", ou seja, considerando os valores preenchidos no campo número. Se está em maiúsculas, manter maiúsculas.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando o pack para o `S0004-282X2002000200003` e verificando que com a correção o seu pdf foi encontrado.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#392

### Referências
n/a
