### PR TITLE
[html][pack] Flexibiliza a estratégia para encontrar o arquivo do ativo digital

### DIFF
--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -238,6 +238,22 @@ def packing_assets(asset_replacements, pkg_path, incomplete_pkg_path, pkg_name,
     return pkg_path
 
 
+def find_file(file_path):
+    """
+    A partir de um dado path, pega o nome de arquivo mais semelhante
+    """
+    dirname = os.path.dirname(file_path)
+    basename = os.path.basename(file_path)
+    try:
+        files = os.listdir(dirname)
+    except FileNotFoundError:
+        return None
+    else:
+        found = case_insensitive_find(basename, files)
+        if found:
+            return os.path.join(dirname, found)
+
+
 def case_insensitive_find(word, words):
     """
     Obtém a palavra que seja mais similar possível dentre uma lista de palavras

--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -167,19 +167,16 @@ def get_asset(old_path, new_fname, dest_path):
         return
 
     try:
-        not_found = []
         for path in [
             os.path.join(config.get('SOURCE_IMG_FILE'), asset_path),
             os.path.join(config.get('SOURCE_PDF_FILE'), asset_path),
         ]:
-            if os.path.exists(path):
+            path = find_file(path)
+            if path:
                 break
-            else:
-                not_found.append(f"Not found {path}")
-
         content = files.read_file_binary(path)
-    except IOError as e:
-        raise AssetNotFoundError(". ".join(not_found))
+    except (TypeError, FileNotFoundError, IOError):
+        raise AssetNotFoundError(f"Not found {old_path}")
     else:
         files.write_file_binary(dest_path_file, content)
 

--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import logging
 import json
+import difflib
 
 from tqdm import tqdm
 from urllib.parse import urlparse
@@ -235,3 +236,24 @@ def packing_assets(asset_replacements, pkg_path, incomplete_pkg_path, pkg_name,
         files.write_file(errors_filename, error_messages)
         return incomplete_pkg_path
     return pkg_path
+
+
+def case_insensitive_find(word, words):
+    """
+    Obtém a palavra que seja mais similar possível dentre uma lista de palavras
+    A palavra obtida deve ser do mesmo tamanho
+    Mas pode ter variações entre maiúsculas e minúsculas
+    """
+    if word in words:
+        return word
+
+    _words = [w for w in words if len(w) == len(word)]
+
+    similar_items = difflib.get_close_matches(word, _words)
+    for item in similar_items:
+        if item.upper() == word.upper():
+            return item
+
+    for item in _words:
+        if item.upper() == word.upper():
+            return item

--- a/tests/test_processing_packing.py
+++ b/tests/test_processing_packing.py
@@ -371,3 +371,36 @@ class TestCaseInsensitiveFind(unittest.TestCase):
         result = packing.case_insensitive_find("07t3.gif", words)
         self.assertEqual(expected, result)
 
+
+class TestFindFile(unittest.TestCase):
+
+    @patch("documentstore_migracao.processing.packing.os.listdir")
+    def test_find_file_a18tab02M(self, mock_listdir):
+        mock_listdir.return_value = [
+            'a16tab02.gif', 'a18tab02m.gif', 'a18tab01.gif',
+        ]
+        expected = "/tmp/a18tab02m.gif"
+        result = packing.find_file("/tmp/a18tab02M.gif")
+        self.assertEqual(expected, result)
+
+    @patch("documentstore_migracao.processing.packing.os.listdir")
+    def test_find_file_webannex(self, mock_listdir):
+        mock_listdir.return_value = ["WEBANNEX.pdf"]
+        expected = "/tmp/WEBANNEX.pdf"
+        result = packing.find_file("/tmp/webannex.pdf")
+        self.assertEqual(expected, result)
+
+    @patch("documentstore_migracao.processing.packing.os.listdir")
+    def test_find_file_en_v32n1a05_1216_t1(self, mock_listdir):
+        mock_listdir.return_value = ["en_v32n1a05_1216_t1.jpg"]
+        expected = "/tmp/en_v32n1a05_1216_t1.jpg"
+        result = packing.find_file("/tmp/en_v32n1a05_1216_t1.JPG")
+        self.assertEqual(expected, result)
+
+    @patch("documentstore_migracao.processing.packing.os.listdir")
+    def test_find_file_07t3(self, mock_listdir):
+        mock_listdir.return_value = ["07t03.gif"]
+        expected = None
+        result = packing.find_file("/tmp/07t3.gif")
+        self.assertEqual(expected, result)
+

--- a/tests/test_processing_packing.py
+++ b/tests/test_processing_packing.py
@@ -333,3 +333,41 @@ class TestProcessingpack_PackingAssets(unittest.TestCase):
         self.assertEqual(result_path, pkg_path)
         self.assertFalse(os.path.isdir(bad_pkg_path))
         self.assertEqual({"f01.gif", "f02.gif"}, set(os.listdir(pkg_path)))
+
+
+class TestCaseInsensitiveFind(unittest.TestCase):
+
+    def test_case_insensitive_find_returns_itself(self):
+        words = [
+            "a18tab02M.gif", 'a18tab02m.gif', 'a18taB02m.gif',
+        ]
+        expected = "a18tab02M.gif"
+        result = packing.case_insensitive_find("a18tab02M.gif", words)
+        self.assertEqual(expected, result)
+
+    def test_case_insensitive_find_returns_most_similar(self):
+        words = [
+            "A18tab02M.gif", 'a18tab02m.gif',
+        ]
+        expected = "a18tab02m.gif"
+        result = packing.case_insensitive_find("a18tab02M.gif", words)
+        self.assertEqual(expected, result)
+
+    def test_case_insensitive_find_returns_WEBANNEX(self):
+        words = ["WEBANNEx.pdf", "WEBANNEX.pdf", ]
+        expected = "WEBANNEx.pdf"
+        result = packing.case_insensitive_find("webannex.pdf", words)
+        self.assertEqual(expected, result)
+
+    def test_case_insensitive_find_returns_lower_ext(self):
+        words = ["v32n1a05_1216_t1.jpg", "v32n1a05_1216_t2.JPG"]
+        expected = "v32n1a05_1216_t1.jpg"
+        result = packing.case_insensitive_find("v32n1a05_1216_t1.JPG", words)
+        self.assertEqual(expected, result)
+
+    def test_case_insensitive_find_returns_none(self):
+        words = ["07t03.gif", "07t2.gif"]
+        expected = None
+        result = packing.case_insensitive_find("07t3.gif", words)
+        self.assertEqual(expected, result)
+


### PR DESCRIPTION
#### O que esse PR faz?
Flexibiliza a estratégia para encontrar o arquivo do ativo digital, identificando nomes de arquivos similares, desconsiderando letras maiúsculas/minúsculas.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executar `ds_migracao pack` para arquivos do ano de 2010 e 2009. Veja mais detalhes em #396

#### Algum cenário de contexto que queira dar?
Este PR não trata o problema:

- Procura por 07t3.gif mas existe 07t03.gif

### Screenshots
n/a

#### Quais são tickets relevantes?
#396

### Referências
https://docs.python.org/3/library/difflib.html#difflib.get_close_matches
