### PR TITLE
[html][pack] Caso o ativo digital é `seta.gif`, procura em `htdocs/img`

### DIFF
--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -166,11 +166,17 @@ def get_asset(old_path, new_fname, dest_path):
         logger.debug("Arquivo já armazenado na pasta de destino: %s", dest_path_file)
         return
 
+    paths = [
+        os.path.join(config.get('SOURCE_IMG_FILE'), asset_path),
+        os.path.join(config.get('SOURCE_PDF_FILE'), asset_path),
+    ]
+    if (filename_m, ext_m) == ("seta", ".gif"):
+        seta_path = os.path.join(
+            config.get('SOURCE_IMG_FILE'), "img", "seta.gif")
+        paths.insert(0, seta_path)
+
     try:
-        for path in [
-            os.path.join(config.get('SOURCE_IMG_FILE'), asset_path),
-            os.path.join(config.get('SOURCE_PDF_FILE'), asset_path),
-        ]:
+        for path in paths:
             path = find_file(path)
             if path:
                 break

--- a/tests/test_processing_packing.py
+++ b/tests/test_processing_packing.py
@@ -256,6 +256,27 @@ class TestProcessingPackingGetAsset(unittest.TestCase):
             str(exc.exception)
         )
 
+    @patch("documentstore_migracao.processing.packing.find_file")
+    @patch("documentstore_migracao.utils.files.read_file_binary")
+    def test_get_asset_raises_AssetNotFoundError_exception(
+            self, mk_read_file_binary, mock_find_file):
+
+        with utils.environ(
+            SOURCE_PATH=SAMPLES_PATH,
+            VALID_XML_PATH=SAMPLES_PATH,
+            SPS_PKG_PATH=SAMPLES_PATH,
+            INCOMPLETE_SPS_PKG_PATH=SAMPLES_PATH,
+            SOURCE_PDF_FILE=os.path.join(os.path.dirname(__file__), "samples"),
+            SOURCE_IMG_FILE=os.path.join(os.path.dirname(__file__), "samples")
+        ):
+            mk_read_file_binary.return_value = b""
+            old_path = "/img/revistas/acron/volume/seta.gif"
+            new_fname = "novo"
+            dest_path = TEMP_TEST_PATH
+            path = packing.get_asset(old_path, new_fname, dest_path)
+            htdocs_path = os.path.join(os.path.dirname(__file__), "samples")
+            mock_find_file.assert_called_with(f"{htdocs_path}/img/seta.gif")
+
 
 class TestProcessingpack_PackingAssets(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
#### O que esse PR faz?
Caso o ativo digital é `seta.gif`, procura em `htdocs/img`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Tenha:
- um XML que contenha `<graphic xlink:href="/img/revistas/acron/vol/seta.gif"/>` no caminho definido por `VALID_XML_PATH`
- no caminho `SOURCE_IMG_FILE/img/revistas/acron/vol` não deve existir seta.gif
- no caminho `SOURCE_IMG_FILE/img/` deve existir seta.gif

Execute:
`ds_migracao pack --file <VALID_XML_PATH>/documento.xml`

Note que em `SPS_PKG_PATH=SAMPLES_PATH` (ou `INCOMPLETE_SPS_PKG_PATH`) é gerado o pacote correspondente e um arquivo correspondente a seta.gif é gerado.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#400

### Referências
n/a
