### PR TITLE
[convert] Troca o `w:` que é um prefixo de namespace para `w-` antes da conversão

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1,4 +1,3 @@
-import re
 import logging
 import plumber
 import os
@@ -4092,7 +4091,7 @@ class Remote2LocalConversion:
             html_tree = etree.fromstring(
                 file_content, parser=etree.HTMLParser()
             )
-        except (FileLocationError, lxml.etree.Error) as e:
+        except (FileLocationError, etree.Error) as e:
             logger.error(
                 self.get_logging_msg(
                     str(e)

--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -1,10 +1,9 @@
+import re
 import logging
 import plumber
-import html
 import os
 from copy import deepcopy
 import difflib
-import json
 
 import requests
 from lxml import etree
@@ -455,7 +454,6 @@ class HTML2SPSPipeline(object):
         self.body_info = BodyInfo(pid, body_index, ref_items, spy)
         body_info_which_spy_is_false = BodyInfo(
             pid, body_index, ref_items, spy=False)
-
         self._ppl = plumber.Pipeline(
             self.SetupPipe(),
             self.SaveInitialTextPipe(self.body_info),
@@ -504,6 +502,7 @@ class HTML2SPSPipeline(object):
             self.FixIdAndRidPipe(self.body_info),
             self.CheckDiffPipe(self.body_info),
         )
+
 
     def deploy(self, raw):
         transformed_data = self._ppl.run(raw, rewrap=True)

--- a/documentstore_migracao/utils/xml.py
+++ b/documentstore_migracao/utils/xml.py
@@ -93,6 +93,18 @@ class LoadToXMLError(Exception):
     ...
 
 
+class GetFixedXMLContentError(Exception):
+    ...
+
+def get_fixed_xml_content(file):
+    try:
+        with open(file, "r") as fp:
+            content = fp.read()
+    except IOError as exc:
+        raise GetFixedXMLContentError("Unable to read file to fix its content: %s. %s" % (file, exc))
+    return fix_namespace_prefix_w(content)
+
+
 def loadToXML(file):
     """Parses `file` to produce an etree instance.
 
@@ -105,7 +117,7 @@ def loadToXML(file):
     parser = etree.XMLParser(remove_blank_text=True, no_network=True)
     try:
         xml = etree.parse(file, parser)
-    except etree.XMLSyntaxError as exc:
+    except (etree.XMLSyntaxError, GetFixedXMLContentError) as exc:
         raise LoadToXMLError(exc)
     else:
         return xml

--- a/documentstore_migracao/utils/xml.py
+++ b/documentstore_migracao/utils/xml.py
@@ -75,6 +75,20 @@ def prettyPrint_format(xml_string):
     return parseString(xml_string).toprettyxml()
 
 
+def fix_namespace_prefix_w(content):
+    """
+    Convert os textos cujo padrão é `w:st="` em `w-st="`
+    """
+    pattern = r"\bw:[a-z]{1,}=\""
+    found_items = re.findall(pattern, content)
+    logger.debug("Found %i namespace prefix w", len(found_items))
+    for item in set(found_items):
+        new_namespace = item.replace(":", "-")
+        logger.debug("%s -> %s" % (item, new_namespace))
+        content = content.replace(item, new_namespace)
+    return content
+
+
 def loadToXML(file):
     """Parses `file` to produce an etree instance.
 

--- a/documentstore_migracao/utils/xml.py
+++ b/documentstore_migracao/utils/xml.py
@@ -89,6 +89,10 @@ def fix_namespace_prefix_w(content):
     return content
 
 
+class LoadToXMLError(Exception):
+    ...
+
+
 def loadToXML(file):
     """Parses `file` to produce an etree instance.
 
@@ -102,7 +106,7 @@ def loadToXML(file):
     try:
         xml = etree.parse(file, parser)
     except etree.XMLSyntaxError as exc:
-        raise Exception(str(exc)) from None
+        raise LoadToXMLError(exc)
     else:
         return xml
 

--- a/documentstore_migracao/utils/xml.py
+++ b/documentstore_migracao/utils/xml.py
@@ -119,7 +119,7 @@ def loadToXML(file):
         content = get_fixed_xml_content(file)
         xml = etree.parse(BytesIO(content.encode("utf-8")), parser)
     except (etree.XMLSyntaxError, GetFixedXMLContentError) as exc:
-        raise LoadToXMLError(exc)
+        raise LoadToXMLError(str(exc)) from None
     else:
         return xml
 

--- a/documentstore_migracao/utils/xml.py
+++ b/documentstore_migracao/utils/xml.py
@@ -116,7 +116,8 @@ def loadToXML(file):
 
     parser = etree.XMLParser(remove_blank_text=True, no_network=True)
     try:
-        xml = etree.parse(file, parser)
+        content = get_fixed_xml_content(file)
+        xml = etree.parse(StringIO(content), parser)
     except (etree.XMLSyntaxError, GetFixedXMLContentError) as exc:
         raise LoadToXMLError(exc)
     else:

--- a/documentstore_migracao/utils/xml.py
+++ b/documentstore_migracao/utils/xml.py
@@ -4,7 +4,7 @@ import re
 import logging
 import itertools
 import html
-from io import StringIO
+from io import StringIO, BytesIO
 from lxml import etree
 from xml.dom.minidom import parseString
 
@@ -117,7 +117,7 @@ def loadToXML(file):
     parser = etree.XMLParser(remove_blank_text=True, no_network=True)
     try:
         content = get_fixed_xml_content(file)
-        xml = etree.parse(StringIO(content), parser)
+        xml = etree.parse(BytesIO(content.encode("utf-8")), parser)
     except (etree.XMLSyntaxError, GetFixedXMLContentError) as exc:
         raise LoadToXMLError(exc)
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -201,3 +201,21 @@ class TestXMLUtilsRemoveElements(unittest.TestCase):
         xml.remove_element(self.xmltree.find(".//body"), ".//p")
         self.assertNotIn(b"<p>text</p>", etree.tostring(self.xmltree))
         self.assertIn(b"<p>second text</p>", etree.tostring(self.xmltree))
+
+
+class TestFixNamespacePrefixW(unittest.TestCase):
+    def test_fix_namespace_prefix_w_fixes_content(self):
+        content = ' w:atributo="abc"'
+        expected = ' w-atributo="abc"'
+        self.assertEqual(xml.fix_namespace_prefix_w(content), expected)
+
+    def test_fix_namespace_prefix_w_does_not_fix_content_because_it_does_not_match(self):
+        items = [
+            'w:attr= "abc"',
+            'w:attr ="abc"',
+            'w: attr="abc"',
+            'w :attr="abc"',
+        ]
+        for item in items:
+            with self.subTest(item):
+                self.assertEqual(xml.fix_namespace_prefix_w(item), item)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,9 +112,9 @@ class TestUtilsXML(unittest.TestCase):
         obj = xml.file2objXML(file_path)
         self.assertIn(expected_text, str(etree.tostring(obj)))
 
-    def test_file2objXML_raise_OSError_for_filenotfound(self):
+    def test_file2objXML_raise_LoadToXMLError_for_filenotfound(self):
         file_path = os.path.join(SAMPLES_PATH, "none.xml")
-        with self.assertRaises(OSError):
+        with self.assertRaises(xml.LoadToXMLError):
             xml.file2objXML(file_path)
 
     def test_file2objXML_raise_XMLSyntaxError_for_filenotfound(self):


### PR DESCRIPTION
#### O que esse PR faz?
Troca o `w:` que é um prefixo de namespace para `w-` antes da conversão

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Crie o arquivo tk375.txt contendo:

```
S0001-37652010000400028
S0004-282X1981000400015
```
Deixe os diretório `xml/source` e `xml/conversion` vazios

Execute os seguintes comandos:

```console
ds_migracao --loglevel DEBUG extract tk375.txt
ds_migracao --loglevel DEBUG convert 
```
Verifique que a conversão termina sem levantamento de exceções e que os XML em `xml/conversion` estão bem formados.

#### Algum cenário de contexto que queira dar?
Uma alteração similar foi feita para mixed-citations (https://github.com/scieloorg/document-store-migracao/pull/382)
Com esta alteração, entraram 30 documentos hoje no new.scielo.br (https://docs.google.com/document/d/1DrRPArvm8pzpuwRzbZQV3H7q3YoQ9dPH10BhfK89Uko/edit#heading=h.mhp2kzv8lg1l)

### Screenshots
n/a

#### Quais são tickets relevantes?
Ver issue #375, inclusive os comentários

### Referências
n/a
