### PR TITLE
Melhora a consulta e o registro dos pids no pid_manager

### DIFF
--- a/documentstore_migracao/export/sps_package.py
+++ b/documentstore_migracao/export/sps_package.py
@@ -9,7 +9,7 @@ from lxml import etree
 
 from documentstore_migracao.export import article
 from documentstore_migracao.utils import files, string
-from documentstore_migracao.utils import scielo_ids_generator, xml
+from documentstore_migracao.utils import xml
 from documentstore_migracao.utils.convert_html_body import HTML2SPSPipeline
 from documentstore_migracao import exceptions
 

--- a/documentstore_migracao/tools/constructor.py
+++ b/documentstore_migracao/tools/constructor.py
@@ -14,13 +14,7 @@ from documentstore_migracao import config
 logger = logging.getLogger(__name__)
 
 
-def article_xml_constructor(file_xml_path: str, dest_path: str, pid_database_engine, in_place: bool) -> None:
-
-    logger.debug("file: %s", file_xml_path)
-
-    parsed_xml = xml.loadToXML(file_xml_path)
-    xml_sps = SPS_Package(parsed_xml)
-
+def register_pid_v3(pid_database_engine, xml_sps):
     pid_v2 = xml_sps.scielo_pid_v2
 
     # VERIFICA A EXISTÊNCIA DO PID V3 NO XC ATRAVES DO PID V2
@@ -38,6 +32,16 @@ def article_xml_constructor(file_xml_path: str, dest_path: str, pid_database_eng
         pid_v3 = pid_manager.get_pid_v3_by_v2(pid_database_engine, pid_v2)
 
         xml_sps.scielo_pid_v3 = pid_v3
+
+
+def article_xml_constructor(file_xml_path: str, dest_path: str, pid_database_engine, in_place: bool) -> None:
+
+    logger.debug("file: %s", file_xml_path)
+
+    parsed_xml = xml.loadToXML(file_xml_path)
+    xml_sps = SPS_Package(parsed_xml)
+
+    register_pid_v3(pid_database_engine, xml_sps)
 
     if in_place:
         new_file_xml_path = file_xml_path

--- a/documentstore_migracao/tools/constructor.py
+++ b/documentstore_migracao/tools/constructor.py
@@ -8,6 +8,7 @@ from fs import path
 from fs.walk import Walker
 
 from documentstore_migracao.utils import files, string, xml, pid_manager
+from documentstore_migracao.utils import scielo_ids_generator
 from documentstore_migracao.export.sps_package import SPS_Package
 from documentstore_migracao import config
 
@@ -16,22 +17,26 @@ logger = logging.getLogger(__name__)
 
 def register_pid_v3(pid_database_engine, xml_sps):
     pid_v2 = xml_sps.scielo_pid_v2
+    pid_v3 = xml_sps.scielo_pid_v3
+    pid_prev = xml_sps.aop_pid
 
-    # VERIFICA A EXISTÊNCIA DO PID V3 NO XC ATRAVES DO PID V2
-    if not pid_manager.check_pid_v3_by_v2(pid_database_engine, pid_v2):
-
-        # CONSTROI O SCIELO-id NO XML CONVERTIDO
-        xml_sps.create_scielo_id()
-
-        # CRIA O PID V2 E V3 NA BASE DE DADOS DO XC
-        pid_manager.create_pid(pid_database_engine, pid_v2, xml_sps.scielo_pid_v3)
-
-    else:
-
-        # SE CASO EXISTA O PID NO VERSÃO 3 NA BASE DO XC É PRECISO ADICIONAR NO XML
-        pid_v3 = pid_manager.get_pid_v3_by_v2(pid_database_engine, pid_v2)
-
+    if not pid_v3:
+        # procura pid_v3 na base pid_manager
+        pid_v3 = (
+            pid_prev and
+            pid_manager.get_pid_v3_by_v2(pid_database_engine, pid_prev) or
+            pid_v2 and
+            pid_manager.get_pid_v3_by_v2(pid_database_engine, pid_v2) or
+            scielo_ids_generator.generate_scielo_pid()
+        )
         xml_sps.scielo_pid_v3 = pid_v3
+
+    # há pid_v3 no XML
+    for v2 in (pid_prev, pid_v2):
+        if v2:
+            record = pid_manager.get_record(pid_database_engine, v2, pid_v3)
+            if not record:
+                pid_manager.create_pid(pid_database_engine, v2, pid_v3)
 
 
 def article_xml_constructor(file_xml_path: str, dest_path: str, pid_database_engine, in_place: bool) -> None:

--- a/documentstore_migracao/utils/pid_manager.py
+++ b/documentstore_migracao/utils/pid_manager.py
@@ -59,6 +59,23 @@ def get_pid_v3_by_v2(engine, pid_v2):
     return sqrs.first()[2]
 
 
+def get_record(engine, pid_v2, pid_v3):
+    """
+    Obtém o pid da versão pid_v2.
+
+    param: engine é uma instância de sqlachemy:create_engine
+
+    param: pid_v2 é uma string Ex: S0006-87051956000100002
+    """
+    conn = get_conn(engine)
+
+    sqrs = conn.execute(
+        "SELECT * FROM pid_versions WHERE v2='%s' and v3='%s'" %
+        (pid_v2, pid_v3)
+    )
+    return sqrs.first()
+
+
 def create_pid(engine, pid_v2, pid_v3):
     """
     Adiciona o pid_v2 e pid_v3 no tabela de pids.

--- a/tests/test_compare_articles_sites.py
+++ b/tests/test_compare_articles_sites.py
@@ -170,7 +170,7 @@ class TestCompareArticlesSite(TestCase):
         """
         html_body = compare_articles_sites.extract(html, {'class': 'articleSection', 'data-anchor': 'Text'})
 
-        self.assertEqual("", html_body)
+        self.assertEqual("qualquer texto no body", html_body)
 
     def test_extractwith_empty_text_must_return_none(self):
         """


### PR DESCRIPTION
#### O que esse PR faz?
Melhora a consulta e o registro dos pids no pid_manager e também passa a considerar que o XML possa ter o pid v3 ao invés de obter do pid_manager ou gerar um novo. Isso torna possível correções quando pid v3 foi atribuído a mais de um pid v2 "por engano".

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
executando uma importação com um documento XML que já contenha pid v3.

#### Algum cenário de contexto que queira dar?

~{"v2": "S1414-32832021000100213", "v3": "RJqTV8D9DWpLDYd3rcTbHXM"}~
{"v2": "S1414-32832021000100502", "v3": "RJqTV8D9DWpLDYd3rcTbHXM"}


### Screenshots
n/a

#### Quais são tickets relevantes?
.

### Referências
.
