### PR TITLE
Completa documentos XML que não tem nenhum `<issn/>` dentro de `journal-meta`

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -24,7 +24,7 @@ This is the complete utilization guide for this tool, these next sections will e
 
 The documents at this point are XML, but their body content is not XML, but escaped HTML, for example:
 
-```xml
+```text
 <body>
 &lt;text find=&quot;text_2&quot;&gt;This is the home page of SciELO Brasil Site.&lt;br&gt;
 			&lt;br&gt;The objective of the site is to implement an electronic virtual library, providing full access to a collection of serial titles, a collection of issues from individual serial titles, as well as to the full text of articles. The access to both serial titles and articles is available via indexes and search forms.&lt;br&gt;
@@ -116,14 +116,16 @@ In order to run the `` packing`` phase, it is necessary to perform some predicte
 
 By default, these variables have the values:
 
-SOURCE_IMG_FILE = "bases"
-SOURCE_PDF_FILE = "htdocs"
+```text
+SOURCE_IMG_FILE="bases"
+SOURCE_PDF_FILE="htdocs"
+```
 
 You can change these values by creating the following environment variables:
 
 ```shell
-export SOURCE_IMG_FILE = path
-export SOURCE_PDF_FILE = path
+export SOURCE_IMG_FILE=path
+export SOURCE_PDF_FILE=path
 ```
 
 To run the packing, it is possible with the following command:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,14 +1,23 @@
 # Migration Tool Usage Instruction and Examples
 
-This is the complete utilization guide for this tool, these next sections will explain how this application works and how users can do a complete HTML migration to XML migration to the SciELO Publishing Framework.
+This is the complete utilization guide for this tool, these next sections will explain how this application works and how users can do a complete XML migration to the SciELO Publishing Framework.
+- Packing **synthetized** XML files or **native** XML files
+- Registering packages on the SPF
 
-## Topics
+## Generating and Packing Synthetized XML files
 1. Obtaining HTML documents
 2. [Converting HTML to XML documents](#2-\--converting-html-to-xml-documents)
 3. [Updating documents' mixed citations](#3-\--updating-documents-mixed-citations)
-4. [Generating documents packages](#4-\--generating-documents-packages)
+4. [Packing synthetized XML files](#4-\--packing-synthetized-xml-files)
+
+## Packing Native XML files
+1. [Packing Native XML files](#1-\--packing-native-xml-files)
+
+## Registering packages on the SPF
 5. Importing documents packages to the Publish Platform
 6. Committing the relationship between documents and issues
+   
+## Checking migration
 7. [Check similarity between sites](#7-\--check-similarity-between-sites)
 
 ## 2 - Converting HTML to XML documents
@@ -97,7 +106,7 @@ It is important to make sure if everything works and if all articles were update
 
 Look closer to messages like `file not found` or `access denied` during previous commands.
 
-## 4 - Generating documents packages
+## 4 - Packing synthetized XML files
 
 Documents Packages is the phase in which we create packages with all the necessary adjustments to be stored in a data store.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -24,7 +24,7 @@ This is the complete utilization guide for this tool, these next sections will e
 
 The documents at this point are XML, but their body content is not XML, but escaped HTML, for example:
 
-```text
+```
 <body>
 &lt;text find=&quot;text_2&quot;&gt;This is the home page of SciELO Brasil Site.&lt;br&gt;
 			&lt;br&gt;The objective of the site is to implement an electronic virtual library, providing full access to a collection of serial titles, a collection of issues from individual serial titles, as well as to the full text of articles. The access to both serial titles and articles is available via indexes and search forms.&lt;br&gt;

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -129,10 +129,27 @@ Optionally it is possible to run the pack for only one xml, see:
 ds_migracao --loglevel DEBUG pack -f path
 ```
 
+Optionally it is possible add `<issn/>` to the packages which the `issn` elements are missing:
+
+```shell
+ds_migracao --loglevel DEBUG pack --issns-jsonfile issns.json
+```
+
+where `issns.json` content format is like:
+```json
+{
+  "1234-0987": {"epub":  "1234-0987", "ppub": "3456-0987"},
+  "3456-0987": {"epub":  "1234-0987", "ppub": "3456-0987"},
+  "1264-5900": {"epub":  "1264-5900", "ppub": "6456-5900"},
+  "6456-5900": {"epub":  "1264-5900", "ppub": "6456-5900"}
+}
+
+```
+
 Help:
 
 ```shell
-ds_migracao --loglevel DEBUG pack -help
+ds_migracao --loglevel DEBUG pack --help
 ```
 
 ## 7 - Check similarity between sites

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -99,11 +99,33 @@ def is_valid_value_for_language(value):
     return True
 
 
+def is_valid_value_for_issns(issns_dict):
+    """
+    Expected issns_dict is a dict
+    keys: 'epub' and/or 'ppub'
+    values: issn (1234-5678)
+    """
+    try:
+        if len(set(issns_dict.keys())) != len(set(issns_dict.values())):
+            raise ValueError(f"{issns_dict} has duplicated keys or values")
+        if not issns_dict:
+            raise ValueError(f"Expected at least one item")
+        if not set(issns_dict.keys()).issubset({'epub', 'ppub'}):
+            raise ValueError(
+                f"Expected keys: 'epub' or 'ppub'. Found: {issns_dict.keys()}")
+        for v in issns_dict.values():
+            if len(v) != 9 or v[4] != "-":
+                raise ValueError(f"{v} is not an ISSN")
+    except AttributeError:
+        raise ValueError(f"Expected dict. {issns_dict} is not dict")
+
+
 VALIDATE_FUNCTIONS = dict((
     ("article_id_which_id_type_is_other", is_valid_value_for_order),
     ("scielo_pid_v2", is_valid_value_for_pid_v2),
     ("aop_pid", is_valid_value_for_pid_v2),
     ("original_language", is_valid_value_for_language),
+    ("issns", is_valid_value_for_issns),
 ))
 
 

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -245,6 +245,16 @@ class SPS_Package:
             pid_node.text = value
 
     @property
+    def issns(self):
+        try:
+            return {
+                issn.get("pub-type"): issn.text
+                for issn in self.xmltree.xpath('.//journal-meta//issn')
+            } or None
+        except (TypeError, AttributeError):
+            return None
+
+    @property
     def journal_meta(self):
         data = []
         issns = [

--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -106,18 +106,17 @@ def is_valid_value_for_issns(issns_dict):
     values: issn (1234-5678)
     """
     try:
-        if len(set(issns_dict.keys())) != len(set(issns_dict.values())):
-            raise ValueError(f"{issns_dict} has duplicated keys or values")
-        if not issns_dict:
-            raise ValueError(f"Expected at least one item")
-        if not set(issns_dict.keys()).issubset({'epub', 'ppub'}):
+        if len(issns_dict) == 0 or not set(issns_dict.keys()).issubset({'epub', 'ppub'}):
             raise ValueError(
-                f"Expected keys: 'epub' or 'ppub'. Found: {issns_dict.keys()}")
+                f"Expected dict which keys are 'epub' and/or 'ppub'. Found {issns_dict}")
+        if len(issns_dict.keys()) != len(set(issns_dict.values())):
+            raise ValueError(f"{issns_dict} has duplicated values")
         for v in issns_dict.values():
             if len(v) != 9 or v[4] != "-":
                 raise ValueError(f"{v} is not an ISSN")
     except AttributeError:
-        raise ValueError(f"Expected dict. {issns_dict} is not dict")
+        raise ValueError(
+            f"Expected dict which keys are 'epub' and/or 'ppub'. Found {issns_dict}")
     return True
 
 

--- a/documentstore_migracao/main/migrate_articlemeta.py
+++ b/documentstore_migracao/main/migrate_articlemeta.py
@@ -107,6 +107,14 @@ def migrate_articlemeta_parser(sargs):
         help="Gera o pacote `SPS` apenas para o documento XML imformado",
     )
 
+    pack_sps_parser.add_argument(
+        "-Issns-jsonfile",
+        "--issns-jsonfile",
+        dest="issns_jsonfile",
+        required=False,
+        help="ISSNs JSON data file",
+    )
+
     # GERACAO PACOTE SPS FROM SITE STRUTURE
     pack_sps_parser_from_site = subparsers.add_parser(
         "pack_from_site", help="Gera pacotes `SPS` a partir da estrutura do Site SciELO"
@@ -374,6 +382,10 @@ def migrate_articlemeta_parser(sargs):
             logger.error("A pasta para obter os IMGs para a fase de empacotamento, não está acessível: %s (revise o arquivo de configuração ``SOURCE_IMG_FILE``) ", pdf)
             sys.exit()
 
+        if args.issns_jsonfile:
+            with open(args.issns_jsonfile) as fp:
+                packing.ISSNs = json.loads(fp.read())
+
         # pack HTML
         if args.packFile:
             packing.pack_article_xml(args.packFile)
@@ -389,8 +401,8 @@ def migrate_articlemeta_parser(sargs):
             args.output_folder,
             args.articles_csvfile,
         )
-        if issns_jsonfile:
-            with open(issns_jsonfile) as fp:
+        if args.issns_jsonfile:
+            with open(args.issns_jsonfile) as fp:
                 build_ps.issns = json.loads(fp.read())
         build_ps.run()
 

--- a/documentstore_migracao/main/migrate_articlemeta.py
+++ b/documentstore_migracao/main/migrate_articlemeta.py
@@ -155,6 +155,14 @@ def migrate_articlemeta_parser(sargs):
         help="Article CSV data file from ISIS bases",
     )
 
+    pack_sps_parser_from_site.add_argument(
+        "-Issns-jsonfile",
+        "--issns-jsonfile",
+        dest="issns_jsonfile",
+        required=False,
+        help="ISSNs JSON data file",
+    )
+
     # IMPORTACAO
     import_parser = subparsers.add_parser(
         "import",
@@ -381,7 +389,9 @@ def migrate_articlemeta_parser(sargs):
             args.output_folder,
             args.articles_csvfile,
         )
-
+        if issns_jsonfile:
+            with open(issns_jsonfile) as fp:
+                build_ps.issns = json.loads(fp.read())
         build_ps.run()
 
     elif args.command == "import":

--- a/documentstore_migracao/main/migrate_articlemeta.py
+++ b/documentstore_migracao/main/migrate_articlemeta.py
@@ -97,7 +97,7 @@ def migrate_articlemeta_parser(sargs):
 
     # GERACAO PACOTE SPS
     pack_sps_parser = subparsers.add_parser(
-        "pack", help="Gera pacotes `SPS` a partir de XMLs válidos"
+        "pack", help="Gera pacotes `SPS` a partir de XMLs sintetizados"
     )
     pack_sps_parser.add_argument(
         "--file",
@@ -117,7 +117,7 @@ def migrate_articlemeta_parser(sargs):
 
     # GERACAO PACOTE SPS FROM SITE STRUTURE
     pack_sps_parser_from_site = subparsers.add_parser(
-        "pack_from_site", help="Gera pacotes `SPS` a partir da estrutura do Site SciELO"
+        "pack_from_site", help="Gera pacotes `SPS` dos XML nativos"
     )
     pack_sps_parser_from_site.add_argument(
         "-a", "--acrons", dest="acrons", nargs="+", help="journal acronyms."

--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -19,6 +19,8 @@ from documentstore_migracao.processing.extracted import PoisonPill, DoJobsConcur
 
 logger = logging.getLogger(__name__)
 
+ISSNs = {}
+
 
 class AssetNotFoundError(Exception):
     ...
@@ -65,6 +67,9 @@ def pack_article_xml(file_xml_path, poison_pill=PoisonPill()):
         sps_package.scielo_pid_v2 and sps_package.scielo_pid_v2[-5:],
         silently=True
     )
+    new_issns = ISSNs and ISSNs.get(sps_package.scielo_pid_v2[1:10])
+    if new_issns:
+        sps_package.fix("issns", new_issns, silently=True)
 
     SPS_PKG_PATH = config.get("SPS_PKG_PATH")
     INCOMPLETE_SPS_PKG_PATH = config.get("INCOMPLETE_SPS_PKG_PATH")

--- a/documentstore_migracao/utils/build_ps_package.py
+++ b/documentstore_migracao/utils/build_ps_package.py
@@ -50,6 +50,7 @@ class BuildPSPackage(object):
         self.pdf_folder = pdf_folder
         self.out_folder = out_folder
         self.articles_csvfile = articles_csvfile
+        self.issns = {}
 
     @property
     def xml_fs(self):
@@ -144,7 +145,9 @@ class BuildPSPackage(object):
             _sps_package, "article_id_which_id_type_is_other",
             _sps_package.order, f_pid, "article-id[@pub-id-type='other']"
         )
-
+        new_issns = self.issns and self.issns.get(f_pid[1:10])
+        if new_issns:
+            _fix_attr(_sps_package, "issns", new_issns, f_pid, "ISSNs")
         if _sps_package.is_ahead_of_print:
             return _sps_package
 

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -1116,3 +1116,50 @@ class TestBuildSPSPackageXMLWEBOptimiser(TestBuildSPSPackageBase):
             self.assertIn("1234-5678-rctb-45-05-0110-e02.png", img_filenames)
             self.assertIn("1234-5678-rctb-45-05-0110-e04.tif", img_filenames)
             self.assertIn("1234-5678-rctb-45-05-0110-e04.png", img_filenames)
+
+
+class TestBuildSPSPackageHasISSNsToFix(TestCase):
+
+    def setUp(self):
+        xml = """<article>
+            <journal-meta>
+                <journal-id/>
+            </journal-meta>
+            <article-meta/>
+        </article>
+        """
+        xmltree = etree.fromstring(xml)
+        self._sps_package = SPS_Package(xmltree)
+        self.builder = build_ps_package.BuildPSPackage(
+            "/data/xmls",
+            "/data/imgs",
+            "/data/pdfs",
+            "/data/output",
+            "/data/article_data_file.csv",
+        )
+        self.pack_name = "1806-0013-test-01-01-0001"
+        self.row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,test,v1n1,en,".split(",")
+
+    def test__update_sps_package_obj_updates_issns(self):
+        # issns data to complete sps_package
+        self.builder.issns = {
+            "0101-0101":
+                {"ppub": "0101-0101", "epub": "8888-0101"}
+        }
+        # self._sps_package has no ISSNs
+        result = self.builder._update_sps_package_obj(
+            self._sps_package, self.pack_name, self.row, self.pack_name + ".xml"
+        )
+        # self._sps_package.issns was updated
+        expected = {"ppub": "0101-0101", "epub": "8888-0101"}
+        self.assertEqual(expected, result.issns)
+
+    def test__update_sps_package_obj_does_not_update_issns(self):
+        # issns data to complete sps_package
+        self.builder.issns = {}
+        # self._sps_package has no ISSNs
+        result = self.builder._update_sps_package_obj(
+            self._sps_package, self.pack_name, self.row, self.pack_name + ".xml"
+        )
+        # self._sps_package.issns was not updated because there is no match
+        self.assertIsNone(result.issns)

--- a/tests/test_build_ps_package.py
+++ b/tests/test_build_ps_package.py
@@ -1163,3 +1163,34 @@ class TestBuildSPSPackageHasISSNsToFix(TestCase):
         )
         # self._sps_package.issns was not updated because there is no match
         self.assertIsNone(result.issns)
+
+    def test__update_sps_package_obj_does_not_update_issns_because_issns_were_already_updated(self):
+        pack_name = "1806-0013-test-01-01-0001"
+        row = "S0101-01012019000100001,,test/v1n1/1806-0013-test-01-01-0001.xml,,,test,v1n1,en,".split(",")
+
+        self.builder.issns = {
+            "0101-0101":
+                {"ppub": "0101-0101", "epub": "8888-0101"}
+        }
+
+        # self._sps_package has no ISSN
+        sps_package_updated = self.builder._update_sps_package_obj(
+            self._sps_package, pack_name, row, pack_name + ".xml"
+        )
+        # sps_package_updated has ISSN now
+        expected = {"ppub": "0101-0101", "epub": "8888-0101"}
+        self.assertEqual(expected, sps_package_updated.issns)
+
+        # try to update sps_package_updated again with different values:
+        # {"ppub": "9999-9999", "epub": "8888-8888"}
+        self.builder.issns = {
+            "0101-0101":
+                {"ppub": "9999-9999", "epub": "8888-8888"}
+        }
+        result = self.builder._update_sps_package_obj(
+            sps_package_updated, pack_name, row, pack_name + ".xml"
+        )
+        # it is expected that result.issns will not be updated with
+        # {"ppub": "9999-9999", "epub": "8888-8888"}
+        expected = {"ppub": "0101-0101", "epub": "8888-0101"}
+        self.assertEqual(expected, result.issns)

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -2731,6 +2731,20 @@ class TestSPSPackageHasNoIssns(unittest.TestCase):
     def test_get_issns_returns_none_because_there_is_no_issn(self):
         self.assertIsNone(self._sps_package.issns)
 
+    def test_set_issns_updates_issns(self):
+        expected = {
+            "epub": "1209-8709",
+            "ppub": "8809-8709",
+        }
+        self._sps_package.issns = {
+            "epub": "1209-8709",
+            "ppub": "8809-8709",
+        }
+        self.assertEqual(expected, self._sps_package.issns)
+        xml = etree.tostring(self._sps_package.xmltree)
+        self.assertIn(b'<issn pub-type="epub">1209-8709</issn>', xml)
+        self.assertIn(b'<issn pub-type="ppub">8809-8709</issn>', xml)
+
 
 class TestSPSPackageHaIssns(unittest.TestCase):
     def setUp(self):

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -2717,7 +2717,7 @@ class TestIsValidValueForIssns(unittest.TestCase):
         self.assertIn("is not an ISSN", str(exc.exception))
 
 
-class TestSPSPackageIssns(unittest.TestCase):
+class TestSPSPackageHasNoIssns(unittest.TestCase):
     def _sps_package(self, issns=''):
         xml = f"""<article>
         <journal-meta>{issns}</journal-meta>
@@ -2728,6 +2728,16 @@ class TestSPSPackageIssns(unittest.TestCase):
 
     def test_get_issns_returns_none_because_there_is_no_issn(self):
         self.assertIsNone(self._sps_package().issns)
+
+
+class TestSPSPackageHaIssns(unittest.TestCase):
+    def _sps_package(self, issns=''):
+        xml = f"""<article>
+        <journal-meta>{issns}</journal-meta>
+        <article-meta></article-meta>
+        </article>"""
+        xmltree = etree.fromstring(xml)
+        return SPS_Package(xmltree, None)
 
     def test_get_issns_returns_dict(self):
         issns = """

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -2745,6 +2745,18 @@ class TestSPSPackageHasNoIssns(unittest.TestCase):
         self.assertIn(b'<issn pub-type="epub">1209-8709</issn>', xml)
         self.assertIn(b'<issn pub-type="ppub">8809-8709</issn>', xml)
 
+    def test_set_issns_raises_exception_if_new_value_is_invalid(self):
+        expected = None
+        with self.assertRaises(InvalidAttributeValueError) as exc:
+            self._sps_package.issns = {
+                "epub": "XXXX-YYY",
+                "ppub": "8888-879",
+            }
+        self.assertEqual(expected, self._sps_package.issns)
+        xml = etree.tostring(self._sps_package.xmltree)
+        self.assertNotIn(b'<issn pub-type="epub">XXXX-YYY</issn>', xml)
+        self.assertNotIn(b'<issn pub-type="ppub">8888-879</issn>', xml)
+
 
 class TestSPSPackageHaIssns(unittest.TestCase):
     def setUp(self):

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -12,6 +12,7 @@ from documentstore_migracao.export.sps_package import (
     InvalidAttributeValueError,
     InvalidValueForOrderError,
     is_valid_value_for_order,
+    is_valid_value_for_issns,
     SourceJson,
 )
 
@@ -2686,3 +2687,31 @@ class TestSourceJson(unittest.TestCase):
         ]
         expected = (renditions, metadata)
         self.assertEqual(expected, source.get_renditions_metadata())
+
+
+class TestIsValidValueForIssns(unittest.TestCase):
+
+    def test_is_valid_value_for_issns_raises_is_exception_because_value_is_empty_dict(self):
+        with self.assertRaises(ValueError) as exc:
+            is_valid_value_for_issns({})
+        self.assertIn("Expected at least one item", str(exc.exception))
+
+    def test_is_valid_value_for_issns_raises_is_exception_because_value_is_not_dict(self):
+        with self.assertRaises(ValueError) as exc:
+            is_valid_value_for_issns(('a', 'b'))
+        self.assertIn("Expected dict", str(exc.exception))
+
+    def test_is_valid_value_for_issns_raises_is_exception_because_of_duplicated_values(self):
+        with self.assertRaises(ValueError) as exc:
+            is_valid_value_for_issns({"epub": 'x', "ppub": "x"})
+        self.assertIn("duplicated keys or values", str(exc.exception))
+
+    def test_is_valid_value_for_issns_raises_is_exception_because_of_invalid_key(self):
+        with self.assertRaises(ValueError) as exc:
+            is_valid_value_for_issns({"invalid_key": 'y', "ppub": "x"})
+        self.assertIn("Expected keys: 'epub' or 'ppub'", str(exc.exception))
+
+    def test_is_valid_value_for_issns_raises_is_exception_because_of_invalid_values(self):
+        with self.assertRaises(ValueError) as exc:
+            is_valid_value_for_issns({"ppub": 'y', "epub": "x"})
+        self.assertIn("is not an ISSN", str(exc.exception))

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -2757,8 +2757,17 @@ class TestSPSPackageHasNoIssns(unittest.TestCase):
         self.assertNotIn(b'<issn pub-type="epub">XXXX-YYY</issn>', xml)
         self.assertNotIn(b'<issn pub-type="ppub">8888-879</issn>', xml)
 
+    def test_fix_does_not_raise_exception_because_is_silenced(self):
+        self._sps_package.fix('issns', 'invalid value', silently=True)
+        self.assertIsNone(self._sps_package.issns)
 
-class TestSPSPackageHaIssns(unittest.TestCase):
+    def test_fix_raises_exception_because_is_not_silenced(self):
+        new_value = 'invalid value'
+        with self.assertRaises(InvalidAttributeValueError) as exc:
+            self._sps_package.fix('issns', new_value, silently=False)
+
+
+class TestSPSPackageHasIssns(unittest.TestCase):
     def setUp(self):
         xml = f"""<article>
         <journal-meta>
@@ -2793,4 +2802,20 @@ class TestSPSPackageHaIssns(unittest.TestCase):
         xml = etree.tostring(self._sps_package.xmltree)
         self.assertIn(b'<issn pub-type="epub">1234-0987</issn>', xml)
         self.assertIn(b'<issn pub-type="ppub">1834-0987</issn>', xml)
+
+    def test_fix_does_not_raise_exception_because_is_silenced(self):
+        new_value = {
+            "epub": "1299-0987",
+            "ppub": "1899-0987",
+        }
+        self._sps_package.fix('issns', new_value, silently=True)
+        self.assertNotEqual(new_value, self._sps_package.issns)
+
+    def test_fix_raises_exception_because_is_not_silenced(self):
+        new_value = {
+            "epub": "1299-0987",
+            "ppub": "1899-0987",
+        }
+        with self.assertRaises(NotAllowedtoChangeAttributeValueError) as exc:
+            self._sps_package.fix('issns', new_value, silently=False)
 

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -2715,3 +2715,29 @@ class TestIsValidValueForIssns(unittest.TestCase):
         with self.assertRaises(ValueError) as exc:
             is_valid_value_for_issns({"ppub": 'y', "epub": "x"})
         self.assertIn("is not an ISSN", str(exc.exception))
+
+
+class TestSPSPackageIssns(unittest.TestCase):
+    def _sps_package(self, issns=''):
+        xml = f"""<article>
+        <journal-meta>{issns}</journal-meta>
+        <article-meta></article-meta>
+        </article>"""
+        xmltree = etree.fromstring(xml)
+        return SPS_Package(xmltree, None)
+
+    def test_get_issns_returns_none_because_there_is_no_issn(self):
+        self.assertIsNone(self._sps_package().issns)
+
+    def test_get_issns_returns_dict(self):
+        issns = """
+        <issn pub-type="epub">1234-0987</issn>
+        <issn pub-type="ppub">1834-0987</issn>
+
+        """
+        expected = {
+            "epub": "1234-0987",
+            "ppub": "1834-0987",
+        }
+        self.assertEqual(expected, self._sps_package(issns).issns)
+

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -2760,9 +2760,25 @@ class TestSPSPackageHaIssns(unittest.TestCase):
         self._sps_package = SPS_Package(xmltree, None)
 
     def test_get_issns_returns_dict(self):
-        
         expected = {
             "epub": "1234-0987",
             "ppub": "1834-0987",
         }
         self.assertEqual(expected, self._sps_package.issns)
+
+    def test_set_issns_raises_exception_and_does_not_allowed_update_issns(self):
+        expected = {
+            "epub": "1234-0987",
+            "ppub": "1834-0987",
+        }
+        with self.assertRaises(NotAllowedtoChangeAttributeValueError) as exc:
+            self._sps_package.issns = {
+                "epub": "XXXX-YYYY",
+                "ppub": "8888-8709",
+            }
+        self.assertIn("Not allowed to set ISSNs", str(exc.exception))
+        self.assertEqual(expected, self._sps_package.issns)
+        xml = etree.tostring(self._sps_package.xmltree)
+        self.assertIn(b'<issn pub-type="epub">1234-0987</issn>', xml)
+        self.assertIn(b'<issn pub-type="ppub">1834-0987</issn>', xml)
+

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -2718,36 +2718,37 @@ class TestIsValidValueForIssns(unittest.TestCase):
 
 
 class TestSPSPackageHasNoIssns(unittest.TestCase):
-    def _sps_package(self, issns=''):
+    def setUp(self):
         xml = f"""<article>
-        <journal-meta>{issns}</journal-meta>
+        <journal-meta>
+            <journal-title-group/>
+        </journal-meta>
         <article-meta></article-meta>
         </article>"""
         xmltree = etree.fromstring(xml)
-        return SPS_Package(xmltree, None)
+        self._sps_package = SPS_Package(xmltree, None)
 
     def test_get_issns_returns_none_because_there_is_no_issn(self):
-        self.assertIsNone(self._sps_package().issns)
+        self.assertIsNone(self._sps_package.issns)
 
 
 class TestSPSPackageHaIssns(unittest.TestCase):
-    def _sps_package(self, issns=''):
+    def setUp(self):
         xml = f"""<article>
-        <journal-meta>{issns}</journal-meta>
+        <journal-meta>
+            <journal-title-group/>
+            <issn pub-type="epub">1234-0987</issn>
+            <issn pub-type="ppub">1834-0987</issn>
+        </journal-meta>
         <article-meta></article-meta>
         </article>"""
         xmltree = etree.fromstring(xml)
-        return SPS_Package(xmltree, None)
+        self._sps_package = SPS_Package(xmltree, None)
 
     def test_get_issns_returns_dict(self):
-        issns = """
-        <issn pub-type="epub">1234-0987</issn>
-        <issn pub-type="ppub">1834-0987</issn>
-
-        """
+        
         expected = {
             "epub": "1234-0987",
             "ppub": "1834-0987",
         }
-        self.assertEqual(expected, self._sps_package(issns).issns)
-
+        self.assertEqual(expected, self._sps_package.issns)

--- a/tests/test_sps_package.py
+++ b/tests/test_sps_package.py
@@ -2694,7 +2694,7 @@ class TestIsValidValueForIssns(unittest.TestCase):
     def test_is_valid_value_for_issns_raises_is_exception_because_value_is_empty_dict(self):
         with self.assertRaises(ValueError) as exc:
             is_valid_value_for_issns({})
-        self.assertIn("Expected at least one item", str(exc.exception))
+        self.assertIn("'epub' and/or 'ppub'", str(exc.exception))
 
     def test_is_valid_value_for_issns_raises_is_exception_because_value_is_not_dict(self):
         with self.assertRaises(ValueError) as exc:
@@ -2704,12 +2704,12 @@ class TestIsValidValueForIssns(unittest.TestCase):
     def test_is_valid_value_for_issns_raises_is_exception_because_of_duplicated_values(self):
         with self.assertRaises(ValueError) as exc:
             is_valid_value_for_issns({"epub": 'x', "ppub": "x"})
-        self.assertIn("duplicated keys or values", str(exc.exception))
+        self.assertIn("duplicated values", str(exc.exception))
 
     def test_is_valid_value_for_issns_raises_is_exception_because_of_invalid_key(self):
         with self.assertRaises(ValueError) as exc:
             is_valid_value_for_issns({"invalid_key": 'y', "ppub": "x"})
-        self.assertIn("Expected keys: 'epub' or 'ppub'", str(exc.exception))
+        self.assertIn("Expected dict which keys are 'epub' and/or 'ppub'.", str(exc.exception))
 
     def test_is_valid_value_for_issns_raises_is_exception_because_of_invalid_values(self):
         with self.assertRaises(ValueError) as exc:


### PR DESCRIPTION
#### O que esse PR faz?
Completa documentos XML que não tem nenhum `<issn/>` dentro de `journal-meta`. Com isso, o documento não terá problema na execução do comando `link_documents_issues`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Execute o `pack` ou `pack_from_site` em XML que não possuem `<issn/>` em `<journal-meta/>`.
Como resultado, será criado `<issn/>` a partir dos dados encontrados em um arquivo json que é passado como parâmetro dos comandos `pack` ou `pack_from_site` (`--issns-jsonfile`)

O formato deste arquivo é:
```json
{
  "1234-0987": {"epub":  "1234-0987", "ppub": "3456-0987"},
  "3456-0987": {"epub":  "1234-0987", "ppub": "3456-0987"},
  "1264-5900": {"epub":  "1264-5900", "ppub": "6456-5900"},
  "6456-5900": {"epub":  "1264-5900", "ppub": "6456-5900"}
}
```

```console
export SOURCE_IMG_FILE=/mnt/vol_dsteste/migracao/htdocs
export SOURCE_PDF_FILE=/mnt/vol_dsteste/migracao/bases
export VALID_XML_PATH=xml/conversion
ds_migracao --loglevel DEBUG pack --issns-jsonfile issns.json
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#411

### Referências
n/a
