### PR TITLE
[conversão] Corrige propriedade FileLocation.remote p/ fazer a combinação da URL

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -3,6 +3,7 @@ import plumber
 import os
 from copy import deepcopy
 import difflib
+from urllib.parse import urljoin
 
 import requests
 from lxml import etree
@@ -3762,7 +3763,7 @@ class FileLocation:
         file_path = self.href
         if file_path.startswith("/"):
             file_path = file_path[1:]
-        return os.path.join(config.get("STATIC_URL_FILE"), file_path)
+        return urljoin(config.get("STATIC_URL_FILE"), file_path)
 
     @property
     def local(self):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige problema na junção de url na propriedade FileLocation.remote, usada na conversão do body HTML. O `urllib.parse.urljoin()` é utlizado, pois trata de forma mais adequada para casos de junção de URL. Assim, a exceção não ocorreria, já que o primeiro atributo informado é uma URL válida.

#### Onde a revisão poderia começar?
Commit 0736fc3.

#### Como este poderia ser testado manualmente?
1. Execute a conversão do XML do documento PID v2 `S0104-42302013000600016`.
2. O arquivo deve ser convertido sem interromper a execução.
3. A tag deve aparecer preservada no XML convertido, pois o link está originalmente incorreto.

#### Algum cenário de contexto que queira dar?
.

### Screenshots
.

#### Quais são tickets relevantes?
#420.

### Referências
.
