### PR TITLE
[dsm][convert] Antes de converter tag HTML img, verifica se há atributo src

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -3217,6 +3217,9 @@ class ConvertElementsWhichHaveIdPipeline(object):
             'table-wrap')
 
         def parser_node(self, node):
+            if not node.attrib.get("src"):
+                return
+
             parent = node.getparent()
             tag = "graphic"
             if parent.tag in self.only_inline:


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera a conversão de tags `img` para verificar antes se o atributo `src` está presente e se tem valor. Em caso negativo, não faz a conversão, preservando a tag como entrou.

#### Onde a revisão poderia começar?
Commit 09adce4.

#### Como este poderia ser testado manualmente?
1. Execute o comando

```ds_migracao convert --file=<caminho para XML extraído>```

OU

```./ferramentas/migracao.sh <diretorio ano> <caminho para arquivo com os PIDs v2> <diretório raíz destino da execução>```

Os PIDs reportados no issue devem estar contidos no arquivo de PIDs.

2. Verifique se os XMLs foram convertidos sem interromper a aplicação e com as tags com problema preservadas.

#### Algum cenário de contexto que queira dar?
Os dois casos reportados no issue estão com erro no HTML extraído:

`S0073-47212010000300010`
- tag no body HTML incorreta: `<img sr="" c="/img/revistas/isz/v100n3/fem.jpg" align="absmiddle" />`

`S2176-94512011000500004`
- tag no body HTML incorreta: `<img scr="/img/revistas/dpjo/v16n5/a04img.jpg" />`


### Screenshots
.

#### Quais são tickets relevantes?
#419.

### Referências
.