### PR TITLE
Registra as exceções levantadas por `pack_article_xml`

### DIFF
--- a/documentstore_migracao/processing/packing.py
+++ b/documentstore_migracao/processing/packing.py
@@ -131,10 +131,18 @@ def pack_article_ALLxml():
         def update_bar(pbar=pbar):
             pbar.update(1)
 
+        def log_exceptions(exception, job, logger=logger):
+            logger.error(
+                "Could not pack file '%s'. The exception '%s' was raised.",
+                job["file_xml_path"],
+                exception,
+            )
+
         DoJobsConcurrently(
             pack_article_xml,
             jobs=jobs,
             max_workers=int(config.get("THREADPOOL_MAX_WORKERS")),
+            exception_callback=log_exceptions,
             update_bar=update_bar,
         )
 


### PR DESCRIPTION
#### O que esse PR faz?
Registra os erros ocorridos na fase de empacotamento de xml sintetizados. Corrige o bug de ter deixado de registrar os erros.

#### Onde a revisão poderia começar?
por commit

#### Como este poderia ser testado manualmente?
Tente empacotar um xml sintetizado

```python
ds_migracao --loglevel DEBUG pack --file documento_mal_formado.xml
```
Note que registra a mensagem de erro


#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
Não foi criado issue para fazer esta correção. Identifiquei problema ao processar um lote de xml sintetizados que não estavam presentes no kernel (https://github.com/orgs/scieloorg/projects/4#card-54097599). 

Corrige bug inserido por https://github.com/scieloorg/document-store-migracao/pull/386/commits/0284facf6a8a591473bd5085d58e1f0a94b1db1a

 

### Referências
Indique as referências utilizadas para a elaboração do pull request.

