### PR TITLE
Altera propriedade year do SPS_Package para priorizar a data collection

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -427,7 +427,12 @@ class SPS_Package:
 
     @property
     def year(self):
-        return self.documents_bundle_pubdate[0]
+        xpaths = (
+            'pub-date[@date-type="collection"]',
+            'pub-date[@pub-type="collection"]',
+            'pub-date[@pub-type="epub-ppub"]',
+        )
+        return parse_date(self._match_pubdate(xpaths))[0]
 
     @property
     def fpage(self):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR tem como objetivo corrigir o ano de publicação do documento no bundle que consta no arquivo resultado do import para o Kernel.

#### Onde a revisão poderia começar?
Em documentstore_migracao/export/sps_package.py, L430.

#### Como este poderia ser testado manualmente?
- Execute os passos descritos em #412
- O comportamento esperado deve ocorrer.

#### Algum cenário de contexto que queira dar?
Este PR se propõe a corrigir o problema na geração do JSONL de saída do comando `ds_migracao import`, não corrigindo o problema de XMLs com data da coleção não presente.

### Screenshots
.

#### Quais são tickets relevantes?
#412

### Referências
.

