### PR TITLE
[conversão] Altera importação de HTMLs referenciados em artigos HTML para não interromper conversão com mais de uma âncora no link

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -4053,7 +4053,7 @@ class Remote2LocalConversion:
         )
         href = a_link_type.get("href")
         if "#" in href:
-            href, anchor = href.split("#")
+            href = href.split("#")[0]
 
         f, ext = os.path.splitext(href)
         new_href = os.path.basename(f)


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera importação de HTMLs referenciados em artigos HTML para não interromper conversão quando o link para o arquivo HTML tem mais de uma âncora no link.
O método `Remote2LocalConversion._imported_html_file()` precisa somente do caminho do arquivo HTML e âncoras não são usadas nesta parte do código.

#### Onde a revisão poderia começar?
Observe que o método `Remote2LocalConversion._imported_html_file()` não utliza a variável `anchor` a ser obtida no no resultado do `str.split()`.

#### Como este poderia ser testado manualmente?
1. Execute o comando

```ds_migracao convert --file=<caminho para XML extraído>```

OU

```./ferramentas/migracao.sh <diretorio ano> <caminho para arquivo com os PIDs v2> <diretório raíz destino da execução>```

Os PIDs reportados no issue devem estar contidos no arquivo de PIDs.


#### Algum cenário de contexto que queira dar?
.

### Screenshots
.

#### Quais são tickets relevantes?
#421 

### Referências
.