### PR TITLE
Adiciona re-tentativas na função fetch_articles e adiciona os ajustes de configuração.

### DIFF
--- a/documentstore_migracao/config.py
+++ b/documentstore_migracao/config.py
@@ -63,28 +63,45 @@ _default = dict(
         {
             "name": "classic",
             "url": "http://www.scielo.br/scielo.php?script=sci_arttext&pid={}",
-            "html": {'tag_name': 'div', 'atrib': {'xmlns': ''}},
-            "compare_tags": ["p", "li", "b", "i", "em", "sup", "br", "div"],
-            "remove_tags": [{'tag_name': 'sup', 'atrib': {}},
-                            {'tag_name': 'div', 'atrib': {'class': 'foot-notes'}},
+            "html": {'tag_name': 'div', 'atrib': {'class': 'content'}},
+            "compare_tags": ["p", "li", "b", "i", "em", "sup", "br", "blockquote", "div"],
+            "remove_tags": [{'tag_name': 'script', 'atrib': {}},
+                            {'tag_name': 'div', 'atrib': {'class': 'footer'}},
                             {'tag_name': 'div', 'atrib': {'id': 'group'}},
-                            {'tag_name': 'script', 'atrib': {}}],
-            "remove_texts": ['REFERENCES', '[ Links ]']
+                            {'tag_name': 'div', 'atrib': {'class': 'license'}}, ],
+            "remove_texts": ['REFERENCES', 'References', '[ Links ]', 'abstract', 'abstracts',
+                             'ABSTRACT', 'ABSTRACTS', 'Abstract', 'Abstracts',
+                             'resumo', 'RESUMO', 'doi', 'thumbnail', 'Thumbnail',
+                             'http', 'https', 'version', 'Print', 'author',
+                             'AUHTOR', 'How', 'cite', 'Close', 'close', 'suppl', 'about', 'About', 'ABOUT',
+                             '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'Copy', 'copy', 'pdf', 'PDF',
+                             'figures', 'Figures', 'FIGURES']
         },
         {
             "name": "new",
             "url": "http://new.scielo.br/article/{}",
-            "html": {'tag_name': 'article', 'atrib': {'id': 'articleText'}},
-            "compare_tags": ["p", "li", "b", "i", "em", "sup", "br", "div"],
-            "remove_tags": [{'tag_name': 'span', 'atrib': {'class': 'ref'}},
-                            {'tag_name': 'ul', 'atrib': {'class': 'refList footnote'}},
+            "html": {'tag_name': 'div', 'atrib': {'id': 'standalonearticle'}},
+            "compare_tags": ["p", "li", "b", "i", "em", "sup", "br", "div", "h1", "h2", "h3", "h4", "h5", "h6", "table"],
+            "remove_tags": [{'tag_name': 'span', 'atrib': {'class': 'refCtt'}},
+                            {'tag_name': 'script', 'atrib': {}},
+                            {'tag_name': 'sup', 'atrib': {'class': 'big'}},
+                            {'tag_name': 'div', 'atrib': {'class': 'thumb'}},
+                            {'tag_name': 'ul', 'atrib': {'class': 'articleMenu'}},
+                            {'tag_name': 'div', 'atrib': {'data-anchor': 'Datas de Publicação '}},
+                            {'tag_name': 'div', 'atrib': {'data-anchor': 'Publication Dates'}},
                             {'tag_name': 'section', 'atrib': {'class': 'documentLicense'}}],
-            "remove_texts": ['REFERENCES', 'REFERÊNCIAS BIBLIOGRÁFICAS']
+            "remove_texts": ['REFERENCES', 'References', 'REFERÊNCIAS BIBLIOGRÁFICAS', 'references',
+                             'abstract', 'abstracts', 'Abstract', 'Abstracts',
+                             'ABSTRACT', 'ABSTRACTS', 'thumbnail', 'Thumbnail',
+                             'resumo', 'RESUMO', 'doi', 'http', 'https',
+                             'version', 'Print', 'author', 'AUHTOR', 'How',
+                             'cite', 'Close', 'close', 'suppl', 'about', 'About', 'ABOUT'
+                             '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'Copy', 'copy', 'pdf', 'PDF',
+                             'figures', 'Figures', 'FIGURES']
         },
     ]
 
 )
-
 
 def get(config: str):
     """Recupera configurações do sistema, caso a configuração não

--- a/documentstore_migracao/processing/compare_articles_sites.py
+++ b/documentstore_migracao/processing/compare_articles_sites.py
@@ -8,6 +8,7 @@ from bs4 import BeautifulSoup as soup
 from documentstore_migracao import config
 
 import aiohttp
+from tenacity import retry, wait_exponential
 
 LOGGER_FORMAT = u"%(asctime)s %(levelname)-5.5s %(message)s"
 logger = logging.getLogger(__name__)
@@ -56,10 +57,11 @@ def sim_jaccard(text1, text2):
     set_text2 = set(text2.split())
 
     intersection = set_text1.intersection(set_text2)
-
     union = set_text1.union(set_text2)
+
     try:
         sim = float(len(intersection)) / (len(union))
+        print(sim)
     except ZeroDivisionError as e:
         return (0, "0.00%")
 
@@ -139,9 +141,14 @@ def dump_jsonl(filename, lines):
             fp.write("\n")
 
 
+@retry(wait=wait_exponential(multiplier=1, min=4, max=20))
 async def fetch_article(session, pid, url):
     """
     Obtém um artigo com acesso HTTP.
+
+    Retentativas: Aguarde 2 ^ x * 1 segundo entre cada nova tentativa,
+                  começando com 4 segundos, depois até 10 segundos e 10
+                  segundos depois
 
     Args:
         session: http session object(aiohttp), sessão http
@@ -166,8 +173,8 @@ async def fetch_article(session, pid, url):
                 return None
 
             return await response.content.read()
-    except aiohttp.ClientResponseError as e:
-        logger.error("Erro: %s.", e)
+    except Exception as e:
+        logger.error("Erro ao obter o artigo, pid: %s, retentando...., erro:%s" % (pid, e))
 
 
 async def fetch_articles(session, pid, cut_off_mark, output_filepath):

--- a/documentstore_migracao/processing/compare_articles_sites.py
+++ b/documentstore_migracao/processing/compare_articles_sites.py
@@ -61,7 +61,6 @@ def sim_jaccard(text1, text2):
 
     try:
         sim = float(len(intersection)) / (len(union))
-        print(sim)
     except ZeroDivisionError as e:
         return (0, "0.00%")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,3 +73,4 @@ JPype1==1.0.1
 ujson==2.0.3
 psycopg2-binary==2.8.5
 aiohttp==3.7.3
+tenacity==6.3.1


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR é resultado de diversas execuções desse código, onde identificamos as partes do texto que é necessário remover/avaliar para que a similaridade seja mais assertiva.

Outro ponto que está contemplado nesse PR é a capacidade de retentar a obtenção dos textos dos artigos nos dois site (novo e clássico)

#### Onde a revisão poderia começar?

Através dos commits.

#### Como este poderia ser testado manualmente?

Executando o código e verificando a taxa de similaridade. 

Para testar as re-tentativas é possível executando o código com o seguinte comando: 

```shell
ds_migracao check_similarity --similarity_input pids_html.txt --similarity_output similarity_html.jsonl
```
e após um tempo desativando a interface de rede local para verificar que a execução não é interrompida.
