### PR TITLE
[conversão] Altera conversão de âncora para prever dígitos não decimais

### DIFF
--- a/documentstore_migracao/utils/convert_html_body.py
+++ b/documentstore_migracao/utils/convert_html_body.py
@@ -2158,7 +2158,11 @@ class ConvertElementsWhichHaveIdPipeline(object):
             for c in _string:
                 if not c.isdigit():
                     break
-                number += c
+                if c.isdecimal():
+                    number += c
+                else:
+                    superscript = str.maketrans("⁰¹²³⁴⁵⁶⁷⁸⁹", "0123456789")
+                    number += c.translate(superscript)
             return int(number)
 
         def _is_a_sequence(self, previous, next):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR tenta previnir exceção de complemento de âncoras com texto completo do label com numéricos não decimais.

#### Onde a revisão poderia começar?
Commit 6e25a41.

#### Como este poderia ser testado manualmente?
1. Execute o comando

```ds_migracao convert --file=<caminho para XML extraído>```

OU

```./ferramentas/migracao.sh <diretorio ano> <caminho para arquivo com os PIDs v2> <diretório raíz destino da execução>```

Os PIDs reportados no issue devem estar contidos no arquivo de PIDs.


#### Algum cenário de contexto que queira dar?
.

### Screenshots
.

#### Quais são tickets relevantes?
#422.

### Referências
.

